### PR TITLE
Ensure make format-check works on a local development env.

### DIFF
--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -4,17 +4,17 @@ import os
 import time
 from distutils.util import strtobool
 
-from committime.collector_azure_devops import AzureDevOpsCommitCollector
-from committime.collector_bitbucket import BitbucketCommitCollector
-from committime.collector_gitea import GiteaCommitCollector
-from committime.collector_github import GitHubCommitCollector
-from committime.collector_gitlab import GitLabCommitCollector
 from kubernetes import client
 from openshift.dynamic import DynamicClient
 from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
 import pelorus
+from committime.collector_azure_devops import AzureDevOpsCommitCollector
+from committime.collector_bitbucket import BitbucketCommitCollector
+from committime.collector_gitea import GiteaCommitCollector
+from committime.collector_github import GitHubCommitCollector
+from committime.collector_gitlab import GitLabCommitCollector
 
 
 class GitFactory:

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -6,11 +6,11 @@ import re
 from abc import abstractmethod
 from typing import Iterable
 
-from committime import CommitMetric
 from jsonpath_ng import parse
 from prometheus_client.core import GaugeMetricFamily
 
 import pelorus
+from committime import CommitMetric
 
 
 class AbstractCommitCollector(pelorus.AbstractPelorusExporter):

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -4,10 +4,11 @@ from typing import Optional
 
 import attr
 import pytest
-from committime import CommitMetric
-from committime.collector_github import GitHubCommitCollector
 from kubernetes.client import ApiClient, Configuration
 from openshift.dynamic import DynamicClient
+
+from committime import CommitMetric
+from committime.collector_github import GitHubCommitCollector
 
 
 def setup_collector():

--- a/exporters/tests/test_deploytime.py
+++ b/exporters/tests/test_deploytime.py
@@ -5,12 +5,12 @@ from typing import Sequence
 from unittest.mock import NonCallableMock
 
 import pytest
-from deploytime.app import DeployTimeMetric, generate_metrics, image_sha  # type: ignore
 from openshift.dynamic import DynamicClient  # type: ignore
 from openshift.dynamic.discovery import Discoverer  # type: ignore
-from tests.openshift_mocks import *
 
 import pelorus
+from deploytime.app import DeployTimeMetric, generate_metrics, image_sha
+from tests.openshift_mocks import *
 
 # pylava:ignore=W0401
 

--- a/exporters/tests/test_exporters.py
+++ b/exporters/tests/test_exporters.py
@@ -1,7 +1,7 @@
 import pytest
-from committime.collector_base import CommitMetric
 
 import pelorus
+from committime.collector_base import CommitMetric
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [tool.isort]
 profile = "black"
+src_paths = ["exporters" ,"scripts"]
+known_first_party = ["pelorus"]
 
 [tool.pytest.ini_options]
 testpaths = ["exporters/tests"]


### PR DESCRIPTION
Lack of .isort.cfg and explicit information about local packages
causes isort to fail. This addresses the issue, so now both
CI runs and local runs should be consistent.

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #<issue number> <-- Use this if merging should auto-close an issue

related to #<issue number> <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
