### PR TITLE
Querying issues by a list of projects in JIRA

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -167,7 +167,7 @@ This exporter provides several configuration options, passed via environment var
 | `USER` | yes | Tracker Username | unset |
 | `TOKEN` | yes | User's API Token | unset |
 | `APP_FIELD` | no | Required for ServiceNow, field used for the Application label. ex: "u_appName" | 'u_application' |
-| `PROJECT` | no | Used for Jira Exporter to query issues from a list of project keys. Comma separated string. ex: `PROJECTKEY1,PROJECTKEY2` | unset |
+| `PROJECTS` | no | Used for Jira Exporter to query issues from a list of project keys. Comma separated string. ex: `PROJECTKEY1,PROJECTKEY2` | unset |
 
 ### ServiceNow exporter details
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -23,7 +23,6 @@ An _exporter_ is a data collection application that pulls data from various tool
 
 Exporters can be deployed and configured via a list of `exporters.instances` inside the `values.yaml` file. Some exporters also require secrets to be created when integrating with external tools and platforms. A sample exporter configuration may look like this:
 
-
 ```
 exporters:
   instances:
@@ -102,7 +101,6 @@ exporters:
 
 This exporter provides several configuration options, passed via environment variables.
 
-
 | Variable | Required | Explanation | Default Value |
 |---|---|---|---|
 | `GIT_USER` | yes | User's github username | unset |
@@ -115,8 +113,6 @@ This exporter provides several configuration options, passed via environment var
 | DEPRECATED `GITHUB_USER` | no | User's github username | unset |
 | DEPRECATED `GITHUB_TOKEN` | no | User's Github API Token | unset |
 | DEPRECATED `GITHUB_API` | no | Github API FQDN.  This allows the override for Github Enterprise users. | `api.github.com` |
-
-
 
 ### Deploy Time Exporter
 
@@ -171,6 +167,7 @@ This exporter provides several configuration options, passed via environment var
 | `USER` | yes | Tracker Username | unset |
 | `TOKEN` | yes | User's API Token | unset |
 | `APP_FIELD` | no | Required for ServiceNow, field used for the Application label. ex: "u_appName" | 'u_application' |
+| `PROJECT` | no | Used for Jira Exporter to query issues from a list of project keys. List of project keys separated by coma. ex: "PROJECTKEY1,PROJECTKEY2" | unset |
 
 ### ServiceNow exporter details
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -167,7 +167,7 @@ This exporter provides several configuration options, passed via environment var
 | `USER` | yes | Tracker Username | unset |
 | `TOKEN` | yes | User's API Token | unset |
 | `APP_FIELD` | no | Required for ServiceNow, field used for the Application label. ex: "u_appName" | 'u_application' |
-| `PROJECT` | no | Used for Jira Exporter to query issues from a list of project keys. List of project keys separated by coma. ex: "PROJECTKEY1,PROJECTKEY2" | unset |
+| `PROJECT` | no | Used for Jira Exporter to query issues from a list of project keys. Comma separated string. ex: "PROJECTKEY1,PROJECTKEY2" | unset |
 
 ### ServiceNow exporter details
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -167,7 +167,7 @@ This exporter provides several configuration options, passed via environment var
 | `USER` | yes | Tracker Username | unset |
 | `TOKEN` | yes | User's API Token | unset |
 | `APP_FIELD` | no | Required for ServiceNow, field used for the Application label. ex: "u_appName" | 'u_application' |
-| `PROJECT` | no | Used for Jira Exporter to query issues from a list of project keys. Comma separated string. ex: "PROJECTKEY1,PROJECTKEY2" | unset |
+| `PROJECT` | no | Used for Jira Exporter to query issues from a list of project keys. Comma separated string. ex: `PROJECTKEY1,PROJECTKEY2` | unset |
 
 ### ServiceNow exporter details
 

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -16,9 +16,9 @@ REQUIRED_CONFIG = ["USER", "TOKEN", "SERVER"]
 
 class TrackerFactory:
     @staticmethod
-    def getCollector(username, token, tracker_api, project, tracker_provider):
+    def getCollector(username, token, tracker_api, projects, tracker_provider):
         if tracker_provider == "jira":
-            return JiraFailureCollector(username, token, tracker_api)
+            return JiraFailureCollector(username, token, tracker_api, projects)
         if tracker_provider == "servicenow":
             return ServiceNowFailureCollector(username, token, tracker_api)
 
@@ -28,7 +28,13 @@ if __name__ == "__main__":
     if pelorus.missing_configs(REQUIRED_CONFIG):
         print("This program will exit.")
         sys.exit(1)
-    project = os.environ.get("PROJECT")
+    projects = None
+    if os.environ.get("PROJECTS") is not None:
+        logging.info(
+            "Querying issues from '%s' projects.",
+            os.environ.get("PROJECTS"),
+        )
+        projects = os.environ.get("PROJECTS")
     username = os.environ.get("USER")
     token = os.environ.get("TOKEN")
     tracker_api = os.environ.get("SERVER")
@@ -38,7 +44,7 @@ if __name__ == "__main__":
     start_http_server(8080)
 
     collector = TrackerFactory.getCollector(
-        username, token, tracker_api, project, tracker_provider
+        username, token, tracker_api, projects, tracker_provider
     )
     REGISTRY.register(collector)
 

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -17,7 +17,7 @@ class JiraFailureCollector(AbstractFailureCollector):
     def __init__(self, user, apikey, server):
         if not os.environ.get("PROJECT"):
             logging.info(
-                "Missing Project Field Parameter, querying all projects."
+                "Missing Project Field Parameter, querying all projects.",
             )
             self.project_field = None
         else:

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -31,8 +31,8 @@ class JiraFailureCollector(AbstractFailureCollector):
     def search_issues(self):
         options = {"server": self.server}
         # Connect to Jira
-        jira = JIRA(options, basic_auth=(self.user, self.apikey))                
-        # TODO FIXME This may need to be modified to suit needs and have a time period.        
+        jira = JIRA(options, basic_auth=(self.user, self.apikey))
+        # TODO FIXME This may need to be modified to suit needs and have a time period.
         query_string = "type=bug and priority=highest"
         if self.project_field is not None:
             query_string = query_string + " and project in (" + self.project_field + ")"

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from datetime import datetime
 
 import pytz
@@ -14,14 +15,23 @@ class JiraFailureCollector(AbstractFailureCollector):
     """
 
     def __init__(self, user, apikey, server):
+        if not os.environ.get("PROJECT"):
+            logging.info(
+                "Missing Project Field Parameter, querying all projects."
+            )
+            self.project_field = None
+        else:
+            self.project_field = os.environ.get("PROJECT")
         super().__init__(server, user, apikey)
 
     def search_issues(self):
         options = {"server": self.server}
         # Connect to Jira
-        jira = JIRA(options, basic_auth=(self.user, self.apikey))
-        # TODO FIXME This may need to be modified to suit needs and have a time period.
+        jira = JIRA(options, basic_auth=(self.user, self.apikey))                
+        # TODO FIXME This may need to be modified to suit needs and have a time period.        
         query_string = "type=bug and priority=highest"
+        if self.project_field is not None:
+            query_string = query_string + " and project in (" + self.project_field + ")"
         jira = JIRA(options, basic_auth=(self.user, self.apikey))
         jira_issues = jira.search_issues(query_string)
         critical_issues = []

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -21,6 +21,10 @@ class JiraFailureCollector(AbstractFailureCollector):
             )
             self.project_field = None
         else:
+            logging.info(
+                "Querying issues from only '%s' projects.",
+                os.environ.get("PROJECT"),
+            )
             self.project_field = os.environ.get("PROJECT")
         super().__init__(server, user, apikey)
 

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from datetime import datetime
 
 import pytz

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -14,19 +14,9 @@ class JiraFailureCollector(AbstractFailureCollector):
     Jira implementation of a FailureCollector
     """
 
-    def __init__(self, user, apikey, server):
-        if not os.environ.get("PROJECT"):
-            logging.info(
-                "Missing Project Field Parameter, querying all projects.",
-            )
-            self.project_field = None
-        else:
-            logging.info(
-                "Querying issues from only '%s' projects.",
-                os.environ.get("PROJECT"),
-            )
-            self.project_field = os.environ.get("PROJECT")
+    def __init__(self, user, apikey, server, projects):
         super().__init__(server, user, apikey)
+        self.projects = projects
 
     def search_issues(self):
         options = {"server": self.server}
@@ -34,8 +24,8 @@ class JiraFailureCollector(AbstractFailureCollector):
         jira = JIRA(options, basic_auth=(self.user, self.apikey))
         # TODO FIXME This may need to be modified to suit needs and have a time period.
         query_string = "type=bug and priority=highest"
-        if self.project_field is not None:
-            query_string = query_string + " and project in (" + self.project_field + ")"
+        if self.projects is not None:
+            query_string = query_string + " and project in (" + self.projects + ")"
         jira = JIRA(options, basic_auth=(self.user, self.apikey))
         jira_issues = jira.search_issues(query_string)
         critical_issues = []


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

This PR uses the `PROJECT` environment variable of the failure-exporter to set the list of project keys in JIRA to extract metrics.

This feature will be valuable when you have a large organization with hundreds of projects but you only want to extract metrics from a subset of them. Many projects in that large organization could be used for other kind of projects not related with IT or  software developed or deployed.

*NOTE*: I am not an python expert developer, so an enhancement of this could be define PROJECT, not only as a comma separated string, also as a regular expression. (Maybe a second iteration of this PR)

## Linked Issues?

related to #304 

@redhat-cop/mdt
