### PR TITLE
Disable fail-fast on all python github actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,13 +18,17 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-formatting.yml
+++ b/.github/workflows/python-formatting.yml
@@ -11,6 +11,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10']
     steps:

--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -11,6 +11,7 @@ jobs:
   python-lint:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10']
     steps:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,8 +14,9 @@ on:
 jobs:
   unit-test:
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ['3.9', '3.10']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Also add a version matrix to unit tests and integration tests.

## Describe the behavior changes introduced in this PR

This means that actions for certain python versions will not be cancelled if there's a failure with another version.

This makes it easier to diagnose python-version-specific issues.

This is a draft until the python version restriction issue is resolved.