### PR TITLE
Make no-auth github exporter okay

### DIFF
--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
+import logging
 import os
-import sys
 import time
 from distutils.util import strtobool
 
@@ -15,8 +15,6 @@ from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
 import pelorus
-
-REQUIRED_CONFIG = ["GIT_USER", "GIT_TOKEN"]
 
 
 class GitFactory:
@@ -46,17 +44,18 @@ class GitFactory:
 
 if __name__ == "__main__":
     pelorus.upgrade_legacy_vars()
-    if pelorus.missing_configs(REQUIRED_CONFIG):
-        print("This program will exit.")
-        sys.exit(1)
 
     pelorus.load_kube_config()
     k8s_config = client.Configuration()
     k8s_client = client.api_client.ApiClient(configuration=k8s_config)
     dyn_client = DynamicClient(k8s_client)
 
-    username = os.environ.get("GIT_USER")
-    token = os.environ.get("GIT_TOKEN")
+    username = os.environ.get("GIT_USER", "")
+    token = os.environ.get("GIT_TOKEN", "")
+    if not username and not token:
+        logging.info(
+            "No GIT_USER and no GIT_TOKEN given. This is okay for public repositories only."
+        )
     git_api = os.environ.get("GIT_API")
     git_provider = os.environ.get("GIT_PROVIDER", pelorus.DEFAULT_GIT)
     tls_verify = bool(

--- a/exporters/committime/collector_github.py
+++ b/exporters/committime/collector_github.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import requests
 
@@ -16,8 +17,8 @@ class GitHubCommitCollector(AbstractCommitCollector):
     def __init__(
         self,
         kube_client,
-        username,
-        token,
+        username: Optional[str],
+        token: Optional[str],
         namespaces,
         apps,
         git_api=None,
@@ -56,9 +57,8 @@ class GitHubCommitCollector(AbstractCommitCollector):
             + self._suffix
             + metric.commit_hash
         )
-        response = requests.get(
-            url, auth=(self._username, self._token), verify=self._tls_verify
-        )
+        auth = (self._username, self._token) if self._username and self._token else None
+        response = requests.get(url, auth=auth, verify=self._tls_verify)
         if response.status_code != 200:
             # This will occur when trying to make an API call to non-Github
             logging.warning(


### PR DESCRIPTION
Public repos do not need authentication.

This makes local testing and demoing the committime exporter much easier.