### PR TITLE
Extract image SHAs from status.containerStatuses as well as spec.containers

### DIFF
--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -92,13 +92,25 @@ class DeployTimeCollector:
         return namespaces
 
 
-@attr.define(kw_only=True)
+@attr.frozen(kw_only=True)
 class DeployTimeMetric:
     name: str
     namespace: str
+    # WARNING: do not mutate the dict after hashing or things may break.
     labels: dict[str, str]
     deploy_time: object
     image_sha: str
+
+    def __hash__(self):
+        return hash(
+            (
+                self.name,
+                self.namespace,
+                hash(tuple(self.labels.items())),
+                self.deploy_time,
+                self.image_sha,
+            )
+        )
 
 
 def image_sha(image_url_or_id: str) -> Optional[str]:

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -101,12 +101,20 @@ class DeployTimeMetric:
     image_sha: str
 
 
-def image_sha(img_url: str) -> Optional[str]:
+def image_sha(image_url_or_id: str) -> Optional[str]:
+    """
+    Gets the hash of the image, extracted from the image URL or image ID.
+
+    Specifically, everything after the first `sha256:` seen.
+    """
     sha_regex = re.compile(r"sha256:.*")
-    try:
-        return sha_regex.search(img_url).group()
-    except AttributeError:
-        logging.debug("Skipping unresolved image reference: %s" % img_url)
+    if match := sha_regex.search(image_url_or_id):
+        return match.group()
+    else:
+        # This may be noisy if there are a lot of pods where the container
+        # spec doesn't have a SHA but the status does.
+        # But since it's only in debug logs, it doesn't matter.
+        logging.debug("Skipping unresolved image reference: %s", image_url_or_id)
         return None
 
 
@@ -167,7 +175,17 @@ def generate_metrics(
                 continue
 
             mark_as_seen(full_path)
-            images = (sha for c in pod.spec.containers if (sha := image_sha(c.image)))
+            container_shas = (
+                image_sha(container.image) for container in pod.spec.containers
+            )
+            # TODO: does this include sidecars, say from MutatingAdmissionControllers?
+            # We'll want some way of excluding those.
+            container_status_shas = (
+                image_sha(status.imageID) for status in pod.status.containerStatuses
+            )
+            images = {sha for sha in container_shas if sha} | {
+                sha for sha in container_status_shas if sha
+            }
 
             # Since a commit will be built into a particular image and there could be multiple
             # containers (images) per pod, we will push one metric per image/container in the

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -178,8 +178,6 @@ def generate_metrics(
             container_shas = (
                 image_sha(container.image) for container in pod.spec.containers
             )
-            # TODO: does this include sidecars, say from MutatingAdmissionControllers?
-            # We'll want some way of excluding those.
             container_status_shas = (
                 image_sha(status.imageID) for status in pod.status.containerStatuses
             )

--- a/exporters/tests/openshift_mocks.py
+++ b/exporters/tests/openshift_mocks.py
@@ -29,9 +29,20 @@ class PodSpec:
 
 
 @attr.define
+class ContainerStatus:
+    imageID: str
+
+
+@attr.define
+class PodStatus:
+    containerStatuses: list[ContainerStatus]
+
+
+@attr.define
 class Pod:
     metadata: Metadata
     spec: PodSpec
+    status: PodStatus
 
 
 @attr.define


### PR DESCRIPTION
## Behavior Changes

The deploytime exporter will now check a pod's `status.containerStatuses` for image IDs as well.

## Linked Issues?

resolves #330

## Testing Instructions

I'm planning on adding a simple mock for our deploytime exporter as well, which will have some images that don't have the ID in their spec.

@redhat-cop/mdt

## Remaining Work

- [x] I need to see if `pod.status.containerStatuses` might list sidecars from MutatingAdmissionControllers (e.g. from Istio / Service Mesh), which we wouldn't want to count. It's also possible that those are already included in `spec.containers`, which would be a separate issue.
- [x] add a unit test / address new unit test failures
- ~~[ ] I need to add the mock as mentioned above.~~