### PR TITLE
Set default exporter source_ref to "stable", remove appVersion from chart

### DIFF
--- a/_test/pre-commit
+++ b/_test/pre-commit
@@ -7,11 +7,6 @@ bump_version() {
     echo "Updated chart ${chart} version to ${version}."
 }
 
-set_app_version() {
-    version=$(vert -g ^1 $(git describe))
-    sed -i "s/appVersion:\ .*$/appVersion:\ ${version}/" charts/pelorus/Chart.yaml
-}
-
 chart_lint=$(ct lint --remote upstream 2>&1)
 failed=$?
 failed_charts=$(echo "${chart_lint}" | sed -n 's/.*\(path:\ \"\)\(.*\)\".*Chart\ version.*$/\2/p')
@@ -22,12 +17,6 @@ if [ ${failed} -ne 0 ] && [ "${failed_charts}" != "" ]; then
     done
     # Recursively call script to ensure tests pass now
     ./$0
-
-    # Ensure app version is correct
-    set_app_version
-    if [ "$(git diff charts/pelorus/Chart.yaml)" != "" ]; then
-        echo "Updated charts/pelorus appVersion to $(git describe)."
-    fi
 
     echo "Please re-commit."
     exit 1

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.1
+version: 1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -15,7 +15,3 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 1.4.2
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.2.2+47.g9b14fd4

--- a/charts/pelorus/charts/exporters/Chart.yaml
+++ b/charts/pelorus/charts/exporters/Chart.yaml
@@ -1,3 +1,3 @@
 name: exporters
-version: v1.2.0
+version: v1.3.0
 apiVersion: v2

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir }}
     git:
-      ref: {{ .source_ref | default "stable" }}
+      ref: {{ .source_ref | default "1.3.0.1" }}
       uri: {{ .source_url }}
     type: Git
   strategy:

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir }}
     git:
-      ref: {{ .source_ref }}
+      ref: {{ .source_ref | default "stable" }}
       uri: {{ .source_url }}
     type: Git
   strategy:

--- a/charts/pelorus/charts/exporters/values.yaml
+++ b/charts/pelorus/charts/exporters/values.yaml
@@ -1,7 +1,6 @@
 instances:
 - app_name: deploytime-exporter
   source_context_dir: exporters/
-  source_ref: master
   source_url: https://github.com/redhat-cop/pelorus.git
 
 scrapeInterval: 5m

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -24,7 +24,6 @@ exporters:
     extraEnv:
     - name: APP_FILE
       value: deploytime/app.py
-    source_ref: master
     source_url: https://github.com/redhat-cop/pelorus.git
 
 snapshot_schedule: "@monthly"


### PR DESCRIPTION
This will address the core issue we saw in  #303, where pinning your repo to a specific tag still has the exporters pointed at `master`-- causing things like python code versions and container versions to get out of
sync.

Making `stable` the default will make for a better user experience, especially for updates.

I've created the [stable branch](https://github.com/konveyor/pelorus/tree/stable) which right now points to the same commit as the [v1.3.0](https://github.com/konveyor/pelorus/tree/v1.3.0) tag.

This also removes the appVersion from the chart. I don't think it makes sense to keep track of it exporter-wise, since users specify their own version with `source_ref`.

It might make sense to keep track of it for the grafana configuration? I can leave this change out if we want.

@redhat-cop/mdt
