### PR TITLE
Fix find in clean-dev-env for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,4 +144,4 @@ endif
 
 clean-dev-env:
 	rm -rf ${PELORUS_VENV}
-	find -delete . -iname "*.pyc"
+	find . -iname "*.pyc" -delete


### PR DESCRIPTION
BSD `find` requires the path to be first.

The order of actions and filters also matters, so -delete must be last.

## Describe the behavior changes introduced in this PR

`make clean-dev-env` now works on macOS.

## Testing Instructions

Run `make clean-dev-env` on macOS.
Run `make clean-dev-env` on Linux to verify it still works the same there.

@redhat-cop/mdt
