### PR TITLE
Helm test prometheus

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.10
+version: 1.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.2+13.g8d66bdd
+appVersion: 1.2.2+17.g3479b19

--- a/charts/pelorus/templates/tests/pelorus-prometheus-test-job.yml
+++ b/charts/pelorus/templates/tests/pelorus-prometheus-test-job.yml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pelorus-prometheus-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: pelorus-prometheus-test
+    spec:
+      containers:
+      - name: prometheus-targets-test
+        image: registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1
+        env:
+        - name: PROM_HOSTNAME
+          value: "http://prometheus-pelorus:9090"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          # Install jq. Not friendly with disconnected environments...
+          curl -so jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          chmod +x jq
+
+          # Check if all the discovered targets health are "UP".
+
+          # If this file exists, then I am inside a Pod.
+          _K8s_SA_TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+          # Default Pometheus config settings
+          _PROM_API_TARGETS="/api/v1/targets"
+
+          echo -e "Checking Prometheus Targets Health.\n"
+
+          if [[ -f "${_K8s_SA_TOKEN_FILE}" ]]
+          then
+              echo -e "Executing tests inside a Kubernetes Pod.\n"
+              _POD_SA_TOKEN="$(cat "${_K8s_SA_TOKEN_FILE}")"
+
+          else
+              echo -e "Executing tests outside a Kubernetes Pod.\n"
+              _POD_SA_TOKEN=""
+          fi
+
+          # Composing vars
+          _PROM_URL="${PROM_HOSTNAME}${_PROM_API_TARGETS}"
+
+          # Show vars for debug purposes
+          echo -e "Final URL: $_PROM_URL \n"
+
+          # Get targets array
+          _PROM_TARGETS=$(curl -k -v -s "${_PROM_URL}" | ./jq -r -c '.data.activeTargets[]')
+
+          echo -e "\nChecking if all Prometheus targets are UP...\n"
+
+          IFS=$'\n'
+          for t in ${_PROM_TARGETS}
+          do
+
+              HEALTH=$(echo "$t" | ./jq -r '.health')
+              TARGET_URL=$(echo "$t" | ./jq -r '.scrapeUrl')
+              TARGET_POOL_NAME=$(echo "$t" | ./jq -r '.scrapePool')
+              if [[ "$HEALTH" != "up" ]]
+              then
+                  echo -e "Test failed, $TARGET_POOL_NAME = $TARGET_URL is not UP.\n"
+                  exit -1
+              else
+                  echo -e "Target $TARGET_POOL_NAME = $TARGET_URL is UP.\n"
+              fi
+
+          done
+
+          echo -e "All Prometheus targets are UP. Test OK!!\n"
+          exit 0
+      restartPolicy: Never

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -286,6 +286,15 @@ For testing changes to the helm chart, you should just follow the [standard inst
 
 We are in the process of refactoring our helm charts such that they can be tested more automatically using [helm chart-testing](https://github.com/helm/chart-testing). Some general guidelines are outlined in the [CoP Helm testing strategy](https://redhat-cop.github.io/ci/linting-testing-helm-charts.html). More to come soon.
 
+### Helm tests
+
+Once Pelorus has been successfully installed, and after waiting a couple of minutes so all Pelorus components (Grafana, Prometheus, etc) are up and running, helm tests can be run.
+At the moment the number of helm tests is small, hopefully in the future it will be larger. Bear in mind that helm tests main purposes is to be part of the Pelorus CI workflow.
+
+```bash
+helm test pelorus -n pelorus
+```
+
 ## Release Management Process
 
 The following is a walkthrough of the process we follow to create and manage versioned releases of Pelorus.


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

This PR adds a helm test hook in the form of a k8s job.
This job checks all the Prometheus targets are "UP".

To run the test once Pelorus has been deployed succesfully:
`helm test pelorus`

If this get merged, I would like to reactor testing documentation with this update, as it seems a bit disperse/hidden in the repo.

A couple of things to look into this PR:

- The container image i am using is from docker, it requites curl and jq
- I did bumped chart version manually, as it seems the pre-commit is not working in my laptop.
 


## Linked Issues?

related to #https://github.com/redhat-cop/pelorus/issues/36 

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
