### PR TITLE
New minor release of Pelorus - requires OpenShift >= 4.7

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.4
+version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.10
+version: 1.5.0
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir }}
     git:
-      ref: {{ .source_ref | default "v1.4.6" }}
+      ref: {{ .source_ref | default "v1.5.0" }}
       uri: {{ .source_url }}
     type: Git
   strategy:

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -25,7 +25,7 @@ Pelorus gets installed via helm charts. The first deploys the operators on which
 
 ```shell
 # clone the repo (you can use a different release or clone from master if you wish)
-git clone --depth 1 --branch v1.4.1 https://github.com/konveyor/pelorus
+git clone --depth 1 --branch v1.5.0 https://github.com/konveyor/pelorus
 cd pelorus
 oc create namespace pelorus
 helm install operators charts/operators --namespace pelorus

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -7,7 +7,7 @@ The following will walk through the deployment of Pelorus.
 
 Before deploying the tooling, you must have the following prepared
 
-* An OpenShift 3.11 or higher Environment
+* An OpenShift 4.7 or higher Environment
 * A machine from which to run the install (usually your laptop)
   * The OpenShift Command Line Tool (oc)
   * [Helm3](https://github.com/helm/helm/releases)


### PR DESCRIPTION
New release of Pelorus, that makes it compatible with OpenShift 4.9
This release works only on the currently supported OpenShift versions
that is >=4.7.

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #<issue number> <-- Use this if merging should auto-close an issue

related to #<issue number> <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
