### PR TITLE
Update grafana operator to 4.2.0 version

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.3
+version: 1.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/operators/templates/grafana-subscription.yaml
+++ b/charts/operators/templates/grafana-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v4.1.1
+  startingCSV: grafana-operator.v4.2.0


### PR DESCRIPTION
Resolves PR #388

With the grafana operator 4.2.0 datasource is properly configured
in the OCP cluster.

@redhat-cop/mdt
