### PR TITLE
New release 1.4.6

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.5
+version: 1.4.6
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir }}
     git:
-      ref: {{ .source_ref | default "v1.4.1" }}
+      ref: {{ .source_ref | default "v1.4.6" }}
       uri: {{ .source_url }}
     type: Git
   strategy:


### PR DESCRIPTION
Describe the behavior changes introduced in this PR
We will release Pelorus 1.4.6, so two files requires version bump.

charts/pelorus/charts/exporters/templates/_buildconfig.yaml:
The default version will match TAG that will be created once this PR is merged.

charts/pelorus/Chart.yaml:
This requires incremental change as we did change the _buildconfig.yaml which belongs to the pelorus chart.

Next steps are to crate TAG and release that are described in the:
https://pelorus.readthedocs.io/en/latest/Development/#release-management-process

This is desired as we are going to merge PR #372, which will cause incompatibility with OCP <= 4.6, however that OCP version is no longer supported: OpenShift Life Cycle Dates

@redhat-cop/mdt