### PR TITLE
Replace images that require entitlements with the upstream versions

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.1+6.g29c88bb
+version: 1.2.2+47.g9b14fd4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/operators/templates/delete-csv-hook.yaml
+++ b/charts/operators/templates/delete-csv-hook.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     spec:
       containers:
-        - image: registry.redhat.io/openshift4/ose-cli:v4.4
+        - image: quay.io/openshift/origin-cli:4.8
           command:
             - /bin/bash
             - -c

--- a/charts/operators/templates/installplan-approval-job.yaml
+++ b/charts/operators/templates/installplan-approval-job.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     spec:
       containers:
-        - image: registry.redhat.io/openshift4/ose-cli:v4.4
+        - image: quay.io/openshift/origin-cli:4.8
           command:
             - /bin/bash
             - -c

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.2+30.gbd6af1c
+appVersion: 1.2.2+47.g9b14fd4

--- a/charts/pelorus/templates/dashboard-snapshot-cronjob.yaml
+++ b/charts/pelorus/templates/dashboard-snapshot-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               snap_key=$(echo $snapshot | ./jq -r .key)
 
               echo "New Snapshot: https://${grafana_url}/dashboard/snapshot/${snap_key}"
-            image: registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1
+            image: quay.io/wto/web-terminal-tooling:1.2
             name: dashboard-snapshots
           dnsPolicy: ClusterFirst
           restartPolicy: Never

--- a/charts/pelorus/templates/grafana-post-install-hook.yaml
+++ b/charts/pelorus/templates/grafana-post-install-hook.yaml
@@ -73,7 +73,7 @@ spec:
   template:
     spec:
       containers:
-        - image: registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1
+        - image: quay.io/wto/web-terminal-tooling:1.2
           command:
             - /bin/bash
             - -c

--- a/charts/pelorus/templates/grafana.yaml
+++ b/charts/pelorus/templates/grafana.yaml
@@ -36,7 +36,7 @@ spec:
     - -openshift-ca=/etc/prometheus/configmaps/cluster-ca-bundle/ca-bundle.crt
 {{- end}}
     - '-skip-auth-regex=^/metrics|^/dashboard/snapshot|^/public|^/api'
-    image: 'quay.io/openshift/origin-oauth-proxy:4.2'
+    image: 'quay.io/openshift/origin-oauth-proxy:4.8'
     name: grafana-proxy
     ports:
       - containerPort: 9091

--- a/charts/pelorus/templates/prometheus-cr.yaml
+++ b/charts/pelorus/templates/prometheus-cr.yaml
@@ -52,7 +52,7 @@ spec:
     - -openshift-ca=/etc/prometheus/configmaps/cluster-ca-bundle/ca-bundle.crt
 {{- end}}
     - -skip-auth-regex=^/metrics
-    image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.5
+    image: quay.io/openshift/origin-oauth-proxy:4.8
     name: prometheus-proxy
     ports:
     - containerPort: 9091

--- a/charts/pelorus/templates/tests/pelorus-grafana-test-job.yaml
+++ b/charts/pelorus/templates/tests/pelorus-grafana-test-job.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: grafana-dashboard-test
-        image: registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1
+        image: quay.io/wto/web-terminal-tooling:1.2
         env:
         - name: PELORUS_DASHBOARDS
           value: "software-delivery-performance,software-delivery-performance-by-app"


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Replace images that require entitlements with the upstream versions

registry.redhat.io/openshift4/ose-cli:v4.4 --> quay.io/openshift/origin-cli:4.8
registry.redhat.io/openshift4/ose-oauth-proxy:v4.5 --> quay.io/openshift/origin-oauth-proxy:4.8
registry.redhat.io/web-terminal-tech-preview/web-terminal-tooling-rhel8:1.0.1 --> quay.io/wto/web-terminal-tooling:1.2

## Linked Issues?

resolves #311 

## Testing Instructions
No extra instructions need it besides the regular testing process

@redhat-cop/mdt