### PR TITLE
Release drafter configuration file

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,55 @@
+name-template: 'v$RESOLVED_VERSION 🎉'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+      - 'fix'
+  - title: '🛠️ Misc. Improvements'
+    label: 'maintenance'
+  - title: '📖 Documentation'
+    label: 'docs'
+  - title: '🔡 Other changes'
+  - title: '📦 Operator Updates'
+    label: 'compatibility'
+    collapse-after: 5
+
+exclude-labels:
+  - 'skip-changelog'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+# Version template: v"$MAJOR.$MINOR.$PATCH"
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+autolabeler:
+  - label: 'docs'
+    files:
+      - '*.md'
+  - label: 'major'
+    title:
+      - '/major release/i'
+  - label: 'minor'
+    title:
+      - '/minor release/i'
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
Release drafter action configuration file
    
Adds release-drafter configuration file to create automatically drafts from the releases which can be approved or modified.
    
This configuration file must be merged before real drafter action is proposed, otherwise github workflow will fail.