### PR TITLE
downgrade openshift due to kube client issue in v12

### DIFF
--- a/exporters/requirements.txt
+++ b/exporters/requirements.txt
@@ -1,6 +1,6 @@
 requests
 prometheus_client
-openshift
+openshift < 0.12
 jsonpath_ng
 jira
 pytz


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR
Due to a change in the kuernetes python package exporters deployed in pods were not able to access the Openshift API.  This fix ties our version of the Openshift/Kuberneets API to the last good working verison 0.11/11.0

resolves #257 

## Testing Instructions
To test do a standard deployment of the exports to a cluster and verify all the exports are running and connecting to the Openshfit API.

@redhat-cop/mdt
