### PR TITLE
Add committime exporter support fot Gitea and Azure DevOps

### DIFF
--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -2,6 +2,7 @@
 from collector_bitbucket import BitbucketCommitCollector
 from collector_gitlab import GitLabCommitCollector
 from collector_github import GitHubCommitCollector
+from collector_gitea import GiteaCommitCollector
 import os
 import pelorus
 import sys
@@ -23,6 +24,8 @@ class GitFactory:
             return GitHubCommitCollector(kube_client, username, token, namespaces, apps, git_api)
         if git_provider == "bitbucket":
             return BitbucketCommitCollector(kube_client, username, token, namespaces, apps)
+        if git_provider == "gitea":
+            return GiteaCommitCollector(kube_client, username, token, namespaces, apps)
 
 
 if __name__ == "__main__":

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -3,6 +3,7 @@ from collector_bitbucket import BitbucketCommitCollector
 from collector_gitlab import GitLabCommitCollector
 from collector_github import GitHubCommitCollector
 from collector_gitea import GiteaCommitCollector
+from collector_azure_devops import AzureDevOpsCommitCollector
 import os
 import pelorus
 import sys
@@ -25,7 +26,9 @@ class GitFactory:
         if git_provider == "bitbucket":
             return BitbucketCommitCollector(kube_client, username, token, namespaces, apps)
         if git_provider == "gitea":
-            return GiteaCommitCollector(kube_client, username, token, namespaces, apps)
+            return GiteaCommitCollector(kube_client, username, token, namespaces, apps, git_api)
+        if git_provider == "azure-devops":
+            return AzureDevOpsCommitCollector(kube_client, username, token, namespaces, apps, git_api)
 
 
 if __name__ == "__main__":

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -1,14 +1,9 @@
 from azure.devops.connection import Connection
 from msrest.authentication import BasicAuthentication
-from urllib.parse import urlparse
-import os.path
 import requests
 import logging
 import pelorus
 from collector_base import AbstractCommitCollector
-# import urllib3
-# urllib3.disable_warnings()
-
 
 class AzureDevOpsCommitCollector(AbstractCommitCollector):
 
@@ -34,7 +29,6 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
         # Fill in with your personal access token and org URL
         personal_access_token = self._token
         organization_url = self._git_api
-        #azure_devops_token = BasicAuthentication('', self._token)
 
         # Create a connection to the org
         credentials = BasicAuthentication('', personal_access_token)
@@ -43,13 +37,8 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
         # Get a client (the "git" client provides access to commits)
         git_client = connection.clients.get_git_client()
 
-        #print("token: {}".format(azure_devops_token))
-        # oauth token authentication
-        # gs = gitlab.Gitlab(git_server, oauth_token='my_long_token_here', api_version=4, session=session)
-        # urlparse(metric.repo_url).path.strip('/').split("/")[0] # Azure proj
-         #urlparse(metric.repo_url).path.strip('/').split("/")[2] # Azure repo
-
-        commit = git_client.get_commit(commit_id=metric.commit_hash,repository_id=metric.repo_project,project=metric.repo_project)
+        commit = git_client.get_commit(
+            commit_id=metric.commit_hash, repository_id=metric.repo_project, project=metric.repo_project)
         logging.debug("Commit %s" % ((commit.committer.date).isoformat("T","auto")))
         if hasattr(commit,"innerExepction"):
             # This will occur when trying to make an API call to non-Github
@@ -57,7 +46,7 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
                 metric.build_name, metric.commit_hash, metric.repo_url, str(commit.message)))
         else:
             try:
-                metric.commit_time = commit.committer.date.isoformat("T","auto")
+                metric.commit_time = commit.committer.date.isoformat("T", "auto")
                 logging.info("metric.commit_time %s" % (str(metric.commit_time)[:19]))
                 logging.info("self._timedate_format %s" % (self._timedate_format))
                 metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -1,0 +1,69 @@
+from azure.devops.connection import Connection
+from msrest.authentication import BasicAuthentication
+from urllib.parse import urlparse
+import os.path
+import requests
+import logging
+import pelorus
+from collector_base import AbstractCommitCollector
+# import urllib3
+# urllib3.disable_warnings()
+
+
+class AzureDevOpsCommitCollector(AbstractCommitCollector):
+
+    def __init__(self, kube_client, username, token, namespaces, apps, git_api):
+        super().__init__(kube_client, username, token, namespaces, apps, "Azure-DevOps", '%Y-%m-%dT%H:%M:%S', git_api)
+
+    # base class impl
+    def get_commit_time(self, metric):
+        """Method called to collect data and send to Prometheus"""
+        session = requests.Session()
+        session.verify = False
+
+        logging.debug("metric.repo_project %s" % (metric.repo_project))
+        logging.debug("metric.git_api %s" % (self._git_api))
+
+        git_server = self._git_api
+
+        if "github" in git_server or "bitbucket" in git_server or "gitlab" in git_server or "gitea" in git_server:
+            logging.warn("Skipping non Azure DevOps server, found %s" % (git_server))
+            return None
+
+        # Private or personal token
+        # Fill in with your personal access token and org URL
+        personal_access_token = self._token
+        organization_url = self._git_api
+        #azure_devops_token = BasicAuthentication('', self._token)
+
+        # Create a connection to the org
+        credentials = BasicAuthentication('', personal_access_token)
+        connection = Connection(base_url=organization_url, creds=credentials)
+
+        # Get a client (the "git" client provides access to commits)
+        git_client = connection.clients.get_git_client()
+
+        #print("token: {}".format(azure_devops_token))
+        # oauth token authentication
+        # gs = gitlab.Gitlab(git_server, oauth_token='my_long_token_here', api_version=4, session=session)
+        # urlparse(metric.repo_url).path.strip('/').split("/")[0] # Azure proj
+         #urlparse(metric.repo_url).path.strip('/').split("/")[2] # Azure repo
+
+        commit = git_client.get_commit(commit_id=metric.commit_hash,repository_id=metric.repo_project,project=metric.repo_project)
+        logging.debug("Commit %s" % ((commit.committer.date).isoformat("T","auto")))
+        if hasattr(commit,"innerExepction"):
+            # This will occur when trying to make an API call to non-Github
+            logging.warning("Unable to retrieve commit time for build: %s, hash: %s, url: %s. Got http code: %s" % (
+                metric.build_name, metric.commit_hash, metric.repo_url, str(commit.message)))
+        else:
+            try:
+                metric.commit_time = commit.committer.date.isoformat("T","auto")
+                logging.info("metric.commit_time %s" % (str(metric.commit_time)[:19]))
+                logging.info("self._timedate_format %s" % (self._timedate_format))
+                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
+                    (str(metric.commit_time)[:19]), self._timedate_format)
+            except Exception:
+                logging.error("Failed processing commit time for build %s" % metric.build_name, exc_info=True)
+                logging.debug(commit)
+                raise
+        return metric

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -5,6 +5,7 @@ import logging
 import pelorus
 from collector_base import AbstractCommitCollector
 
+
 class AzureDevOpsCommitCollector(AbstractCommitCollector):
 
     def __init__(self, kube_client, username, token, namespaces, apps, git_api):
@@ -39,8 +40,8 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
 
         commit = git_client.get_commit(
             commit_id=metric.commit_hash, repository_id=metric.repo_project, project=metric.repo_project)
-        logging.debug("Commit %s" % ((commit.committer.date).isoformat("T","auto")))
-        if hasattr(commit,"innerExepction"):
+        logging.debug("Commit %s" % ((commit.committer.date).isoformat("T", "auto")))
+        if hasattr(commit, "innerExepction"):
             # This will occur when trying to make an API call to non-Github
             logging.warning("Unable to retrieve commit time for build: %s, hash: %s, url: %s. Got http code: %s" % (
                 metric.build_name, metric.commit_hash, metric.repo_url, str(commit.message)))

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -273,7 +273,6 @@ class CommitMetric:
     @property
     def git_server(self):
         """Returns the Git server FQDN with the protocol"""
-        logging.debug("Returns the Git server FQDN with the protocol: %s" % (self.__repo_protocol + '://' + self.__repo_fqdn))
         return str(self.__repo_protocol + '://' + self.__repo_fqdn)
 
     def __parse_repourl(self):

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -125,10 +125,11 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
 
             metric = CommitMetric(app)
 
-            if build.spec.source.git:
-                repo_url = build.spec.source.git.uri
-            else:
-                repo_url = self._get_repo_from_build_config(build)
+            if not repo_url:
+                if build.spec.source.git:
+                    repo_url = build.spec.source.git.uri
+                else:
+                    repo_url = self._get_repo_from_build_config(build)
 
             metric.repo_url = repo_url
             commit_sha = build.spec.revision.git.commit
@@ -272,13 +273,16 @@ class CommitMetric:
     @property
     def git_server(self):
         """Returns the Git server FQDN with the protocol"""
+        logging.debug("Returns the Git server FQDN with the protocol: %s" % (self.__repo_protocol + '://' + self.__repo_fqdn))
         return str(self.__repo_protocol + '://' + self.__repo_fqdn)
 
     def __parse_repourl(self):
+        logging.debug(self.__repo_url)
         """Parse the repo_url into individual pieces"""
         if self.__repo_url is None:
             return
         parsed = giturlparse.parse(self.__repo_url)
+        logging.debug(self.__repo_url)
         if len(parsed.protocols) > 0 and parsed.protocols[0] not in CommitMetric.supported_protocols:
             raise ValueError("Unsupported protocol %s", parsed.protocols[0])
         self.__repo_protocol = parsed.protocol

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -1,4 +1,3 @@
-import gitea_client
 import requests
 import logging
 import pelorus
@@ -48,7 +47,8 @@ class GiteaCommitCollector(AbstractCommitCollector):
                 metric.commit_time = commit['commit']['committer']['date']
                 logging.debug("metric.commit_time %s" % (str(metric.commit_time)[:19]))
                 logging.debug("self._timedate_format %s" % (self._timedate_format))
-                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp((str(metric.commit_time)[:19]), self._timedate_format)
+                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp((
+                    str(metric.commit_time)[:19]), self._timedate_format)
             except Exception:
                 logging.error("Failed processing commit time for build %s" % metric.build_name, exc_info=True)
                 logging.debug(commit)

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -1,0 +1,99 @@
+import gitea_client
+import requests
+import logging
+import pelorus
+from collector_base import AbstractCommitCollector
+# import urllib3
+# urllib3.disable_warnings()
+
+
+class GiteaCommitCollector(AbstractCommitCollector):
+
+    _prefix_pattern = "https://%s/repos/"
+    _defaultapi = "try.gitea.io/api/v1"
+    _prefix = _prefix_pattern % _defaultapi
+    _suffix = "/git/commits/"
+
+    def __init__(self, kube_client, username, token, namespaces, apps, git_api=None):
+        super().__init__(kube_client, username, token, namespaces, apps, "Gitea", '%Y-%m-%dT%H:%M:%S', git_api)
+        if git_api is not None and len(git_api) > 0:
+            logging.info("Using non-default API: %s" % (git_api))
+        else:
+            self._git_api = self._defaultapi
+        self._prefix = self._prefix_pattern % self._git_api
+
+    # base class impl
+    def get_commit_time(self, metric):
+        """Method called to collect data and send to Prometheus"""
+        session = requests.Session()
+        session.verify = False
+
+        project_name = metric.repo_project
+        git_server = metric.git_server
+
+        if "github" in git_server or "bitbucket" in git_server or "gitlab" in git_server:
+            logging.warn("Skipping non Gitea server, found %s" % (git_server))
+            return None
+
+        # Private or personal token
+        gitea_token = gitea_client.Token(self._token)
+
+        print("token: {}".format(gitea_token))
+        # oauth token authentication
+        # gs = gitlab.Gitlab(git_server, oauth_token='my_long_token_here', api_version=4, session=session)
+
+        url = self._prefix + metric.repo_group + "/" + metric.repo_project + self._suffix + metric.commit_hash
+        logging.info("URL %s" % (url))
+        response = requests.get(url, auth=(self._username, self._token))
+        logging.info("response %s" % (requests.get(url, auth=(self._username, self._token))))
+        if response.status_code != 200:
+            # This will occur when trying to make an API call to non-Github
+            logging.warning("Unable to retrieve commit time for build: %s, hash: %s, url: %s. Got http code: %s" % (
+                metric.build_name, metric.commit_hash, metric.repo_url, str(response.status_code)))
+        else:
+            commit = response.json()
+            try:
+                metric.commit_time = commit['commit']['committer']['date']
+                logging.info("metric.commit_time %s" % (str(metric.commit_time)[:19]))
+                logging.info("self._timedate_format %s" % (self._timedate_format))
+                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp((str(metric.commit_time)[:19]), self._timedate_format)
+            except Exception:
+                logging.error("Failed processing commit time for build %s" % metric.build_name, exc_info=True)
+                logging.debug(commit)
+                raise
+        return metric
+
+    @staticmethod
+    def _get_next_results(gs, project_name, git_url, page):
+        """
+        Returns a list of projects according to the search term project_name.
+        :param gs: Gitlab library
+        :param project_name: search term in the form of a string
+        :param git_url: Repository url stored in the metric
+        :param page: int represents the next page to retrieve
+        :return: matching project or None if no match is found
+        """
+        if page == 0:
+            project_list = gs.search('projects', project_name)
+        else:
+            project_list = gs.search('projects', project_name, page=page)
+        if project_list:
+            project = GiteaCommitCollector.get_matched_project(project_list, git_url)
+            if project:
+                return gs.projects.get(project['id'])
+            else:
+                GiteaCommitCollector._get_next_results(gs, project_name, git_url, page + 1)
+        return None
+
+    @staticmethod
+    def get_matched_project(project_list, git_url):
+        """
+        Returns the project in the project list that matches the git url
+        :param project_list: list of projects returned by the search by name API call
+        :param git_url: Repository url stored in the metric
+        :return: Matching project or None if there is no match
+        """
+        for p in project_list:
+            if p.get('http_url_to_repo') == git_url or p.get('ssh_url_to_repo') == git_url:
+                return p
+        return None

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -9,7 +9,7 @@ from collector_base import AbstractCommitCollector
 
 class GiteaCommitCollector(AbstractCommitCollector):
 
-    _prefix_pattern = "https://%s/repos/"
+    _prefix_pattern = "%s/api/v1/repos/"
     _defaultapi = "try.gitea.io/api/v1"
     _prefix = _prefix_pattern % _defaultapi
     _suffix = "/git/commits/"
@@ -30,16 +30,9 @@ class GiteaCommitCollector(AbstractCommitCollector):
 
         git_server = metric.git_server
 
-        if "github" in git_server or "bitbucket" in git_server or "gitlab" in git_server:
+        if "github" in git_server or "bitbucket" in git_server or "gitlab" in git_server or "azure" in git_server:
             logging.warn("Skipping non Gitea server, found %s" % (git_server))
             return None
-
-        # Private or personal token
-        gitea_token = gitea_client.Token(self._token)
-
-        print("token: {}".format(gitea_token))
-        # oauth token authentication
-        # gs = gitlab.Gitlab(git_server, oauth_token='my_long_token_here', api_version=4, session=session)
 
         url = self._prefix + metric.repo_group + "/" + metric.repo_project + self._suffix + metric.commit_hash
         logging.info("URL %s" % (url))
@@ -53,47 +46,11 @@ class GiteaCommitCollector(AbstractCommitCollector):
             commit = response.json()
             try:
                 metric.commit_time = commit['commit']['committer']['date']
-                logging.info("metric.commit_time %s" % (str(metric.commit_time)[:19]))
-                logging.info("self._timedate_format %s" % (self._timedate_format))
-                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
-                    (str(metric.commit_time)[:19]), self._timedate_format)
+                logging.debug("metric.commit_time %s" % (str(metric.commit_time)[:19]))
+                logging.debug("self._timedate_format %s" % (self._timedate_format))
+                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp((str(metric.commit_time)[:19]), self._timedate_format)
             except Exception:
                 logging.error("Failed processing commit time for build %s" % metric.build_name, exc_info=True)
                 logging.debug(commit)
                 raise
         return metric
-
-    @staticmethod
-    def _get_next_results(gs, project_name, git_url, page):
-        """
-        Returns a list of projects according to the search term project_name.
-        :param gs: Gitlab library
-        :param project_name: search term in the form of a string
-        :param git_url: Repository url stored in the metric
-        :param page: int represents the next page to retrieve
-        :return: matching project or None if no match is found
-        """
-        if page == 0:
-            project_list = gs.search('projects', project_name)
-        else:
-            project_list = gs.search('projects', project_name, page=page)
-        if project_list:
-            project = GiteaCommitCollector.get_matched_project(project_list, git_url)
-            if project:
-                return gs.projects.get(project['id'])
-            else:
-                GiteaCommitCollector._get_next_results(gs, project_name, git_url, page + 1)
-        return None
-
-    @staticmethod
-    def get_matched_project(project_list, git_url):
-        """
-        Returns the project in the project list that matches the git url
-        :param project_list: list of projects returned by the search by name API call
-        :param git_url: Repository url stored in the metric
-        :return: Matching project or None if there is no match
-        """
-        for p in project_list:
-            if p.get('http_url_to_repo') == git_url or p.get('ssh_url_to_repo') == git_url:
-                return p
-        return None

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -28,7 +28,6 @@ class GiteaCommitCollector(AbstractCommitCollector):
         session = requests.Session()
         session.verify = False
 
-        project_name = metric.repo_project
         git_server = metric.git_server
 
         if "github" in git_server or "bitbucket" in git_server or "gitlab" in git_server:
@@ -56,7 +55,8 @@ class GiteaCommitCollector(AbstractCommitCollector):
                 metric.commit_time = commit['commit']['committer']['date']
                 logging.info("metric.commit_time %s" % (str(metric.commit_time)[:19]))
                 logging.info("self._timedate_format %s" % (self._timedate_format))
-                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp((str(metric.commit_time)[:19]), self._timedate_format)
+                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
+                    (str(metric.commit_time)[:19]), self._timedate_format)
             except Exception:
                 logging.error("Failed processing commit time for build %s" % metric.build_name, exc_info=True)
                 logging.debug(commit)

--- a/exporters/requirements.txt
+++ b/exporters/requirements.txt
@@ -6,5 +6,4 @@ jira
 pytz
 python-gitlab >= 2.4.0
 git-url-parse
-gitea_client
 azure-devops

--- a/exporters/requirements.txt
+++ b/exporters/requirements.txt
@@ -7,3 +7,4 @@ pytz
 python-gitlab >= 2.4.0
 git-url-parse
 gitea_client
+azure-devops


### PR DESCRIPTION
Describe the behavior changes introduced in this PR
This PR add support for Gitea and Azure Devops as an source to get Lead time for change metric

Linked Issues?
resolves #260
resolver #189 

Testing Instructions
Please include any additional commands or pointers in addition to our standard PR testing process.
Gitea

1- Login into https://try.gitea.io/ using your github account

2- Execute the steps describe on this repo https://github.com/konveyor/pelorus/blob/master/labs/consultant/03-Exporters.md#configuring-exporters , but using your gitea account instead of github.

3- Configure GIT_PROVIDER env on the exporter as "gitea"

4- Create a commit and check Pelorus dashboard to see the metrics

Azure Devops

1. Create and account on azure devops

2- Execute the steps describe on this repo https://github.com/konveyor/pelorus/blob/master/labs/consultant/03-Exporters.md#configuring-exporters , but using your gitea account instead of github.

3- Configure GIT_PROVIDER env on the exporter as "azure-devops"

4- Create a commit and check Pelorus dashboard to see the metrics

@redhat-cop/mdt