### PR TITLE
Small setuptools improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# We don't publish pip generated files
+exporters/AUTHORS
+exporters/ChangeLog
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/exporters/requirements-dev.txt
+++ b/exporters/requirements-dev.txt
@@ -1,7 +1,9 @@
-pytest
-coverage
-semver
-mkdocs
 black
+coverage
 isort
+mkdocs
 pylava
+pytest
+semver
+setuptools
+wheel

--- a/exporters/setup.cfg
+++ b/exporters/setup.cfg
@@ -1,0 +1,22 @@
+[metadata]
+name = pelorus
+description = Metrics Exporters for Pelorus project
+long_description = file: README.md
+long_description_content_type = text/markdown
+home_page = https://github.com/konveyor/pelorus
+classifier =
+    Intended Audience :: Information Technology
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[egg_info]
+egg_base = .
+
+[bdist_wheel]
+universal = 1
+
+[pbr]
+warnerrors = true

--- a/exporters/setup.py
+++ b/exporters/setup.py
@@ -1,3 +1,10 @@
-from setuptools import find_packages, setup
+#!/usr/bin/env python3
 
-setup(name="pelorus", packages=find_packages(where="."), python_requires=">=3.9")
+import setuptools
+
+setuptools.setup(
+    packages=setuptools.find_packages(where="."),
+    setup_requires=["pbr>=2.0.0"],
+    python_requires=">=3.9",
+    pbr=True,
+)


### PR DESCRIPTION
With the https://github.com/pypa/pip/issues/7555 the pip install .
is going to be removed with the pip 21.3. We should use instead:
$ pip install --use-feature=in-tree-build exporters/

This change also adds wheel so the python package versionig for
exporters in the python packaging is also included.

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #<issue number> <-- Use this if merging should auto-close an issue

related to #<issue number> <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
