### PR TITLE
Committime github provider integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,28 @@
+name: Integration Tests
+on: [push, pull_request]
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r exporters/requirements.txt
+          pip install -r exporters/requirements-dev.txt
+      - name: Start Mockoon in background
+        run: docker run --name=mockoon -d --mount type=bind,source=$PWD/mocks/commitexporter_github.json,target=/data,readonly -p 3000:3000 mockoon/cli:latest -d /data --name openshift -p 3000
+      - name: try until mockoon is ready
+        run: |
+          pip install httpie
+          until curl -k https://localhost:3000/version; do echo "trying again in 1 second"; sleep 1; done
+      - name: run commit exporter
+        run: |
+          pip install ./exporters
+          pytest -m integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,19 @@
 name: Integration Tests
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'exporters/**'
+      - 'mocks/**'
+      - '!mocks/README.md'
+      - 'pyproject.toml'
+      - '.github/workflows/integration-tests.yml'
+  pull_request:
+    paths:
+      - 'exporters/**'
+      - 'mocks/**'
+      - '!mocks/README.md'
+      - 'pyproject.toml'
+      - '.github/workflows/integration-tests.yml'
 
 jobs:
   integration-test:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,6 +30,6 @@ jobs:
           pip install -r exporters/requirements.txt
           pip install -r exporters/requirements-dev.txt
       - name: Test with pytest
-        run: coverage run -m pytest -rap
+        run: coverage run -m pytest -rap -m "not integration"
       - name: Generate coverage report
         run: coverage report

--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -1,0 +1,93 @@
+import logging
+from typing import Any, Optional
+
+import attr
+import giturlparse
+
+SUPPORTED_PROTOCOLS = {"http", "https", "ssh", "git"}
+
+
+@attr.define
+class CommitMetric:
+    name: str = attr.field()
+    labels: Any = attr.field(default=None, kw_only=True)
+    namespace: Optional[str] = attr.field(default=None, kw_only=True)
+
+    __repo_url = attr.field(default=None, init=False)
+    __repo_protocol = attr.field(default=None, init=False)
+    __repo_fqdn = attr.field(default=None, init=False)
+    __repo_group = attr.field(default=None, init=False)
+    __repo_name = attr.field(default=None, init=False)
+    __repo_project = attr.field(default=None, init=False)
+
+    committer: Optional[str] = attr.field(default=None, kw_only=True)
+    commit_hash: Optional[str] = attr.field(default=None, kw_only=True)
+    commit_time: Optional[str] = attr.field(default=None, kw_only=True)
+    commit_timestamp: Optional[float] = attr.field(default=None, kw_only=True)
+
+    build_name: Optional[str] = attr.field(default=None, kw_only=True)
+    build_config_name: Optional[str] = attr.field(default=None, kw_only=True)
+
+    image_location: Optional[str] = attr.field(default=None, kw_only=True)
+    image_name: Optional[str] = attr.field(default=None, kw_only=True)
+    image_tag: Optional[str] = attr.field(default=None, kw_only=True)
+    image_hash: Optional[str] = attr.field(default=None, kw_only=True)
+
+    @property
+    def repo_url(self):
+        return self.__repo_url
+
+    @repo_url.setter
+    def repo_url(self, value):
+        self.__repo_url = value
+        self.__parse_repourl()
+
+    @property
+    def repo_protocol(self):
+        """Returns the Git server protocol"""
+        return self.__repo_protocol
+
+    @property
+    def git_fqdn(self):
+        """Returns the Git server FQDN"""
+        return self.__repo_fqdn
+
+    @property
+    def repo_group(self):
+        return self.__repo_group
+
+    @property
+    def repo_name(self):
+        """Returns the Git repo name, example: myrepo.git"""
+        return self.__repo_name
+
+    @property
+    def repo_project(self):
+        """Returns the Git project name, this is normally the repo_name with '.git' parsed off the end."""
+        return self.__repo_project
+
+    @property
+    def git_server(self):
+        """Returns the Git server FQDN with the protocol"""
+        return str(self.__repo_protocol + "://" + self.__repo_fqdn)
+
+    def __parse_repourl(self):
+        logging.debug(self.__repo_url)
+        """Parse the repo_url into individual pieces"""
+        if self.__repo_url is None:
+            return
+        parsed = giturlparse.parse(self.__repo_url)
+        logging.debug(self.__repo_url)
+        if len(parsed.protocols) > 0 and parsed.protocols[0] not in SUPPORTED_PROTOCOLS:
+            raise ValueError("Unsupported protocol %s", parsed.protocols[0])
+        self.__repo_protocol = parsed.protocol
+        # In the case of multiple subgroups the host will be in the pathname
+        # Otherwise, it will be in the resource
+        if parsed.pathname.startswith("//"):
+            self.__repo_fqdn = parsed.pathname.split("/")[2]
+            self.__repo_protocol = parsed.protocols[0]
+        else:
+            self.__repo_fqdn = parsed.resource
+        self.__repo_group = parsed.owner
+        self.__repo_name = parsed.name
+        self.__repo_project = parsed.name

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -4,11 +4,11 @@ import sys
 import time
 from distutils.util import strtobool
 
-from collector_azure_devops import AzureDevOpsCommitCollector
-from collector_bitbucket import BitbucketCommitCollector
-from collector_gitea import GiteaCommitCollector
-from collector_github import GitHubCommitCollector
-from collector_gitlab import GitLabCommitCollector
+from committime.collector_azure_devops import AzureDevOpsCommitCollector
+from committime.collector_bitbucket import BitbucketCommitCollector
+from committime.collector_gitea import GiteaCommitCollector
+from committime.collector_github import GitHubCommitCollector
+from committime.collector_gitlab import GitLabCommitCollector
 from kubernetes import client
 from openshift.dynamic import DynamicClient
 from prometheus_client import start_http_server

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -4,16 +4,13 @@ import json
 import logging
 import re
 from abc import abstractmethod
-from typing import Any, Iterable, Optional
+from typing import Iterable
 
-import attr
-import giturlparse
+from committime import CommitMetric
 from jsonpath_ng import parse
 from prometheus_client.core import GaugeMetricFamily
 
 import pelorus
-
-SUPPORTED_PROTOCOLS = {"http", "https", "ssh", "git"}
 
 
 class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
@@ -76,7 +73,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
             )
             yield commit_metric
 
-    def generate_metrics(self) -> Iterable[CollectorMetric]:
+    def generate_metrics(self) -> Iterable[CommitMetric]:
         """Method called by the collect to create a list of metrics to publish"""
         # This will loop and look at OCP builds (calls get_git_commit_time)
         if not self._namespaces:
@@ -276,89 +273,3 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
                     return git_uri + ".git"
 
         return None
-
-
-@attr.define
-class CommitMetric:
-    name: str = attr.field()
-    labels: Any = attr.field(default=None, kw_only=True)
-    namespace: Optional[str] = attr.field(default=None, kw_only=True)
-
-    __repo_url = attr.field(default=None, init=False)
-    __repo_protocol = attr.field(default=None, init=False)
-    __repo_fqdn = attr.field(default=None, init=False)
-    __repo_group = attr.field(default=None, init=False)
-    __repo_name = attr.field(default=None, init=False)
-    __repo_project = attr.field(default=None, init=False)
-
-    committer: Optional[str] = attr.field(default=None, kw_only=True)
-    commit_hash: Optional[str] = attr.field(default=None, kw_only=True)
-    commit_time: Optional[str] = attr.field(default=None, kw_only=True)
-    commit_timestamp: Optional[float] = attr.field(default=None, kw_only=True)
-
-    build_name: Optional[str] = attr.field(default=None, kw_only=True)
-    build_config_name: Optional[str] = attr.field(default=None, kw_only=True)
-
-    image_location: Optional[str] = attr.field(default=None, kw_only=True)
-    image_name: Optional[str] = attr.field(default=None, kw_only=True)
-    image_tag: Optional[str] = attr.field(default=None, kw_only=True)
-    image_hash: Optional[str] = attr.field(default=None, kw_only=True)
-
-    @property
-    def repo_url(self):
-        return self.__repo_url
-
-    @repo_url.setter
-    def repo_url(self, value):
-        self.__repo_url = value
-        self.__parse_repourl()
-
-    @property
-    def repo_protocol(self):
-        """Returns the Git server protocol"""
-        return self.__repo_protocol
-
-    @property
-    def git_fqdn(self):
-        """Returns the Git server FQDN"""
-        return self.__repo_fqdn
-
-    @property
-    def repo_group(self):
-        return self.__repo_group
-
-    @property
-    def repo_name(self):
-        """Returns the Git repo name, example: myrepo.git"""
-        return self.__repo_name
-
-    @property
-    def repo_project(self):
-        """Returns the Git project name, this is normally the repo_name with '.git' parsed off the end."""
-        return self.__repo_project
-
-    @property
-    def git_server(self):
-        """Returns the Git server FQDN with the protocol"""
-        return str(self.__repo_protocol + "://" + self.__repo_fqdn)
-
-    def __parse_repourl(self):
-        logging.debug(self.__repo_url)
-        """Parse the repo_url into individual pieces"""
-        if self.__repo_url is None:
-            return
-        parsed = giturlparse.parse(self.__repo_url)
-        logging.debug(self.__repo_url)
-        if len(parsed.protocols) > 0 and parsed.protocols[0] not in SUPPORTED_PROTOCOLS:
-            raise ValueError("Unsupported protocol %s", parsed.protocols[0])
-        self.__repo_protocol = parsed.protocol
-        # In the case of multiple subgroups the host will be in the pathname
-        # Otherwise, it will be in the resource
-        if parsed.pathname.startswith("//"):
-            self.__repo_fqdn = parsed.pathname.split("/")[2]
-            self.__repo_protocol = parsed.protocols[0]
-        else:
-            self.__repo_fqdn = parsed.resource
-        self.__repo_group = parsed.owner
-        self.__repo_name = parsed.name
-        self.__repo_project = parsed.name

--- a/exporters/committime/collector_github.py
+++ b/exporters/committime/collector_github.py
@@ -1,9 +1,10 @@
 import logging
 
 import requests
-from collector_base import AbstractCommitCollector
 
 import pelorus
+
+from .collector_base import AbstractCommitCollector
 
 
 class GitHubCommitCollector(AbstractCommitCollector):

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -9,13 +9,6 @@ from committime.collector_github import GitHubCommitCollector
 from kubernetes.client import ApiClient, Configuration
 from openshift.dynamic import DynamicClient
 
-# export GIT_USER=gituser
-# export GIT_TOKEN=gittoken
-# export GIT_API=localhost:3000
-# export LOG_LEVEL=DEBUG
-# export NAMESPACES=basic-nginx-build,basic-nginx-dev,basic-nginx-stage,basic-nginx-prod
-# export TLS_VERIFY=False
-
 
 def setup_collector():
     kube_config = Configuration()

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -87,7 +87,7 @@ class CommitMetricEssentials:
 
 
 @pytest.mark.integration
-def test_github_collector():
+def test_github_provider():
     collector = setup_collector()
 
     actual = [

--- a/exporters/tests/integration/test_committime_integration.py
+++ b/exporters/tests/integration/test_committime_integration.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import attr
+import pytest
+from committime.collector_base import CommitMetric
+from committime.collector_github import GitHubCommitCollector
+from kubernetes.client import ApiClient, Configuration
+from openshift.dynamic import DynamicClient
+
+# export GIT_USER=gituser
+# export GIT_TOKEN=gittoken
+# export GIT_API=localhost:3000
+# export LOG_LEVEL=DEBUG
+# export NAMESPACES=basic-nginx-build,basic-nginx-dev,basic-nginx-stage,basic-nginx-prod
+# export TLS_VERIFY=False
+
+
+def setup_collector():
+    kube_config = Configuration()
+    kube_config.host = "https://localhost:3000"
+    kube_config.verify_ssl = False
+    dyn_client = DynamicClient(ApiClient(configuration=kube_config))
+
+    username = "gituser"
+    token = "gittoken"
+    git_api = "localhost:3000"
+    namespaces = (
+        "basic-nginx-build,basic-nginx-dev,basic-nginx-stage,basic-nginx-prod".split(
+            ","
+        )
+    )
+    apps = None
+    tls_verify = False
+    return GitHubCommitCollector(
+        dyn_client, username, token, namespaces, apps, git_api, tls_verify
+    )
+
+
+def expected_commits() -> list[CommitMetricEssentials]:
+    ns = "basic-nginx-build"
+    name = "basic-nginx"
+    metrics = [
+        CommitMetricEssentials(
+            commit_timestamp=1619381788.0,
+            namespace="basic-nginx-build",
+            name="basic-nginx",
+            commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
+            image_hash="sha256:c1282f65b5c327db4dcc6cdfb27e91338bd625d119d9ae769318f089d82e35e2",
+        ),
+        CommitMetricEssentials(
+            commit_timestamp=1619381788.0,
+            namespace="basic-nginx-build",
+            name="basic-nginx",
+            commit_hash="15dedb60b6208aafdfb2328a93543e3d94500978",
+            image_hash="sha256:4a20c8cfa48af3a938462e9cd7bfa0b16abfbc6ba16f0999f3931c79b1130e4b",
+        ),
+        CommitMetricEssentials(
+            commit_timestamp=1620401174.0,
+            namespace="basic-nginx-build",
+            name="basic-nginx",
+            commit_hash="620ce8b570c644338ba34224fc09b2d8a30bca02",
+            image_hash="sha256:71309995e6da43b76079a649b00e0aa8378443e72f1fccc76af0d73d67a7f644",
+        ),
+    ]
+    metrics.sort(key=lambda commit: commit.commit_timestamp)
+    return metrics
+
+
+@attr.define
+class CommitMetricEssentials:
+    name: str = attr.field()
+    namespace: Optional[str] = attr.field(default=None, kw_only=True)
+
+    commit_hash: Optional[str] = attr.field(default=None, kw_only=True)
+    commit_timestamp: Optional[float] = attr.field(default=None, kw_only=True)
+
+    image_hash: Optional[str] = attr.field(default=None, kw_only=True)
+
+    @staticmethod
+    def from_commit_metric(cm: CommitMetric) -> CommitMetricEssentials:
+        args = {
+            key: getattr(cm, key)
+            for key in "name namespace commit_hash commit_timestamp image_hash".split()
+        }
+
+        return CommitMetricEssentials(**args)
+
+
+@pytest.mark.integration
+def test_github_collector():
+    collector = setup_collector()
+
+    actual = [
+        CommitMetricEssentials.from_commit_metric(cm)
+        for cm in collector.generate_metrics()
+    ]
+
+    actual.sort(key=lambda commit: commit.commit_timestamp)
+
+    assert actual == expected_commits()

--- a/exporters/tests/integration/test_committime_integration.py
+++ b/exporters/tests/integration/test_committime_integration.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import attr
 import pytest
-from committime.collector_base import CommitMetric
+from committime import CommitMetric
 from committime.collector_github import GitHubCommitCollector
 from kubernetes.client import ApiClient, Configuration
 from openshift.dynamic import DynamicClient
@@ -39,8 +39,6 @@ def setup_collector():
 
 
 def expected_commits() -> list[CommitMetricEssentials]:
-    ns = "basic-nginx-build"
-    name = "basic-nginx"
     metrics = [
         CommitMetricEssentials(
             commit_timestamp=1619381788.0,

--- a/mocks/commitexporter_github.json
+++ b/mocks/commitexporter_github.json
@@ -1,11 +1,11 @@
 {
-    "source": "mockoon:1.13.0",
+    "source": "mockoon:1.14.1",
     "data": [
         {
             "type": "environment",
             "item": {
                 "uuid": "",
-                "lastMigration": 13,
+                "lastMigration": 15,
                 "name": "openshift",
                 "endpointPrefix": "",
                 "latency": 0,
@@ -110,7 +110,8 @@
                             }
                         ],
                         "enabled": false,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -191,7 +192,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -259,7 +261,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -327,7 +330,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -395,7 +399,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -463,7 +468,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -531,7 +537,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -595,7 +602,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -659,7 +667,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -723,7 +732,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -791,7 +801,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -855,7 +866,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -995,7 +1007,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -1135,7 +1148,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -1203,7 +1217,8 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     },
                     {
                         "uuid": "",
@@ -1271,10 +1286,11 @@
                             }
                         ],
                         "enabled": true,
-                        "randomResponse": false
+                        "randomResponse": false,
+                        "sequentialResponse": false
                     }
                 ],
-                "proxyMode": true,
+                "proxyMode": false,
                 "proxyHost": "https://api.cluster-36cb.dynamic.opentlc.com:6443",
                 "https": true,
                 "cors": true,
@@ -1307,7 +1323,8 @@
                         "key": "",
                         "value": ""
                     }
-                ]
+                ],
+                "proxyRemovePrefix": false
             }
         }
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@ profile = "black"
 
 [tool.pytest.ini_options]
 testpaths = ["exporters/tests"]
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
+]


### PR DESCRIPTION
Introduce a GitHub committime integration test and runs it during CI. This will run mockoon to mock the GitHub and OpenShift APIs.

There is currently a strange bug where running integration tests alongside unit tests will cause the integration tests to fail, but this doesn't happen when they're run separately. They're run separately in CI, so I'm not fully concerned, but I'm looking into it now.

## Testing Instructions

Start mockoon's server, then run: `pytest -m integration`

To see the bug I mentioned, run: `pytest -m`

@redhat-cop/mdt
