### PR TITLE
Fix default exporter ref pointing to old release

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.3
+version: 1.4.4
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir }}
     git:
-      ref: {{ .source_ref | default "1.3.0.1" }}
+      ref: {{ .source_ref | default "1.4.1" }}
       uri: {{ .source_url }}
     type: Git
   strategy:

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -327,17 +327,20 @@ The following is a walkthrough of the process we follow to create and manage ver
     * Ensure that you can install Pelorus from the tagged version of the code, including all exporters and optional configurations. (Ensure you update the values.yaml file you are using to refer to the tagged version of the code in all builds)
     * Follow the above guidance for testing Pull requests.
 6. If any bugs are found, open PRs to fix them, then create the next -rc tag (e.g. `<version>-rc2`), and start again from step 1.
-7. Create an annotated tag for the final release with the `-rc` suffix removed.
+7. Update the install version in `docs/Install.md`:
 
-        git checkout <version>-rc
+        git clone --depth 1 --branch NEW_VERSION_HERE https://github.com/konveyor/pelorus
+
+8. Create an annotated tag for the final release with the `-rc` suffix removed.
+
         git tag -a <version>
         git push -u upstream <version>
 
-8. Generate git release notes from the `git log`.
+9. Generate git release notes from the `git log`.
 
         git log <previous tag>..<new tag> --pretty=format:"- %h %s by %an" --no-merges
 
-9.  On the [Pelorus releases](https://github.com/redhat-cop/pelorus/releases) page, click **Draft a new release**. 
+10.  On the [Pelorus releases](https://github.com/redhat-cop/pelorus/releases) page, click **Draft a new release**. 
     * Select the tag that was pushed in the previous step.
     * The release _title_ should be `Release <version>`. 
     * In the main text area, create a `# Release Notes` heading, and then paste in the git log output.

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -25,7 +25,7 @@ Pelorus gets installed via helm charts. The first deploys the operators on which
 
 ```shell
 # clone the repo (you can use a different release or clone from master if you wish)
-git clone --depth 1 --branch v1.3.0 https://github.com/konveyor/pelorus
+git clone --depth 1 --branch v1.4.1 https://github.com/konveyor/pelorus
 cd pelorus
 oc create namespace pelorus
 helm install operators charts/operators --namespace pelorus


### PR DESCRIPTION
The v.1.4.0 release didn't have an updated default tag.

I've fixed that, and another step in the release process that was missing.