### PR TITLE
Use newest version of pip CLI

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -134,6 +134,7 @@ Running an exporter on your local machine should follow this process:
 
         python -m venv .venv
         source .venv/bin/activate
+        pip install --upgrade pip
 
 1. Install dependencies
 
@@ -141,6 +142,7 @@ Running an exporter on your local machine should follow this process:
         pip install -r exporters/requirements-dev.txt
 
 1. Install the pelorus library
+
         pip install exporters/
 
 1. Set any environment variables required (or desired) for the given exporter (see [Configuring Exporters](/page/Configuration.md#configuring-exporters) to see supported variables).


### PR DESCRIPTION
On some systems e.g. RHEL8.3 the pip version is not allowing to
install cryptography that is required as one of the sub-deps
for jira from requirements.txt. Upgrading pip in the venv
fixes the issue and it's not breaking system installed pip.

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #<issue number> <-- Use this if merging should auto-close an issue

related to #<issue number> <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
