### PR TITLE
Use of Makefile from github actions

### DIFF
--- a/.github/workflows/python-formatting.yml
+++ b/.github/workflows/python-formatting.yml
@@ -10,17 +10,15 @@ on:
 jobs:
   format-check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r exporters/requirements.txt
-          pip install -r exporters/requirements-dev.txt
+          python-version: ${{ matrix.python-version }}
       - name: Check for formatting
-        run: ./scripts/format --check
+        run: make format-check

--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -1,4 +1,4 @@
-name: Pylama
+name: Pylava
 on:
   pull_request:
     paths:
@@ -10,17 +10,15 @@ on:
 jobs:
   python-lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r exporters/requirements.txt
-          pip install -r exporters/requirements-dev.txt
+          python-version: ${{ matrix.python-version }}
       - name: Run pylava for linting
-        run: pylava
+        run: make pylava

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifndef PELORUS_VENV
   PELORUS_VENV=.venv
 endif
 
-ifeq (, $(shell command -v $(PYTHON_BINARY) ))
+ifeq (, $(shell which $(PYTHON_BINARY) ))
   $(error "PYTHON=$(PYTHON_BINARY) binary not found in $(PATH)")
 endif
 
@@ -31,7 +31,7 @@ all: default
 
 $(PELORUS_VENV): exporters/requirements.txt exporters/requirements-dev.txt
 	test -d ${PELORUS_VENV} || ${PYTHON_BINARY} -m venv ${PELORUS_VENV}
-	source ${PELORUS_VENV}/bin/activate && \
+	. ${PELORUS_VENV}/bin/activate && \
 	       pip install -U pip && \
 	       pip install -r exporters/requirements.txt \
 	                   -r exporters/requirements-dev.txt
@@ -39,7 +39,7 @@ $(PELORUS_VENV): exporters/requirements.txt exporters/requirements-dev.txt
 
 .PHONY: exporters
 exporters: $(PELORUS_VENV)
-	source ${PELORUS_VENV}/bin/activate && \
+	. ${PELORUS_VENV}/bin/activate && \
 	       pip install -e exporters/
 
 dev-env: $(PELORUS_VENV) exporters
@@ -48,17 +48,17 @@ dev-env: $(PELORUS_VENV) exporters
 
 .PHONY: format
 format: $(PELORUS_VENV)
-	source ${PELORUS_VENV}/bin/activate && \
+	. ${PELORUS_VENV}/bin/activate && \
 	./scripts/format;
 
 .PHONY: format-check
 format-check: $(PELORUS_VENV)
-	source ${PELORUS_VENV}/bin/activate && \
+	. ${PELORUS_VENV}/bin/activate && \
 	./scripts/format --check;
 
 .PHONY: pylava
 pylava: $(PELORUS_VENV)
-	source ${PELORUS_VENV}/bin/activate && \
+	. ${PELORUS_VENV}/bin/activate && \
 	pylava;
 
 clean-dev-env:


### PR DESCRIPTION
Fixes #363

Matrix of currently used in development python versions 3.9 and 3.10.

Makefile adjustments necessary to be compatible with github actions shell, that is missing 'command' and 'source'.