### PR TITLE
Invalid tag 1.4.1

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.4
+version: 1.4.5
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir }}
     git:
-      ref: {{ .source_ref | default "1.4.1" }}
+      ref: {{ .source_ref | default "v1.4.1" }}
       uri: {{ .source_url }}
     type: Git
   strategy:


### PR DESCRIPTION
Fixed the error to find the remote ref, there is a tag with the name v1.4.1 and not 1.4.1

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #349 <-- Use this if merging should auto-close an issue

related to #349 <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
