### PR TITLE
Add python tekton pipeline demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,13 @@
+# demo
+
+Scripts to demonstrate pelorus functionality live here.
+
+## demo-tekton
+
+Although the pelorus functionality isn't merged yet, you can set up a basic python tekton pipeline with this script.
+
+It takes a single argument which is the downstream/fork URL you'll be pushing to.
+
+## demo.sh
+
+See the [demo docs in the official pelorus documentation.](https://pelorus.readthedocs.io/en/latest/Demo/)

--- a/demo/demo-tekton
+++ b/demo/demo-tekton
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#Assumes User is logged in to cluster
+set -euo pipefail
+
+all_cmds_found=0
+for cmd in oc tkn; do
+   if ! which -s $cmd; then
+      echo "No $cmd executable found in $PATH" >&2
+      all_cmds_found=1
+   fi
+done
+if ! [[ $all_cmds_found ]]; then exit 1; fi
+
+
+tekton_setup_dir="$(dirname $BASH_SOURCE)/tekton-demo-setup"
+python_example_txt="$(dirname $BASH_SOURCE)/python-example/response.txt"
+
+echo "Setting up resources:"
+
+echo "1. Installing tekton operator"
+oc apply -f "$tekton_setup_dir/01-tekton-operator.yaml"
+
+echo "2. Setting up python tekton project"
+if ! project_setup_output="$(oc apply -f $tekton_setup_dir/02-project.yaml 2>&1)"; then
+   if echo "$project_setup_output" | grep -q "AlreadyExists"; then
+      echo "Project already exists"
+   else
+      echo "$project_setup_output" >&2
+      exit 1
+   fi
+else
+   echo "$project_setup_output"
+fi
+
+
+echo "3. Setting up build and deployment information"
+oc process -f "$tekton_setup_dir/03-build-and-deploy.yaml" | oc apply -f -
+
+route="$(oc get -n basic-python-tekton route/basic-python-tekton --output=go-template='http://{{.spec.host}}')"
+
+url=$1
+
+counter=1
+
+current_branch="$(git symbolic-ref HEAD)"
+current_branch=${current_branch##refs/heads/}
+
+function run_pipeline {
+   tkn pipeline start -n basic-python-tekton --showlog basic-python-tekton-pipeline \
+      -w name=repo,claimName=basic-python-tekton-build-pvc \
+      -p git-url="$url" -p git-revision="$current_branch"
+}
+
+echo -e "\nRunning pipeline\n"
+run_pipeline
+
+echo -e "\nWhen ready, page will be available at $route"
+
+while true; do
+   echo ""
+   echo "The pipeline and first run of the demo app has started. When it has finished, you may rerun (with commits) or quit now."
+   echo "1. Rerun with Commit"
+   echo "2. Quit"
+   read -p "Type 1 or 2: " -n 1 a
+   echo ""
+   case $a in
+      1* )
+         echo "We've modified this file, time to build and deploy a new version. Times modified: $counter" | tee -a "$python_example_txt"
+         git commit -m "modifying python example, number $counter" -- "$python_example_txt"
+         git push origin "$current_branch"
+
+         run_pipeline
+
+         echo -e "\nWhen ready, page will be available at $route"
+
+         counter=$((counter+1))
+      ;;
+
+      2* ) exit 0 ;;
+      * ) echo "I'm not sure what $a means, please give 1 or 2" >&2 ;;
+   esac
+done
+

--- a/demo/python-example/README.md
+++ b/demo/python-example/README.md
@@ -1,0 +1,5 @@
+# python-example
+
+This contains a very simple python HTTP server that just serves the `response.txt` file.
+
+This file can easily be appended to, in order to demonstrate pipelines deploying changes.

--- a/demo/python-example/example.py
+++ b/demo/python-example/example.py
@@ -1,0 +1,35 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+response_file_bytes = b""
+response_file_txt = ""
+
+
+class ResponseHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.log_message(
+            f"Got request, returning {response_file_txt} "
+            f"(as bytes {response_file_bytes})"
+        )
+        self.send_response(200, "PELORUS IS COOL")
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(response_file_bytes)))
+        self.end_headers()
+
+        self.wfile.write(response_file_bytes)
+
+
+def main():
+    global response_file_txt, response_file_bytes
+    with open("response.txt", "br") as f:
+        response_file_bytes = f.read()
+    response_file_txt = response_file_bytes.decode("utf-8")
+    print(
+        f"Loaded response.txt with contents {response_file_txt} "
+        f"(as bytes {response_file_bytes})"
+    )
+    server = HTTPServer(("", 8080), ResponseHandler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/python-example/response.txt
+++ b/demo/python-example/response.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/demo/tekton-demo-setup/01-tekton-operator.yaml
+++ b/demo/tekton-demo-setup/01-tekton-operator.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: openshift-pipelines-operator-rh 
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace 

--- a/demo/tekton-demo-setup/02-project.yaml
+++ b/demo/tekton-demo-setup/02-project.yaml
@@ -1,0 +1,6 @@
+apiVersion: project.openshift.io/v1
+kind: ProjectRequest
+displayName: Basic Python Tekton App
+metadata:
+  name: basic-python-tekton
+  creationTimestam: null

--- a/demo/tekton-demo-setup/03-build-and-deploy.yaml
+++ b/demo/tekton-demo-setup/03-build-and-deploy.yaml
@@ -1,0 +1,169 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: basic-python-tekton-template
+parameters:
+  - description: The name for the application.
+    name: APPLICATION_NAME
+    value: basic-python-tekton
+  - name: NAMESPACE
+    description: The namespace the imagestream and pipeline will be deployed in.
+    value: basic-python-tekton
+objects:
+  # Build
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      name: ${APPLICATION_NAME}
+      namespace: ${NAMESPACE}
+      labels:
+        app.kubernetes.io/name: ${APPLICATION_NAME}
+        app.kubernetes.io/instance: ${APPLICATION_NAME}-build
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ${APPLICATION_NAME}
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: ${APPLICATION_NAME}-build-pvc
+      namespace: ${NAMESPACE}
+      labels:
+        app.kubernetes.io/name: ${APPLICATION_NAME}
+        app.kubernetes.io/instance: ${APPLICATION_NAME}-build
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ${APPLICATION_NAME}
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 500Mi
+  - apiVersion: tekton.dev/v1beta1
+    kind: Pipeline
+    metadata:
+      name: ${APPLICATION_NAME}-pipeline
+      namespace: ${NAMESPACE}
+      labels:
+        app.kubernetes.io/name: ${APPLICATION_NAME}
+        app.kubernetes.io/instance: ${APPLICATION_NAME}-build
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ${APPLICATION_NAME}
+    spec:
+      workspaces:
+        - name: repo
+      params:
+        - name: git-url
+          type: string
+          default: https://github.com/konveyor/pelorus
+        - name: git-revision
+          type: string
+          default: master
+      tasks:
+        - name: checkout
+          taskRef:
+            name: git-clone
+            kind: ClusterTask
+          params:
+            - name: url
+              value: $(params.git-url)
+            - name: revision
+              value: $(params.git-revision)
+          workspaces:
+            - name: output
+              workspace: repo
+        - name: s2i-python-build
+          taskRef:
+            name: s2i-python
+            kind: ClusterTask
+          params:
+            - name: PATH_CONTEXT
+              value: demo/python-example
+            - name: IMAGE
+              value: image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/${APPLICATION_NAME}:latest
+          workspaces:
+            - name: source
+              workspace: repo
+          runAfter: [checkout]
+  # Deploy
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      annotations:
+        description: The web server's http port.
+      labels:
+        app.kubernetes.io/name: ${APPLICATION_NAME}
+        app.kubernetes.io/instance: ${APPLICATION_NAME}-deployment
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}
+      namespace: ${NAMESPACE}
+    spec:
+      ports:
+        - port: 8080
+          targetPort: 8080
+      selector:
+        deploymentConfig: ${APPLICATION_NAME}
+  - kind: Route
+    apiVersion: route.openshift.io/v1
+    metadata:
+      name: ${APPLICATION_NAME}
+      namespace: ${NAMESPACE}
+      annotations:
+        description: Route for application's http service.
+      labels:
+        app.kubernetes.io/name: ${APPLICATION_NAME}
+        app.kubernetes.io/instance: ${APPLICATION_NAME}-deployment
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ${APPLICATION_NAME}
+    spec:
+      to:
+        name: ${APPLICATION_NAME}
+  - kind: DeploymentConfig
+    apiVersion: apps.openshift.io/v1
+    metadata:
+      name: ${APPLICATION_NAME}
+      namespace: ${NAMESPACE}
+      labels:
+        app.kubernetes.io/name: ${APPLICATION_NAME}
+        app.kubernetes.io/instance: ${APPLICATION_NAME}-deployment
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: ${APPLICATION_NAME}
+    spec:
+      replicas: 1
+      selector:
+        deploymentConfig: ${APPLICATION_NAME}
+      strategy:
+        type: Rolling
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ${APPLICATION_NAME}
+            app.kubernetes.io/instance: ${APPLICATION_NAME}-deployment
+            app.kubernetes.io/component: api
+            app.kubernetes.io/part-of: ${APPLICATION_NAME}
+            deploymentConfig: ${APPLICATION_NAME}
+          name: ${APPLICATION_NAME}
+        spec:
+          containers:
+            - name: ${APPLICATION_NAME}
+              image: ${APPLICATION_NAME}
+              env:
+                - name: APP_FILE
+                  value: example.py
+              imagePullPolicy: Always
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                exec:
+                  command: [/bin/bash, -c, curl -s 'http://localhost:8080']
+          terminationGracePeriodSeconds: 60
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${APPLICATION_NAME}
+            from:
+              kind: ImageStreamTag
+              name: ${APPLICATION_NAME}:latest
+          type: ImageChange
+        - type: ConfigChange

--- a/demo/tekton-demo-setup/README.md
+++ b/demo/tekton-demo-setup/README.md
@@ -1,0 +1,3 @@
+# tekton-demo-setup
+
+This contains OpenShift resources to set up a tekton python demo. 


### PR DESCRIPTION
This adds a basic python-based tekton demo in the `demo` dir, and a script to set it up and run it.

This is separate from the work in #333 because we should merge early and merge often. #333 will be a big enough PR on its own, so separating this will help with readability.

This is _not_ documented in the `docs/Demo.md` page because we should have the tekton functionality in pelorus up and running first.

Closes #331.

## Testing Instructions

1. Make sure:
  - `oc` and `tkn` are installed
  - you're logged in to the cluster
  - you have permission to install operators and create projects
2. run `./demo/demo-tekton

You should eventually see a simple page served at the link referenced in the output.

Continuing with the script as normal should eventually show changes to that page.

@redhat-cop/mdt
