### PR TITLE
Release drafter action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,55 @@
+name-template: 'v$RESOLVED_VERSION 🎉'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+      - 'fix'
+  - title: '🛠️ Misc. Improvements'
+    label: 'maintenance'
+  - title: '📖 Documentation'
+    label: 'docs'
+  - title: '🔡 Other changes'
+  - title: '📦 Operator Updates'
+    label: 'compatibility'
+    collapse-after: 5
+
+exclude-labels:
+  - 'skip-changelog'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+# Version template: v"$MAJOR.$MINOR.$PATCH"
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+autolabeler:
+  - label: 'docs'
+    files:
+      - '*.md'
+  - label: 'major'
+    title:
+      - '/major release/i'
+  - label: 'minor'
+    title:
+      - '/minor release/i'
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,18 @@
+name: Pelorus Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+  # pull_request required to auto label PRs
+  pull_request:
+    types: [opened, reopened, synchronize]
+    
+jobs:
+  release_drafter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release drafter action to create releases in automated manner

Adds release-drafter action to create automatically drafts
for the releases which can be approved or modified.

Later another action could create releases from those drafts.

To bump major or minor version simply create PR with the
subject that contains "major release" or "minor release".

This action also auto-labels PRs based on some simple regex
which can be extended in the future.