### PR TITLE
Optional shellcheck and chart lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ isort-check: $(PELORUS_VENV)
 # Linting
 
 .PHONY: lint pylava chart-lint chart-lint-optional shellcheck shellcheck-optional
-lint: pylava shellcheck chart-lint-optional shellcheck-optional
+lint: pylava chart-lint-optional shellcheck-optional
 
 pylava: $(PELORUS_VENV)
 	@echo 🐍 🌋 Linting with pylava

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ ifneq (, $(CHART_TEST))
 chart-lint-optional: chart-lint
 else
 chart-lint-optional:
-	@echo "chart test (ct) not installed, skipping"
+	$(warning chart test (ct) not installed, skipping)
 endif
 
 shellcheck:
@@ -131,7 +131,7 @@ ifneq (, $(SHELLCHECK))
 shellcheck-optional: shellcheck
 else
 shellcheck-optional:
-	@echo "🐚 ⏭ Shellcheck not found, skipping"
+	$(warning 🐚 ⏭ Shellcheck not found, skipping)
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 CHART_TEST=$(shell which ct)
 
 SHELLCHECK=$(shell which shellcheck)
-SHELL_SCRIPTS=./scripts/pre-commit ./scripts/setup-pre-commit-hook ./demo/demo.sh ./demo/demo-tekton
+SHELL_SCRIPTS=./scripts/pre-commit ./scripts/setup-pre-commit-hook ./demo/demo-tekton
 
 
 .PHONY: default

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 CHART_TEST=$(shell which ct)
 
 SHELLCHECK=$(shell which shellcheck)
-SHELL_SCRIPTS=./scripts/pre-commit ./scripts/setup-pre-commit-hook
+SHELL_SCRIPTS=./scripts/pre-commit ./scripts/setup-pre-commit-hook ./demo/demo.sh ./demo/demo-tekton
 
 
 .PHONY: default

--- a/demo/demo-tekton
+++ b/demo/demo-tekton
@@ -12,8 +12,8 @@ done
 if ! [[ $all_cmds_found ]]; then exit 1; fi
 
 
-tekton_setup_dir="$(dirname $BASH_SOURCE)/tekton-demo-setup"
-python_example_txt="$(dirname $BASH_SOURCE)/python-example/response.txt"
+tekton_setup_dir="$(dirname "${BASH_SOURCE[0]}")/tekton-demo-setup"
+python_example_txt="$(dirname "${BASH_SOURCE[0]}")/python-example/response.txt"
 
 echo "Setting up resources:"
 
@@ -21,7 +21,7 @@ echo "1. Installing tekton operator"
 oc apply -f "$tekton_setup_dir/01-tekton-operator.yaml"
 
 echo "2. Setting up python tekton project"
-if ! project_setup_output="$(oc apply -f $tekton_setup_dir/02-project.yaml 2>&1)"; then
+if ! project_setup_output="$(oc apply -f "$tekton_setup_dir/02-project.yaml" 2>&1)"; then
    if echo "$project_setup_output" | grep -q "AlreadyExists"; then
       echo "Project already exists"
    else
@@ -61,7 +61,7 @@ while true; do
    echo "The pipeline and first run of the demo app has started. When it has finished, you may rerun (with commits) or quit now."
    echo "1. Rerun with Commit"
    echo "2. Quit"
-   read -p "Type 1 or 2: " -n 1 a
+   read -r -p "Type 1 or 2: " -n 1 a
    echo ""
    case $a in
       1* )

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 
 failed=0
 

--- a/scripts/setup-pre-commit-hook
+++ b/scripts/setup-pre-commit-hook
@@ -8,7 +8,7 @@ desired_link_path=../../scripts/pre-commit
 if [[ -h $target_hook_path ]]; then
     link_path="$(readlink $target_hook_path)"
 
-    if [[ $link_path = $desired_link_path ]]; then
+    if [[ $link_path = "$desired_link_path" ]]; then
         echo "pre-commit hook already set up"
     else
         echo "warning: pre-commit hook pointing to unknown location $link_path, should be $desired_link_path" >&2


### PR DESCRIPTION
I made a typo in #353, making a bad shebang in ./scripts/setup-pre-commit-hook.

Shellcheck would have caught this.

While trying to figure out how to make shellcheck optionally run, I realized the pattern would work for chart-lint as well, so I added that.