### PR TITLE
Prometheus can now persist metrics

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.10
+version: 1.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.2+13.g8d66bdd
+appVersion: 1.2.2+17.g4366383

--- a/charts/pelorus/templates/prometheus-cr.yaml
+++ b/charts/pelorus/templates/prometheus-cr.yaml
@@ -13,6 +13,17 @@ spec:
       key: thanos.yaml
       name: thanos-objstore-config
   {{- end }}
+  {{- if .Values.storage }}
+  storage:
+    volumeClaimTemplate:
+      spec:
+      {{- if .Values.storage.storage_class_name }}
+        storageClassName: {{ .Values.storage.storage_class_name }}
+      {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.volume_size }}
+  {{- end }}
   replicas: 2
   replicaExternalLabelName: ""
   ruleNamespaceSelector: {}

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -16,6 +16,11 @@ deployment:
     app.kubernetes.io/name: pelorus
     app.kubernetes.io/version: v0.33.0
 
+# Uncomment this if you want to persist Prometheus metrics.
+#storage:
+#  volume_size: 10Gi # PV size per Prometheus Pod. Make sure you define volume size according to your environment size and retention needs.
+#  storage_class_name: cinder-cs # Optional, otheriwse the default SC is used. Use a block storage SC if possible.
+
 exporters:
   instances:
     # Values file for exporter helm chart

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -17,9 +17,9 @@ deployment:
     app.kubernetes.io/version: v0.33.0
 
 # Uncomment this if you want to persist Prometheus metrics.
-#storage:
-#  volume_size: 10Gi # PV size per Prometheus Pod. Make sure you define volume size according to your environment size and retention needs.
-#  storage_class_name: cinder-cs # Optional, otheriwse the default SC is used. Use a block storage SC if possible.
+# storage:
+#   volume_size: 10Gi # PV size per Prometheus Pod. Make sure you define volume size according to your environment size and retention needs.
+#   storage_class_name: cinder-cs # Optional, otheriwse the default SC is used. Use a block storage SC if possible.
 
 exporters:
   instances:


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Optionally now Prometheus can be deployed with persistent storage, so metrics are persisted after reboots.

## Linked Issues?

resolves #https://github.com/redhat-cop/pelorus/issues/205

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
