### PR TITLE
Release 1.4.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,12 @@ git-blame:
 .git/hooks/pre-commit: scripts/pre-commit
 	./scripts/setup-pre-commit-hook
 
-dev-env: $(PELORUS_VENV) exporters git-blame .git/hooks/pre-commit
+$(PELORUS_VENV)/binary_tools_installed:
+	./scripts/install_dev_tools -v $(PELORUS_VENV)
+	touch $(PELORUS_VENV)/binary_tools_installed
+
+dev-env: $(PELORUS_VENV) $(PELORUS_VENV)/binary_tools_installed \
+         exporters git-blame .git/hooks/pre-commit
 	$(info **** To run VENV: $$source ${PELORUS_VENV}/bin/activate)
 	$(info **** To later deactivate VENV: $$deactivate)
 

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.5
+version: 1.4.6
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir }}
     git:
-      ref: {{ .source_ref | default "v1.4.1" }}
+      ref: {{ .source_ref | default "v1.4.6" }}
       uri: {{ .source_url }}
     type: Git
   strategy:

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -37,9 +37,8 @@ When any of our Helm charts are updated, we need to bump the version number.
 This allows for a seemless upgrade experience.
 We have provided scripts that can test when a version bump is needed and do the bumping for you.
 
-1. Install Helm's [chart-testing](https://github.com/helm/chart-testing) tool.
-2. Ensure the development environment is set up with `make dev-env`.
-3. Run `make chart-lint` to lint the charts, including checking the version number.
+1. Ensure the development environment is set up with `make dev-env`.
+2. Run `make chart-lint` to lint the charts, including checking the version number.
 
 You can check all chart versions and bump them if needed with `./scripts/chart-check-and-bump`,
 or bump specific charts with `./scripts/bump-version CHART_PATH [ CHART_PATH ...]`.
@@ -135,6 +134,7 @@ This will:
 
 - check for the right version of python
 - set up a virtual environment
+- install required CLI tools such as helm, oc, tkn and ct (inside .venv/bin)
 - install dependencies
 - install the exporters package
 - set up git hooks for formatting and linting checks
@@ -215,26 +215,26 @@ Running an exporter on your local machine should follow this process:
 
         make dev-env
 
-2. Set any environment variables required (or desired) for the given exporter (see [Configuring Exporters](Configuration.md#configuring-exporters) to see supported variables).
+2. Activate your virtual environment
+
+        . .venv/bin/activate
+
+3. Set any environment variables required (or desired) for the given exporter (see [Configuring Exporters](Configuration.md#configuring-exporters) to see supported variables).
 
         export GIT_TOKEN=xxxx
         export GIT_USER=xxxx
 
-3. Log in to your OpenShift cluster
+4. Log in to your OpenShift cluster
 
         oc login --token=<token> --server=https://api.cluster-my.fun.domain.com:6443 
 
-4. (Optional) To avoid certificate warnings and some possible errors, you need to set up your local machine to trust your cluster certificate
+5. (Optional) To avoid certificate warnings and some possible errors, you need to set up your local machine to trust your cluster certificate
 
     1.  Download your cluster ca.crt file
     2.  Add cert to system trust bundle
     3.  Pass cert bundle with your login command
 
             oc login --token=<token> --server=https://api.cluster-my.fun.domain.com:6443  --certificate-authority=/etc/pki/tls/certs/ca-bundle.crt
-
-5. Activate your virtual environment
-
-        . .venv/bin/activate
 
 6. Start the exporter
         
@@ -287,15 +287,19 @@ Most exporter changes can be tested locally.
 
         make dev-env
 
-3. Run unit tests using `python -m pytest`.
+3. Activate your virtual environment
+
+        . .venv/bin/activate
+
+4. Run unit tests using `python -m pytest`.
     1. You can also run coverage reports with the following:
 
             coverage run -m pytest
             coverage report
 
-4. Gather necessary [configuration information](Configuration.md#configuring-exporters).
-5. [Run exporter locally](#running-locally). You can do this either via the command line, or use the provided [VSCode debug confuration](#ide-setup-vscode) to run it in your IDE Debugger.
-6. Once exporter is running, you can test it via a simple `curl localhost:8080`. You should be validating that:
+5. Gather necessary [configuration information](Configuration.md#configuring-exporters).
+6. [Run exporter locally](#running-locally). You can do this either via the command line, or use the provided [VSCode debug confuration](#ide-setup-vscode) to run it in your IDE Debugger.
+7. Once exporter is running, you can test it via a simple `curl localhost:8080`. You should be validating that:
     1. You get a valid response with metrics.
     1. Confirm the format of expected metrics.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,10 @@ Various scripts for development reside here.
 
 Sets up a python3.9 virtual environment, installs dependencies, and sets up the pre-commit hook.
 
+## install_dev_tools
+
+Installs required packages for deploying and testing Pelorus inside virtual environment.
+
 ## pre-commit
 
 A pre-commit hook for git. Will lint helm charts, and check if formatting is correct.

--- a/scripts/install_dev_tools
+++ b/scripts/install_dev_tools
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+# Get the full absolute path to the script. Needed while calling the script
+# via various partial paths or sourcing the file from shell
+# BASH_SOURCE[0] is safer then $0 when sourcing.
+# We enter the dirname of the invoked script and then get the current
+# path of the script using pwd
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# Match the .venv created by the Makefile
+DEFAULT_VENV="${SCRIPT_DIR}/../.venv"
+
+TMP_DIR_PREFIX="pelorus_tmp_"
+
+TKN_CLIENT_API_URL="https://api.github.com/repos/tektoncd/cli/releases/latest"
+CT_CLIENT_API_URL="https://api.github.com/repos/helm/chart-testing/releases/latest"
+
+HELM_INSTALL_SCRIPT="https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3"
+
+# Currently we are interested in development on Linux and Mac OS platforms
+# Because OCP_CLIENT URL links do not follow standard binary name format
+# e.g. Linux/Darwin we need to map those 
+PLATFORM="linux"
+[[ "$(uname -s)" =~ "Darwin" ]] && PLATFORM="mac"
+OCP_CLIENT_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-${PLATFORM}.tar.gz"
+
+
+function download_file_from_url() {
+    local url=$1
+    local dest_folder=$2
+
+    pushd "${dest_folder}" || exit
+      echo "Downloading file: ${url}"
+      echo "To: ${dest_folder}"
+      curl -LO "${url}"
+    popd || exit
+}
+
+function extract_file_to_dir() {
+    local file_path=$1
+    local dest_dir=$2
+    local file_names=$3 # Extract only specific files
+
+    if [ ! -f "${file_path}" ]; then
+        echo "extract_file_to_dir(): File does not exists: ${file_path}" >&2
+        return 2
+    fi
+
+    if [ ! -d "${dest_dir}" ]; then
+        echo "extract_file_to_dir(): Dest dir does not exists: ${dest_dir}" >&2
+        return 2
+    fi
+
+    # shellcheck disable=SC2116,SC2046 # We need to expand $file_names
+    tar xvzf "${file_path}" -C "${dest_dir}" $(echo "${file_names}")
+}
+
+function get_download_url_from_github_api() {
+    local api_url=$1
+    if [ -z "${api_url}" ]; then
+        echo "get_download_url_from_github(): API URL not provided" >&2
+        return 2
+    fi
+
+    local arch
+    local kernel_name
+    arch="$(uname -m)"
+    kernel_name="$(uname -s)" # e.g. Linux / Darwin
+
+    # Little hack for grep as some projects are shipping release tarballs
+    # as x86_64 and some as amd64
+    if [[ "${arch}" == "x86_64" ]]; then
+        arch="-e ${arch} -e amd64"
+    elif [[ "${arch}" == "amd64" ]]; then
+        arch="-e ${arch} -e x86_64"
+    fi
+
+    # Call the API to find the latest binary matching kernel and architecture
+    local url_cmd
+    local download_url
+    url_cmd="curl -s ${api_url} | \
+          grep -o -E 'https://(.*).tar.gz' | \
+          grep -i '${kernel_name}' | \
+          grep ${arch}"
+    download_url=$(eval "${url_cmd}")
+
+    if [ -z "${download_url}" ]; then
+        echo "get_download_url_from_github(): download_url not available." >&2
+        echo "command used to get URL: $ ${url_cmd}" >&2
+        return 2
+    fi
+
+    # Return URL
+    echo "${download_url}"
+}
+
+# Installs helm into .venv path
+function install_helm() {
+    local helm_install_script=$1
+    local dest_dir=$2
+    if [ ! -f "${helm_install_script}" ]; then
+        echo "install_helm(): File does not exists: ${helm_install_script}" >&2
+        return 2
+    fi
+
+    if [ ! -d "${dest_dir}" ]; then
+        echo "install_helm(): Dest dir does not exists: ${dest_dir}" >&2
+        return 2
+    fi
+
+    chmod +x "${helm_install_script}" 
+    HELM_INSTALL_DIR="${dest_dir}" USE_SUDO=false "${helm_install_script}"
+}
+
+# Function to safely remove temporary files and temporary download dir
+# Argument is optional exit value to propagate it after cleanup
+function cleanup_and_exit() {
+    local exit_val=$1
+    if [ -z "${DWN_DIR}" ]; then
+        echo "cleanup_and_exit(): Temp download dir not provided !" >&2
+    else
+      # Ensure dir exists and starts with prefix
+      if [ -d "${DWN_DIR}" ]; then
+          PELORUS_TMP_DIR=$(basename "${DWN_DIR}")
+          if [[ "${PELORUS_TMP_DIR}" =~ "${TMP_DIR_PREFIX}"* ]]; then
+              echo "Cleaning up temporary files"
+              eval rm -f "${DWN_DIR}/*"
+              rmdir "${DWN_DIR}"
+          fi
+      fi
+    fi
+    # Propagate exit value if was provided
+    [ -n "${exit_val}" ] && exit "$exit_val"
+    exit 0
+}
+
+function print_help() {
+    printf "\nUsage: %s [OPTION]... -v [DIR]\n\n" % "$0"
+    printf "\tStartup:\n"
+    printf "\t  -h\tprint this help\n"
+    printf "\n\tOptions:\n"
+    printf "\t  -v\tpath to virtualenv DIR\n"
+
+    exit 0
+}
+
+### Options
+OPTIND=1
+while getopts "h?v:" option; do
+    case "$option" in
+    h|\?) print_help;;
+    v)    venv_dir=$OPTARG;;
+    esac
+done
+
+if [ -z "${venv_dir}" ]; then
+    VENV="${DEFAULT_VENV}"
+else
+    VENV="${venv_dir}"
+fi
+
+# Create download directory inside virtual env dir
+DWN_DIR=$(mktemp -p "${VENV}" -d -t "${TMP_DIR_PREFIX}XXXXX") || exit 2
+
+trap 'cleanup_and_exit' INT TERM EXIT
+
+# Helm install
+if ! [ -x "$(command -v "${VENV}/bin/helm")" ]; then
+    echo "Installing helm CLI to: ${VENV}/bin/helm"
+    download_file_from_url "${HELM_INSTALL_SCRIPT}" "${DWN_DIR}"
+    HELM_SCRIPT="${DWN_DIR}"/$(basename "${HELM_INSTALL_SCRIPT}")
+    install_helm "${HELM_SCRIPT}" "${VENV}/bin"
+fi
+
+# Tekton install
+if ! [ -x "$(command -v "${VENV}/bin/tkn")" ]; then
+    echo "Installing tkn CLI to: ${VENV}/bin/tkn"
+    TKN_CLIENT_URL=$(get_download_url_from_github_api "${TKN_CLIENT_API_URL}")
+    download_file_from_url "${TKN_CLIENT_URL}" "${DWN_DIR}"
+    TKN_CLIENT_PATH="${DWN_DIR}"/$(basename "${TKN_CLIENT_URL}")
+    extract_file_to_dir "${TKN_CLIENT_PATH}" "${VENV}/bin/" "tkn"
+fi
+
+# OC install
+if ! [ -x "$(command -v "${VENV}/bin/oc")" ]; then
+    echo "Installing oc CLI to: ${VENV}/bin/oc"
+    download_file_from_url "${OCP_CLIENT_URL}" "${DWN_DIR}"
+    OCP_CLIENT_PATH="${DWN_DIR}"/$(basename "${OCP_CLIENT_URL}")
+    # We are interested only in oc/kubectl binaries
+    extract_file_to_dir "${OCP_CLIENT_PATH}" "${VENV}/bin/" "oc kubectl"
+fi
+
+# CT install
+if ! [ -x "$(command -v "${VENV}/bin/ct")" ]; then
+    CT_CLIENT_URL=$(get_download_url_from_github_api "${CT_CLIENT_API_URL}") \
+                  || (echo "$CT_CLIENT_URL"; cleanup_and_exit 2)
+    download_file_from_url "${CT_CLIENT_URL}" "${DWN_DIR}"
+    CT_CLIENT_PATH="${DWN_DIR}"/$(basename "${CT_CLIENT_URL}")
+    extract_file_to_dir "${CT_CLIENT_PATH}" "${VENV}/bin/" "ct"
+fi


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

We will release Pelorus 1.4.6, so two files requires version bump.

charts/pelorus/charts/exporters/templates/_buildconfig.yaml:
  The default version will match TAG that will be created once this PR is merged.

charts/pelorus/Chart.yaml:
  This requires incremental change as we did change the _buildconfig.yaml which belongs to the pelorus chart.

Next steps are to crate TAG and release that are described in the:
  https://pelorus.readthedocs.io/en/latest/Development/#release-management-process

This is desired as we are going to merge PR #372, which will cause incompatibility with OCP <= 4.6, however that OCP version is no longer supported: [OpenShift Life Cycle Dates](https://access.redhat.com/support/policy/updates/openshift#dates) 

@redhat-cop/mdt