### PR TITLE
Tekton compatibility for committime exporter

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.7
+version: 1.4.8
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/rbac.yaml
+++ b/charts/pelorus/charts/exporters/templates/rbac.yaml
@@ -41,6 +41,16 @@ rules:
   verbs:
   - list
   - get
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - pipelines
+  - tasks
+  - taskruns
+  verbs:
+  - list
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/demo/demo-tekton
+++ b/demo/demo-tekton
@@ -66,8 +66,8 @@ while true; do
    case $a in
       1* )
          echo "We've modified this file, time to build and deploy a new version. Times modified: $counter" | tee -a "$python_example_txt"
-         git commit -m "modifying python example, number $counter" -- "$python_example_txt"
-         git push origin "$current_branch"
+         git commit --no-verify -m "modifying python example, number $counter" -- "$python_example_txt"
+         git push "$url" "$current_branch"
 
          run_pipeline
 

--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -9,6 +9,12 @@ SUPPORTED_PROTOCOLS = {"http", "https", "ssh", "git"}
 
 @attr.define
 class CommitMetric:
+    """
+    CommitMetric holds information about a certain commit.
+    Only the commit_timestamp, namespace, name, commit_hash,
+    and image_hash fields are exposed to prometheus.
+    """
+
     name: str = attr.field()
     labels: Any = attr.field(default=None, kw_only=True)
     namespace: Optional[str] = attr.field(default=None, kw_only=True)

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -155,7 +155,10 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
                 for pipeline in pipelines
             }
 
-            metrics += self.get_metrics_from_pipelineruns(runs_by_app, namespace)
+            try:
+                metrics += self.get_metrics_from_pipelineruns(runs_by_app, namespace)
+            except Exception as e:
+                logging.error(f"Error while getting metrics from Tekton: {e}")
 
         return metrics
 

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -131,13 +131,15 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
             except openshift.dynamic.exceptions.ResourceNotFoundError:
                 pipeline_runs = pelorus.NoOpResourceInstance()
 
-            # use a jsonpath expression to find all possible values for the app label
-            jsonpath_str = f"$['items'][*]['metadata']['labels']['{app_label_key}']"
-            jsonpath_expr = parse(jsonpath_str)
+            jsonpath_labels_expr = parse("$['items'][*]['metadata']['labels']")
 
-            apps: set[str] = {match.value for match in jsonpath_expr.find(builds)}
+            apps: set[str] = {
+                match.value[app_label_key]
+                for match in jsonpath_labels_expr.find(builds)
+            }
             pipeline_run_app_labels: set[str] = {
-                match.value for match in jsonpath_expr.find(pipeline_runs)
+                match.value[app_label_key]
+                for match in jsonpath_labels_expr.find(pipeline_runs)
             }
 
             builds_by_app: dict[str, list] = {

--- a/exporters/committime/collector_bitbucket.py
+++ b/exporters/committime/collector_bitbucket.py
@@ -102,7 +102,7 @@ class BitbucketCommitCollector(AbstractCommitCollector):
                     % (
                         metric.build_name,
                         metric.commit_hash,
-                        metric.repo_fqdn,
+                        metric.git_fqdn,
                         str(api_response.status_code),
                     )
                 )

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -125,3 +125,18 @@ class AbstractPelorusExporter(ABC):
 
     def __init_():
         pass
+
+
+class ApiGroup(NamedTuple):
+    """
+    A Kubernetes [API Group](https://kubernetes.io/docs/reference/using-api/#api-groups)
+    that can be used by the openshift.dynamic client.
+    A `build.openshift.io/v1/Build` would have `build.openshift.io` as the group, `v1` as the api_version,
+    and `Build` as the Kind.
+    As a convenience, the group and api_version can be combined in the api_version field,
+    separated with a slash.
+    """
+
+    api_version: str
+    kind: str
+    group: Optional[str] = None

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 from abc import ABC
 from datetime import datetime, timezone
-from typing import Optional, Sequence
+from typing import NamedTuple, Optional, Sequence
 
 from kubernetes import config
 
@@ -44,7 +44,9 @@ def load_kube_config():
         config.load_kube_config()
 
 
-def convert_date_time_to_timestamp(date_time, format_string="%Y-%m-%dT%H:%M:%SZ"):
+def convert_date_time_to_timestamp(
+    date_time, format_string="%Y-%m-%dT%H:%M:%SZ"
+) -> float:
     timestamp = None
     try:
         if isinstance(date_time, datetime):
@@ -102,6 +104,18 @@ def url_joiner(url, path, trailing=None):
     if trailing:
         url_link += "/"
     return url_link
+
+
+class NoOpResourceInstance(NamedTuple):
+    """
+    Like an empty openshift.dynamic.ResourceInstance.
+
+    Useful when a resource type does not exist.
+    """
+
+    # TODO: may need to be fleshed out more depending upon the use case.
+    # Right now it just supports when committime can't find tekton resources.
+    items: Sequence = tuple()
 
 
 class AbstractPelorusExporter(ABC):

--- a/exporters/pelorus/utils.py
+++ b/exporters/pelorus/utils.py
@@ -1,0 +1,152 @@
+"""
+Module utils contains helper utilities for common tasks in the codebase.
+They are mainly to help with type information and to deal with data structures
+in kubernetes that are not so idiomatic to deal with.
+"""
+import dataclasses
+from collections.abc import Iterable
+from typing import Any, Optional, Protocol, TypeVar, Union, overload
+
+__FIRST_NO_DEFAULT = object()
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+@overload
+def first(iterable: Iterable[T]) -> T:
+    ...
+
+
+@overload
+def first(iterable: Iterable[T], *, default: U) -> Union[T, U]:
+    ...
+
+
+def first(iterable: Iterable[T], *, default: U = __FIRST_NO_DEFAULT) -> Union[T, U]:
+    """
+    First wraps next() to make its use as "return the first member of this iterable"
+    more clear, and to make default a keyword only argument.
+    """
+    if default is __FIRST_NO_DEFAULT:
+        return next(iter(iterable))
+    else:
+        return next(iter(iterable), default)
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class NameValueNamespace(Protocol[K, V]):
+    """
+    A representation of an object that has name and value fields.
+    """
+
+    name: K
+    value: V
+
+
+def name_value_attrs_to_dict(
+    name_values: Iterable[NameValueNamespace[K, V]]
+) -> dict[K, V]:
+    """
+    Kubernetes commonly expresses mappings as a list of objects with two entries: `name` and `value`.
+    This converts those to a dict.
+    """
+    return {x.name: x.value for x in name_values}
+
+
+__GET_NESTED_NO_DEFAULT = object()
+
+
+@overload
+def get_nested(
+    root: Any,
+    path: Union[list[Any], str],
+    *,
+    name: str = None,
+) -> Any:
+    ...
+
+
+@overload
+def get_nested(
+    root: Any,
+    path: Union[list[Any], str],
+    *,
+    default: Any,
+    name: str = None,
+) -> Any:
+    ...
+
+
+def get_nested(
+    root: Any,
+    path: Union[list[Any], str],
+    default: Any = __GET_NESTED_NO_DEFAULT,
+    name: str = None,
+) -> Any:
+    """
+    `get_nested` helps you safely traverse a deeply nested object that is indexable.
+    If `TypeError`, `KeyError`, or `IndexError` are thrown, then `default` will be returned.
+    If `default` is not given, a `MissingAttributeError` will be thrown,
+    which includes information about where in the path things went wrong, and a human-readable name (if included).
+
+    You may specify the path as either an iterable of keys / indexes, or a single string.
+    The string will be split on '.' so you can emulate the nested attribute lookup `ResourceField`
+    would offer.
+
+    A `name` for the item, if specified, makes the error message in the exception more useful.
+
+    Kubernetes API items often are deeply nested, with any number of fields that could be absent.
+    When using an `openshift.dynamic.ResourceField`, it will turn attribute accesses into
+    dictionary accesses. Normally, a deeply nested access like item.status.ref.foo.bar has four different spots
+    you could get an `AttributeError`. With a `ResourceField`, there are actually only three, since `item.status`
+    will return `None` if `status` is absent, but `None` will not have a `ref` field, leading to an
+    AttributeError.
+
+    This all may be unnecessary once Python 3.11 comes out, because of PEP-0647:
+    https://www.python.org/dev/peps/pep-0657/
+    """
+    item = root
+    if isinstance(path, str):
+        # filter out leading dot (or accidental double dots, technically)
+        path = [part for part in path.split(".") if part]
+    for i, key in enumerate(path):
+        try:
+            item = item[key]
+        except (TypeError, IndexError, KeyError):
+            if default is not __GET_NESTED_NO_DEFAULT:
+                return default
+
+            raise BadAttributePathError(
+                root=root,
+                path=path,
+                path_slice=slice(i),
+                value=item,
+                root_name=name,
+            )
+
+    return item
+
+
+@dataclasses.dataclass
+class BadAttributePathError(Exception):
+    """
+    An error representing a nested lookup that went wrong.
+    """
+
+    root: Any
+    path: list[Any]
+    path_slice: slice
+    value: Any
+    root_name: Optional[str] = None
+
+    @property
+    def message(self):
+        return (
+            f"While trying to look up {'.'.join(self.path)} within "
+            f"{self.root_name if self.root_name else 'an item'}, "
+            f"{'.'.join(self.path[self.path_slice])} was {self.value}, "
+            "so we could not continue."
+        )

--- a/exporters/requirements.txt
+++ b/exporters/requirements.txt
@@ -1,7 +1,6 @@
 requests
 prometheus_client
 openshift < 0.12
-jsonpath_ng
 jira
 pytz
 python-gitlab >= 2.4.0


### PR DESCRIPTION
copied from #327

## Describe the behavior changes introduced in this PR

Adds the ability to get git commit information from Tekton runs.

It's a good enough implementation for "technology preview" status. There are open questions about how to extract the right information when there's near infinite flexibility in making a pipeline.

Right now, it tries to follow the (I believe) most common usage patterns:

- Looks up git information from the `git-checkout` `ClusterTask` that comes with Tekton
- Gets the image hash from the first `TaskRun` with a `taskResult` named `IMAGE_DIGEST`
- Gets the image location from the first `TaskRun` with `IMAGE` or `IMAGE_NAME` as a param, following patterns from various s2i and buildah tasks

I'm sure we'll need to figure out a way to add some flexibility. I've started exploring some possible solutions while experimenting with this, but that should come later.

Special thanks to @jlozano-rh for starting the work on this.

## Linked Issues?

resolves #224

## Testing Instructions

1. Fork _my_ fork of this repo and check out the tekton branch.
2. Set up the committime exporter. Make sure it is pointed to your fork. The deploytime exporter must also be there but can still point upstream.
3. Run the tekton demo with `./demo/demo-tekton $URL_FOR_FORK`.
4. Make sure the pipeline was successful and look at the sample page.
5. Use the prompt to make a change, and wait for it to show up.
6. Verify the metrics show up in the dashboard.

@redhat-cop/mdt

## Remaining Work

- [ ] feature-flag the tekton features
- [ ] resolve demo issue: occasional `unable to recognize no matches for kind "Pipeline" in version "tekton.dev/v1beta1"`
- [ ] demo should poll for the page to be ready
- [ ] git-clone task unavailable for the first run?