### PR TITLE
Update python image to ubi8/python-39

### DIFF
--- a/.github/workflows/build-pelorus.yaml
+++ b/.github/workflows/build-pelorus.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: redhat-actions/s2i-build@v1
         with:
           path_context: 'exporters'
-          builder_image: 'registry.access.redhat.com/ubi8/python-38'
+          builder_image: 'registry.access.redhat.com/ubi8/python-39'
           image_name: 'committime-exporter'
           image_tag: ${{ github.sha }}
 
@@ -63,7 +63,7 @@ jobs:
         uses: redhat-actions/s2i-build@v1
         with:
           path_context: 'exporters'
-          builder_image: 'registry.access.redhat.com/ubi8/python-38'
+          builder_image: 'registry.access.redhat.com/ubi8/python-39'
           image_name: 'deploytime-exporter'
           image_tag: ${{ github.sha }}
 
@@ -98,7 +98,7 @@ jobs:
         uses: redhat-actions/s2i-build@v1
         with:
           path_context: 'exporters'
-          builder_image: 'registry.access.redhat.com/ubi8/python-38'
+          builder_image: 'registry.access.redhat.com/ubi8/python-39'
           image_name: 'failure-exporter'
           image_tag: ${{ github.sha }}
 


### PR DESCRIPTION
## What's it do?

Update the python base image on the GitHub action flow to ubi8/python-39 to be able to generate the Pelorus images

## Linked Issues

resolves #289 

## Testing Instructions

The unit testing process remains the same

@redhat-cop/mdt
