### PR TITLE
Only search for tests in exporters/tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+testpaths = ["exporters/tests"]


### PR DESCRIPTION
Addresses root cause of #305 

## Testing Instructions

1. Install ansible roles in `samples` as per its README.

2. Run `pytest` in the root directory and see if it tries to run tests in `samples`.
