### PR TITLE
Use Makefile for chart-lint github action

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -20,11 +20,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
-
-      - name: Install chart-testing tool `ct`
-        uses: helm/chart-testing-action@v2.1.0
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
         with:
-          version: "v3.4.0"
-
+          python-version: 3.9
       - name: Lint charts
-        run: ct lint --config ct.yaml
+        run: make chart-lint

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,9 @@ pylava: $(PELORUS_VENV)
 # shellcheck follows a similar pattern, but is not currently set up for CI.
 
 chart-lint: $(PELORUS_VENV)
+	./scripts/install_dev_tools -v $(PELORUS_VENV) -c ct && \
 	. ${PELORUS_VENV}/bin/activate && \
-	./scripts/chart-lint
+	ct lint --config ct.yaml
 
 ifneq (, $(CHART_TEST))
 chart-lint-optional: chart-lint

--- a/scripts/install_dev_tools
+++ b/scripts/install_dev_tools
@@ -95,7 +95,7 @@ function get_download_url_from_github_api() {
     url_cmd="curl -s ${api_url} | \
           grep -o -E 'https://(.*).tar.gz' | \
           grep -i '${kernel_name}' | \
-          grep ${arch}"
+          grep ${arch} | head -n 1"
     download_url=$(eval "${url_cmd}")
 
     if [ -z "${download_url}" ]; then
@@ -126,6 +126,24 @@ function install_helm() {
     HELM_INSTALL_DIR="${dest_dir}" USE_SUDO=false "${helm_install_script}"
 }
 
+# Function to check if particular cli binary should be installed
+# it checks cli name from arg against array from the passed to this
+# script via optarg list of cli's to be installed
+function should_cli_be_installed(){
+    local cli_check=$1
+    local cli_array=("${@:2}")
+    # No cli_array is set, accept all CLIs
+    if [ -z "${cli_array[*]}" ]; then
+        return 0
+    fi
+    for cli in "${cli_array[@]}"; do
+        if [ "$cli" == "$cli_check" ]; then
+            return 0
+        fi
+    done
+    return 2
+}
+
 # Function to safely remove temporary files and temporary download dir
 # Argument is optional exit value to propagate it after cleanup
 function cleanup_and_exit() {
@@ -153,6 +171,7 @@ function print_help() {
     printf "\tStartup:\n"
     printf "\t  -h\tprint this help\n"
     printf "\n\tOptions:\n"
+    printf "\t  -c\tcomma separated list of CLI tools e.g. ct,oc\n"
     printf "\t  -v\tpath to virtualenv DIR\n"
 
     exit 0
@@ -160,9 +179,10 @@ function print_help() {
 
 ### Options
 OPTIND=1
-while getopts "h?v:" option; do
+while getopts "c:h?v:" option; do
     case "$option" in
     h|\?) print_help;;
+    c)    cli_tools=$OPTARG;;
     v)    venv_dir=$OPTARG;;
     esac
 done
@@ -173,42 +193,53 @@ else
     VENV="${venv_dir}"
 fi
 
+# Get the list of CLI tools to be installed from comma separated output
+# Remove any whitespace which user may have added before or after ","
+cli_tools_arr=("${cli_tools//' '/}")
+
+# shellcheck disable=SC2206
+cli_tools_arr=(${cli_tools_arr//','/ })
+
 # Create download directory inside virtual env dir
 DWN_DIR=$(TMPDIR="${VENV}" mktemp -d -t "${TMP_DIR_PREFIX}XXXXX") || exit 2
 
 trap 'cleanup_and_exit' INT TERM EXIT
 
 # Helm install
-if ! [ -x "$(command -v "${VENV}/bin/helm")" ]; then
-    echo "Installing helm CLI to: ${VENV}/bin/helm"
-    download_file_from_url "${HELM_INSTALL_SCRIPT}" "${DWN_DIR}"
-    HELM_SCRIPT="${DWN_DIR}"/$(basename "${HELM_INSTALL_SCRIPT}")
-    install_helm "${HELM_SCRIPT}" "${VENV}/bin"
+if should_cli_be_installed "helm" "${cli_tools_arr[@]}" && \
+    ! [ -x "$(command -v "${VENV}/bin/helm")" ]; then
+      echo "Installing helm CLI to: ${VENV}/bin/helm"
+      download_file_from_url "${HELM_INSTALL_SCRIPT}" "${DWN_DIR}"
+      HELM_SCRIPT="${DWN_DIR}"/$(basename "${HELM_INSTALL_SCRIPT}")
+      install_helm "${HELM_SCRIPT}" "${VENV}/bin"
 fi
 
 # Tekton install
-if ! [ -x "$(command -v "${VENV}/bin/tkn")" ]; then
-    echo "Installing tkn CLI to: ${VENV}/bin/tkn"
-    TKN_CLIENT_URL=$(get_download_url_from_github_api "${TKN_CLIENT_API_URL}")
-    download_file_from_url "${TKN_CLIENT_URL}" "${DWN_DIR}"
-    TKN_CLIENT_PATH="${DWN_DIR}"/$(basename "${TKN_CLIENT_URL}")
-    extract_file_to_dir "${TKN_CLIENT_PATH}" "${VENV}/bin/" "tkn"
+if should_cli_be_installed "tkn" "${cli_tools_arr[@]}" && \
+    ! [ -x "$(command -v "${VENV}/bin/tkn")" ]; then
+      echo "Installing tkn CLI to: ${VENV}/bin/tkn"
+      TKN_CLIENT_URL=$(get_download_url_from_github_api "${TKN_CLIENT_API_URL}")
+      download_file_from_url "${TKN_CLIENT_URL}" "${DWN_DIR}"
+      TKN_CLIENT_PATH="${DWN_DIR}"/$(basename "${TKN_CLIENT_URL}")
+      extract_file_to_dir "${TKN_CLIENT_PATH}" "${VENV}/bin/" "tkn"
 fi
 
 # OC install
-if ! [ -x "$(command -v "${VENV}/bin/oc")" ]; then
-    echo "Installing oc CLI to: ${VENV}/bin/oc"
-    download_file_from_url "${OCP_CLIENT_URL}" "${DWN_DIR}"
-    OCP_CLIENT_PATH="${DWN_DIR}"/$(basename "${OCP_CLIENT_URL}")
-    # We are interested only in oc/kubectl binaries
-    extract_file_to_dir "${OCP_CLIENT_PATH}" "${VENV}/bin/" "oc kubectl"
+if should_cli_be_installed "oc" "${cli_tools_arr[@]}" && \
+    ! [ -x "$(command -v "${VENV}/bin/oc")" ]; then
+      echo "Installing oc CLI to: ${VENV}/bin/oc"
+      download_file_from_url "${OCP_CLIENT_URL}" "${DWN_DIR}"
+      OCP_CLIENT_PATH="${DWN_DIR}"/$(basename "${OCP_CLIENT_URL}")
+      # We are interested only in oc/kubectl binaries
+      extract_file_to_dir "${OCP_CLIENT_PATH}" "${VENV}/bin/" "oc kubectl"
 fi
 
 # CT install
-if ! [ -x "$(command -v "${VENV}/bin/ct")" ]; then
-    CT_CLIENT_URL=$(get_download_url_from_github_api "${CT_CLIENT_API_URL}") \
-                  || (echo "$CT_CLIENT_URL"; cleanup_and_exit 2)
-    download_file_from_url "${CT_CLIENT_URL}" "${DWN_DIR}"
-    CT_CLIENT_PATH="${DWN_DIR}"/$(basename "${CT_CLIENT_URL}")
-    extract_file_to_dir "${CT_CLIENT_PATH}" "${VENV}/bin/" "ct"
+if should_cli_be_installed "ct" "${cli_tools_arr[@]}" && \
+    ! [ -x "$(command -v "${VENV}/bin/ct")" ]; then
+      CT_CLIENT_URL=$(get_download_url_from_github_api "${CT_CLIENT_API_URL}") \
+                    || (echo "$CT_CLIENT_URL"; cleanup_and_exit 2)
+      download_file_from_url "${CT_CLIENT_URL}" "${DWN_DIR}"
+      CT_CLIENT_PATH="${DWN_DIR}"/$(basename "${CT_CLIENT_URL}")
+      extract_file_to_dir "${CT_CLIENT_PATH}" "${VENV}/bin/" "ct"
 fi


### PR DESCRIPTION
Partial fix for #374

Couple of changes required to make it happen:
 - ensure install_dev_tools can selectively install CLIs as we don't want to install everything when running just chart-lint
 - Change Makefile to use ct lint rather then charts.py
 - Change github workflow file to use make chart-lint
 - Introduce SKIP_PYTHON_CHECK in the Makefile. github actions python version with latest Ubuntu runner is at lower then required version.

@redhat-cop/mdt
