### PR TITLE
Update docs for stable release, fix docs formatting

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -23,7 +23,7 @@ An _exporter_ is a data collection application that pulls data from various tool
 
 Exporters can be deployed and configured via a list of `exporters.instances` inside the `values.yaml` file. Some exporters also require secrets to be created when integrating with external tools and platforms. A sample exporter configuration may look like this:
 
-```
+```yaml
 exporters:
   instances:
     # Values file for exporter helm chart
@@ -38,7 +38,7 @@ exporters:
 
 Additionally, you may want to deploy a single exporter multiple times to gather data from different sources. For example, if you wanted to pull commit data from both GitHub and a private GitHub Enterprise instance, you would deploy two instances of the Commit Time Exporter like so:
 
-```
+```yaml
 exporters:
   instances:
   - app_name: committime-github
@@ -75,15 +75,19 @@ Currently we support GitHub and GitLab, with BitBucket coming soon. Open an issu
 
 Create a secret containing your Git username and token.
 
-    oc create secret generic github-secret --from-literal=GIT_USER=<username> --from-literal=GIT_TOKEN=<personal access token> -n pelorus
+```shell
+oc create secret generic github-secret --from-literal=GIT_USER=<username> --from-literal=GIT_TOKEN=<personal access token> -n pelorus
+```
 
 Create a secret containing your Git username, token, and API.  An API example is `github.mycompany.com/api/v3`
 
-    oc create secret generic github-secret --from-literal=GIT_USER=<username> --from-literal=GIT_TOKEN=<personal access token> --from-literal=GIT_API=<api> -n pelorus
+```shell
+oc create secret generic github-secret --from-literal=GIT_USER=<username> --from-literal=GIT_TOKEN=<personal access token> --from-literal=GIT_API=<api> -n pelorus
+```
 
 #### Sample Values
 
-```
+```yaml
 exporters:
   instances:
   - app_name: committime-exporter
@@ -139,21 +143,25 @@ The job of the deploy time exporter is to capture the timestamp at which a failu
 
 Create a secret containing your Jira information.
 
-    oc create secret generic jira-secret \
-    --from-literal=SERVER=<Jira Server> \
-    --from-literal=USER=<username> \
-    --from-literal=TOKEN=<personal access token> \
-    -n pelorus
+```shell
+oc create secret generic jira-secret \
+--from-literal=SERVER=<Jira Server> \
+--from-literal=USER=<username> \
+--from-literal=TOKEN=<personal access token> \
+-n pelorus
+```
 
 For ServiceNow create a secret containing your ServiceNow information.
 
-    oc create secret generic snow-secret \
-    --from-literal=SERVER=<ServiceNow Server> \
-    --from-literal=USER=<username> \
-    --from-literal=TOKEN=<personal access token> \
-    --from-literal=TRACKER_PROVICER=servicenow \
-    --from-literal=APP_FIELD=<Custom app label field> \
-    -n pelorus
+```shell
+oc create secret generic snow-secret \
+--from-literal=SERVER=<ServiceNow Server> \
+--from-literal=USER=<username> \
+--from-literal=TOKEN=<personal access token> \
+--from-literal=TRACKER_PROVICER=servicenow \
+--from-literal=APP_FIELD=<Custom app label field> \
+-n pelorus
+```
 
 #### Environment Variables
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,7 +32,6 @@ exporters:
     extraEnv:
     - name: APP_FILE
       value: deploytime/app.py
-    source_ref: master
     source_url: https://github.com/redhat-cop/pelorus.git
 ```
 
@@ -48,7 +47,6 @@ exporters:
     extraEnv:
     - name: APP_FILE
       value: committime/app.py
-    source_ref: master
     source_url: https://github.com/redhat-cop/pelorus.git
   - app_name: committime-gh-enterprise
     env_from_secrets: 
@@ -57,11 +55,27 @@ exporters:
     extraEnv:
     - name: APP_FILE
       value: committime/app.py
-    source_ref: master
     source_url: https://github.com/redhat-cop/pelorus.git
 ```
 
 Each exporter additionally takes a unique set of environment variables to further configure its integrations and behavior. These can be set with literal keys names and values under `extraEnv` or by creating a kubernetes secret and listing the secret name under `env_from_secrets`. As detailed below.
+
+Any individual exporter can use a specific version of itself by specifying a git reference under `source_ref`. For example:
+
+```yaml
+exporters:
+  instances:
+    # Values file for exporter helm chart
+  - app_name: deploytime-exporter
+    source_context_dir: exporters/
+    extraEnv:
+    - name: APP_FILE
+      value: deploytime/app.py
+    source_ref: master
+    source_url: https://github.com/redhat-cop/pelorus.git
+```
+
+If not specified, it will use the latest stable release tag.
 
 ### Commit Time Exporter
 
@@ -97,7 +111,6 @@ exporters:
     extraEnv:
     - name: APP_FILE
     value: committime/app.py
-    source_ref: master
     source_url: https://github.com/redhat-cop/pelorus.git
 ```
 

--- a/docs/Demo.md
+++ b/docs/Demo.md
@@ -24,9 +24,9 @@ Clone the [pelorus repo](https://github.com/redhat-cop/pelorus).
 
 Fork the [RedHat COP Container Pipeline Repo](https://github.com/redhat-cop/container-pipelines), then clone (using ssh).
 
-The location of the repo will be passed as an argument to the pelorus demo script (i.e. /home/<user>/projects/container-pipelines).
+The location of the repo will be passed as an argument to the pelorus demo script, e.g. `/home/USER/projects/container-pipelines`
 
-The second argument the script takes is the url of the forked repo, so for example ,"https://github.com/kenwilli/container-pipelines.git".
+The second argument the script takes is the url of the forked repo, e.g. `https://github.com/kenwilli/container-pipelines.git`
 
 ## Flow
 - Deploy sample application (basic-nginx)
@@ -39,19 +39,18 @@ The second argument the script takes is the url of the forked repo, so for examp
 An "idle" state could resemble:
 ![Idle-Data](img/pelorus-dashboard-idle-data.png)
 
-    >:mag: **Note**<br/>
-    >Dashboard can be found by going to grafana which url can found with:
-    >`oc get route grafana-route -o json | jq -r '.spec.host'`
-    >
-    > And navigating Home(top left) -> pelorus -> Softare Delivery Performance
+> **Note**  
+> Dashboard can be found by going to grafana which url can found with:  
+> `oc get route grafana-route -o json | jq -r '.spec.host'`  
+> And navigating Home(top left) -> pelorus -> Softare Delivery Performance
 
 Run the demo script
-``` 
-pelorus/demo/demo.sh <path to container-pipelines> <url to forked repo>
+```shell
+pelorus/demo/demo.sh path_to_container-pipelines url_to_forked_repo
 ```
 
-The script will start and will begin to run the ansible-applier on the <path to container-pipelines> path. It will attempt to install ansible-galaxy, skipping if it is, and then run the ansible-applier playbook. This will setup a build (jenkins) as well as a dev, stage and prod environment. Once jenkins has been setup, an initial run of the basic-nginx app will build and deploy. Once that is complete, the dashboard should resemble the following:
+The script will start and will begin to run the ansible-applier on the path to container-pipelines. It will attempt to install ansible-galaxy, skipping if it is, and then run the ansible-applier playbook. This will setup a build (jenkins) as well as a dev, stage and prod environment. Once jenkins has been setup, an initial run of the basic-nginx app will build and deploy. Once that is complete, the dashboard should resemble the following:
 ![First-Deploy-Data](img/pelorus-dashboard-first-deploy.png)
 
-A prompt will appear on the screen waiting for user input, the user can "rerun" the script. What this will do is create a change in the index.html file, git commit and push it to the <url to forked repo> repository, then create another pipeline build. Then the second pipeline build of basic-nginx will start. Once complete, the dashboard will update again:
+A prompt will appear on the screen waiting for user input, the user can "rerun" the script. What this will do is create a change in the index.html file, git commit and push it to the url of the forked repo, then create another pipeline build. Then the second pipeline build of basic-nginx will start. Once complete, the dashboard will update again:
 ![Second-Deploy-Data](img/pelorus-dashboard-second-deploy.png)

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -316,17 +316,18 @@ The following is a walkthrough of the process we follow to create and manage ver
     * Ensure that you can install Pelorus from the tagged version of the code, including all exporters and optional configurations. (Ensure you update the values.yaml file you are using to refer to the tagged version of the code in all builds)
     * Follow the above guidance for testing Pull requests.
 5. If any bugs are found, open PRs to fix them, then delete the release and tag that was created, and start again from step 1.
-6. Create an annotated tag for the final release with the `-rc` suffix removed.
+6. Update the default exporter tag version to the new tag you're about to make. In `charts/pelorus/charts/exporters/templates/_buildconfig.yaml`, update `ref: {{ .source_ref | default "TAG_HERE" }}` accordingly.
+7. Create an annotated tag for the final release with the `-rc` suffix removed.
 
         git checkout <version>-rc
         git tag -a <version>
         git push -u upstream <version>
 
-8. Generate git release notes from the `git log`.
+9. Generate git release notes from the `git log`.
 
         git log <previous tag>..<new tag> --pretty=format:"- %h %s by %an" --no-merges
 
-7. On the [Pelorus releases](https://github.com/redhat-cop/pelorus/releases) page, click **Draft a new release**. 
+10. On the [Pelorus releases](https://github.com/redhat-cop/pelorus/releases) page, click **Draft a new release**. 
     * Select the tag that was pushed in the previous step.
     * The release _title_ should be `Release <version>`. 
     * In the main text area, create a `# Release Notes` heading, and then paste in the git log output.

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -37,11 +37,10 @@ When any of our Helm charts are updated, we need to bump the version number. Thi
 
 1. Install Helm's [chart-testing](https://github.com/helm/chart-testing) tool.
 1. Install the latest release of [vert](https://github.com/Masterminds/vert/releases/)
-    1. Run `vert -g ^1 $(git describe)` to test that its working.
+    1. Run `vert -g ^1 $(git describe)` to test that it is working.
 1. Copy the pre-commit hook into your git hooks directory.
-    ```
-    cp _test/pre-commit .git/hooks/pre-commit
-    ```
+
+        cp _test/pre-commit .git/hooks/pre-commit
 
 This script will use Helm's built-in linter to check whether a version bump is necessary, and if it is, it will take the current `version` from Chart.yaml and increment it one patch version. It will also keep `appVersion` fo the Pelorus chart up to date with the repo version using `git describe`.
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -4,15 +4,12 @@ We appreciate your interest in contributing to Pelorus! Use this guide to help y
 
 There are three main tracks of Pelorus development to consider.
 
-1. [Deployment Automation](#contributing-to-deployment-development)
-    
-    This track mostly involves testing, fixing, and updating our Helm chart(s) to streamline the installation and configuration experience. Knowledge of Helm, OpenShift, Operators and Prometheus configuration is assumed for this work.
-1. [Dashboard Development](#dashboard-development)
-
-    This is where we take the raw data we've collected and turn it into actionable visual representations that will help IT organizations make important decisions. Knowledge of Grafana and PromQL is required for contribution here.
-1. [Exporter Development](#exporter-development)
-
-    This track is focused around the development of custom [Prometheus exporters](https://prometheus.io/docs/instrumenting/writing_exporters/) to gather the information we need in order to calculate our core metrics. Python development experience is assumed.
+1. [Deployment Automation](#contributing-to-deployment-development)  
+This track mostly involves testing, fixing, and updating our Helm chart(s) to streamline the installation and configuration experience. Knowledge of Helm, OpenShift, Operators and Prometheus configuration is assumed for this work.
+2. [Dashboard Development](#dashboard-development)  
+This is where we take the raw data we've collected and turn it into actionable visual representations that will help IT organizations make important decisions. Knowledge of Grafana and PromQL is required for contribution here.
+3. [Exporter Development](#exporter-development)  
+This track is focused around the development of custom [Prometheus exporters](https://prometheus.io/docs/instrumenting/writing_exporters/) to gather the information we need in order to calculate our core metrics. Python development experience is assumed.
 
 ## Contributing to Deployment Automation
 
@@ -58,56 +55,57 @@ The following outlines a workflow for working on a dashboard:
 
 1. Sign in to Grafana via the Grafana route.
 1. Once signed in, sign as an administrator
-  1. Click the signin button in the bottom right corner
+    1. Click the signin button in the bottom right corner:  
     ![Signin button](img/signin.png)
-  1. The admin credentials can be pulled from the following commands:
-    ```
-    oc get secrets -n pelorus grafana-admin-credentials -o jsonpath='{.data.GF_SECURITY_ADMIN_USER}' | base64 -d
-    oc get secrets -n pelorus grafana-admin-credentials -o jsonpath='{.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d
-    ```
+    1. The admin credentials can be pulled from the following commands:  
+
+            oc get secrets -n pelorus grafana-admin-credentials -o jsonpath='{.data.GF_SECURITY_ADMIN_USER}' | base64 -d
+            oc get secrets -n pelorus grafana-admin-credentials -o jsonpath='{.data.GF_SECURITY_ADMIN_PASSWORD}' | base64 -d
 1. Export the dashboard JSON.
-   * Open the dashboard, and select the **Share...** button.
-   * Select the **Export** tab.
-   * Click **View JSON**.
-   * Click **Copy to Clipboard**.
+    1. Open the dashboard, and select the **Share...** button.
+    1. Select the **Export** tab.
+    1. Click **View JSON**.
+    1. Click **Copy to Clipboard**.
 1. Import as a new dashboard
-   1. Click **Create** -> **Import**.
-   1. Paste your JSON code in the box and click **Load**.
-   1. Change the _Name_ and _Unique Identifier_ fields, and click **Import**.
+    1. Click **Create** -> **Import**.
+    1. Paste your JSON code in the box and click **Load**.
+    1. Change the _Name_ and _Unique Identifier_ fields, and click **Import**.
 1. Make changes to the live dashboard. You can do this by clicking the dropdown by the panel names, and selecting **Edit**.
 1. Once you are happy with your changes, export your updated dashboard, and replace the existing content in the `GrafanaDashbaord` CR.
-   1. Open the dashboard, and select the **Share...** button.
-   1. Select the **Export** tab.
-   1. Click **View JSON**.
-   1. Click **Copy to Clipboard**.
-   1. Open the appropriate `GrafanaDashboard` CR file, and paste the new dashboard JSON over the existing.
-      >:mag: **NOTE**<br/>
-      >Be sure to match the indentation of the previous dashboard JSON. Your git diffs should still show only the lines changed like the example below
-            
-            $ git diff charts/deploy/templates/metrics-dashboard.yaml
-            diff --git a/charts/deploy/templates/metrics-dashboard.yaml b/charts/deploy/templates/metrics-dashboard.yaml
-            index 73151ad..c470afc 100644
-            --- a/charts/deploy/templates/metrics-dashboard.yaml
-            +++ b/charts/deploy/templates/metrics-dashboard.yaml
-            @@ -25,7 +25,7 @@ spec:
-                        "editable": true,
-                        "gnetId": null,
-                        "graphTooltip": 0,
-            -            "id": 2,
-            +            "id": 3,
-                        "links": [],
-                        "panels": [
-                            {
-            @@ -323,7 +323,7 @@ spec:
-                            "tableColumn": "",
-                            "targets": [
-                                {
-            -                    "expr": "count (deploy_timestamp)",
-            +                    "expr": "count (count_over_time (deploy_timestamp [$__range]) )",
-                                "format": "time_series",
-                                "instant": true,
-                                "intervalFactor": 1,
-            @@ -410,7 +410,7 @@ spec:
+    1. Open the dashboard, and select the **Share...** button.
+    1. Select the **Export** tab.
+    1. Click **View JSON**.
+    1. Click **Copy to Clipboard**.
+    1. Open the appropriate `GrafanaDashboard` CR file, and paste the new dashboard JSON over the existing.  
+        
+        **NOTE:**  
+        
+        > Be sure to match the indentation of the previous dashboard JSON. Your git diffs should still show only the lines changed like the example below.
+             
+             $ git diff charts/deploy/templates/metrics-dashboard.yaml
+             diff --git a/charts/deploy/templates/metrics-dashboard.yaml b/charts/deploy/templates/metrics-dashboard.yaml
+             index 73151ad..c470afc 100644
+             --- a/charts/deploy/templates/metrics-dashboard.yaml
+             +++ b/charts/deploy/templates/metrics-dashboard.yaml
+             @@ -25,7 +25,7 @@ spec:
+                         "editable": true,
+                         "gnetId": null,
+                         "graphTooltip": 0,
+             -            "id": 2,
+             +            "id": 3,
+                         "links": [],
+                         "panels": [
+                             {
+             @@ -323,7 +323,7 @@ spec:
+                             "tableColumn": "",
+                             "targets": [
+                                 {
+             -                    "expr": "count (deploy_timestamp)",
+             +                    "expr": "count (count_over_time (deploy_timestamp [$__range]) )",
+                                 "format": "time_series",
+                                 "instant": true,
+                                 "intervalFactor": 1,
+             @@ -410,7 +410,7 @@ spec:
 
 You're done! Commit your changes and open a PR!
 
@@ -141,6 +139,7 @@ Running an exporter on your local machine should follow this process:
         pip install -r exporters/requirements-dev.txt
 
 1. Install the pelorus library
+
         pip install exporters/
 
 1. Set any environment variables required (or desired) for the given exporter (see [Configuring Exporters](/page/Configuration.md#configuring-exporters) to see supported variables).
@@ -175,6 +174,7 @@ Most of us use Visual Studio Code to do our python development. The following ex
 * [Markdown Preview Github Styling](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-preview-github-styles)
 
         ext install bierner.markdown-preview-github-styles
+
 * [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 
         ext install ms-python.python
@@ -182,7 +182,7 @@ Most of us use Visual Studio Code to do our python development. The following ex
 
 Code also comes with a nice debugger feature. Here is a starter configuration to use with our exporters. Just create a file called `.vscode/launch.json` in your `pelorus/` project directory with the following content.
 
-```
+```json
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
@@ -240,48 +240,52 @@ The following are notes and general steps for testing Pull Requests for specific
 ### Dashboard Changes
 
 1. Clone/checkout the PR fork/branch
-    ```
-    git remote add themoosman git@github.com:themoosman/pelorus.git
-    git fetch themoosman
-    git checkout themoosman/feature-branch
-    ```
+
+        git remote add themoosman git@github.com:themoosman/pelorus.git
+        git fetch themoosman
+        git checkout themoosman/feature-branch
 2. [Install Pelorus](/page/Install.md) from checked out fork/branch.
-    >:mag: **Note**<br/>
-    >:mag: In most cases you can deploy changes to an existing deployment to retain existing data.
+
+    **NOTE:**
+
+    > In most cases you can deploy changes to an existing deployment to retain existing data.
+
 3. Log into Grafana via the grafana route.
-    ```
-    oc get route grafana-route -n pelorus
-    ```
-4. Click on the dashboard containing changes, and visually validate the behavior change described in the PR
-    >:mag: **Note**<br/>
-    >Eventually we'd like to have some Selenium tests in place to validate dashboards. If you have skills in this area let us know!
+
+        oc get route grafana-route -n pelorus
+
+4. Click on the dashboard containing changes, and visually validate the behavior change described in the PR.
+
+    **NOTE:**  
+
+    > Eventually we'd like to have some Selenium tests in place to validate dashboards. If you have skills in this area let us know!
 
 ### Exporter Changes
 
 Most exporter changes can be tested locally.
 
 1. Clone/checkout the PR fork/branch
-    ```
-    git remote add themoosman git@github.com:themoosman/pelorus.git
-    git fetch themoosman
-    git checkout themoosman/feature-branch
-    ```
+
+        git remote add themoosman git@github.com:themoosman/pelorus.git
+        git fetch themoosman
+        git checkout themoosman/feature-branch
+
 1. Install both the runtime and development dependencies.
-    ```
-    pip install -r exporters/requirements.txt
-    pip install -r exporters/requirements-dev.txt
-    ```
+
+        pip install -r exporters/requirements.txt
+        pip install -r exporters/requirements-dev.txt
+
 1. Run unit tests using `python -m pytest`.
-  1. You can also run coverage reports with the following:
-        ```
-        coverage run -m pytest
-        coverage report
-        ```
+    1. You can also run coverage reports with the following:
+
+            coverage run -m pytest
+            coverage report
+
 1. Gather necessary [configuration information](/page/Configuration.md#configuring-exporters).
-1. [Run exporter localy](#running-locally). You can do this either via the command line, or use the provided [VSCode debug confuration](#ide-setup-vscode) to run it in your IDE Debugger.
+1. [Run exporter locally](#running-locally). You can do this either via the command line, or use the provided [VSCode debug confuration](#ide-setup-vscode) to run it in your IDE Debugger.
 1. Once exporter is running, you can test it via a simple `curl localhost:8080`. You should be validating that:
-   1. You get a valid response with metrics.
-   1. Confirm the format of expected metrics.
+    1. You get a valid response with metrics.
+    1. Confirm the format of expected metrics.
 
 ### Helm Install changes
 
@@ -316,18 +320,22 @@ The following is a walkthrough of the process we follow to create and manage ver
     * Ensure that you can install Pelorus from the tagged version of the code, including all exporters and optional configurations. (Ensure you update the values.yaml file you are using to refer to the tagged version of the code in all builds)
     * Follow the above guidance for testing Pull requests.
 5. If any bugs are found, open PRs to fix them, then delete the release and tag that was created, and start again from step 1.
-6. Update the default exporter tag version to the new tag you're about to make. In `charts/pelorus/charts/exporters/templates/_buildconfig.yaml`, update `ref: {{ .source_ref | default "TAG_HERE" }}` accordingly.
+6. Update the default exporter tag version to the new tag you're about to make.  
+    In `charts/pelorus/charts/exporters/templates/_buildconfig.yaml`, update the following line accordingly:
+    
+        ref: {{ .source_ref | default "TAG_HERE" }}
+
 7. Create an annotated tag for the final release with the `-rc` suffix removed.
 
         git checkout <version>-rc
         git tag -a <version>
         git push -u upstream <version>
 
-9. Generate git release notes from the `git log`.
+8. Generate git release notes from the `git log`.
 
         git log <previous tag>..<new tag> --pretty=format:"- %h %s by %an" --no-merges
 
-10. On the [Pelorus releases](https://github.com/redhat-cop/pelorus/releases) page, click **Draft a new release**. 
+9.  On the [Pelorus releases](https://github.com/redhat-cop/pelorus/releases) page, click **Draft a new release**. 
     * Select the tag that was pushed in the previous step.
     * The release _title_ should be `Release <version>`. 
     * In the main text area, create a `# Release Notes` heading, and then paste in the git log output.

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -24,26 +24,26 @@ Additionally, if you are planning to use the out of the box exporters to collect
 Pelorus gets installed via helm charts. The first deploys the operators on which Pelorus depends, the second deploys the core Pelorus stack and the third deploys the exporters that gather the data. By default, the below instructions install into a namespace called `pelorus`, but you can choose any name you wish.
 
 ```shell
-    # clone the repo (you can use a different release or clone from master if you wish)
-    git clone --depth 1 --branch v1.3.0 https://github.com/konveyor/pelorus
-    cd pelorus
-    oc create namespace pelorus
-    helm install operators charts/operators --namespace pelorus
-    # Verify the operators are completely installed before installing the pelorus helm chart
-    helm install pelorus charts/pelorus --namespace pelorus
+# clone the repo (you can use a different release or clone from master if you wish)
+git clone --depth 1 --branch v1.3.0 https://github.com/konveyor/pelorus
+cd pelorus
+oc create namespace pelorus
+helm install operators charts/operators --namespace pelorus
+# Verify the operators are completely installed before installing the pelorus helm chart
+helm install pelorus charts/pelorus --namespace pelorus
 ```
 
 In a few seconds, you will see a number of resourced get created. The above commands will result in the following being deployed:
 
 * Prometheus and Grafana operators
 * The core Pelorus stack, which includes:
-  * A `Prometheus` instance
-  * A `Grafana` instance
-  * A `ServiceMonitor` instance for scraping the Pelorus exporters.
-  * A `GrafanaDatasource` pointing to Prometheus.
-  * A set of `GrafanaDashboards`. See the [dashboards documentation](/page/Dashboards/) for more details.
+    * A `Prometheus` instance
+    * A `Grafana` instance
+    * A `ServiceMonitor` instance for scraping the Pelorus exporters.
+    * A `GrafanaDatasource` pointing to Prometheus.
+    * A set of `GrafanaDashboards`. See the [dashboards documentation](/page/Dashboards/) for more details.
 * The following exporters:
-  * Deploy Time
+    * Deploy Time
 
 From here, some additional configuration is required in order to deploy other exporters, and make the Pelorus
 


### PR DESCRIPTION
This PR:

- Documents changes to the release process, reflecting the work in #316 .
- Removes `source_ref` from examples, but adds a new example explaining how source_ref could be used.
- Fixes various formatting issues with the docs.