### PR TITLE
Remove python patch version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 # Minimal python version supported by exporters
 PYTHON_BINARY=python3
-PYTHON_VER_MIN=3.9
-PYTHON_VER_MAX=3.10.2
 
 ifndef PELORUS_VENV
   PELORUS_VENV=.venv
@@ -14,17 +12,12 @@ ifeq (, $(shell which $(PYTHON_BINARY) ))
 endif
 
 SYS_PYTHON_VER=$(shell $(PYTHON_BINARY) -c 'from sys import version_info; \
-  from pkg_resources import packaging; \
-  print(packaging.version.parse("%d.%d.%d" % version_info[0:3]))')
+  print("%d.%d" % version_info[0:2])')
 $(info Found system python version: $(SYS_PYTHON_VER));
-PYTHON_VER=$(shell $(PYTHON_BINARY) -c 'from pkg_resources import packaging; \
-  print("%s" % (packaging.version.parse("$(PYTHON_VER_MAX)") >= \
-  packaging.version.parse("$(SYS_PYTHON_VER)") >= \
-  packaging.version.parse("$(PYTHON_VER_MIN)")))')
+PYTHON_VER_CHECK=$(shell $(PYTHON_BINARY) scripts/python-version-check.py $(PYTHON_BINARY))
 
-ifeq ($(PYTHON_VER), False)
-  $(error $(PYTHON_BINARY) needs to be at >= $(PYTHON_VER_MIN)\
-                           and <= $(PYTHON_VER_MAX))
+ifneq ($(strip $(PYTHON_VER_CHECK)),)
+  $(error $(PYTHON_VER_CHECK))
 endif
 
 CHART_TEST=$(shell which ct)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Variable setup and preflight checks
 
-# Minimal python version supported by exporters
-PYTHON_BINARY=python3
+# may override with environment variable
+PYTHON_BINARY?=python3
 
 ifndef PELORUS_VENV
   PELORUS_VENV=.venv
@@ -14,10 +14,10 @@ endif
 SYS_PYTHON_VER=$(shell $(PYTHON_BINARY) -c 'from sys import version_info; \
   print("%d.%d" % version_info[0:2])')
 $(info Found system python version: $(SYS_PYTHON_VER));
-PYTHON_VER_CHECK=$(shell $(PYTHON_BINARY) scripts/python-version-check.py $(PYTHON_BINARY))
+PYTHON_VER_CHECK=$(shell $(PYTHON_BINARY) scripts/python-version-check.py)
 
 ifneq ($(strip $(PYTHON_VER_CHECK)),)
-  $(error $(PYTHON_VER_CHECK))
+  $(error $(PYTHON_VER_CHECK). You may set the PYTHON_BINARY env var to specify a compatible version)
 endif
 
 CHART_TEST=$(shell which ct)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,12 @@ Lints helm charts.
 
 Lints helm charts, attempting to bump their versions if required.
 
+## python-version-check.py
+
+Used by the makefile to check if the python version is valid.
+
+Not meant to be used directly.
+
 ## lib
 
 Contains common code used by python scripts.

--- a/scripts/python-version-check.py
+++ b/scripts/python-version-check.py
@@ -1,4 +1,4 @@
-from sys import argv, exit, version_info
+from sys import executable, exit, version_info
 
 PYTHON_VER_MIN = (3, 9)
 PYTHON_VER_MAX = (3, 10)
@@ -8,7 +8,7 @@ SYS_PYTHON_VER = (version_info.major, version_info.minor)
 if not PYTHON_VER_MIN <= SYS_PYTHON_VER <= PYTHON_VER_MAX:
     print(
         "{} needs to be between {}.{} and {}.{}, but was {}.{}".format(
-            argv[1], *PYTHON_VER_MIN, *PYTHON_VER_MAX, *SYS_PYTHON_VER
+            executable, *PYTHON_VER_MIN, *PYTHON_VER_MAX, *SYS_PYTHON_VER
         )
     )
     exit(1)

--- a/scripts/python-version-check.py
+++ b/scripts/python-version-check.py
@@ -1,0 +1,14 @@
+from sys import argv, exit, version_info
+
+PYTHON_VER_MIN = (3, 9)
+PYTHON_VER_MAX = (3, 10)
+
+SYS_PYTHON_VER = (version_info.major, version_info.minor)
+
+if not PYTHON_VER_MIN <= SYS_PYTHON_VER <= PYTHON_VER_MAX:
+    print(
+        "{} needs to be between {}.{} and {}.{}, but was {}.{}".format(
+            argv[1], *PYTHON_VER_MIN, *PYTHON_VER_MAX, *SYS_PYTHON_VER
+        )
+    )
+    exit(1)

--- a/scripts/python-version-check.py
+++ b/scripts/python-version-check.py
@@ -1,3 +1,18 @@
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
 from sys import executable, exit, version_info
 
 PYTHON_VER_MIN = (3, 9)


### PR DESCRIPTION
Also move version checking to separate script for cleanliness.

## Describe the behavior changes introduced in this PR

Python patch versions (3.10.PATCH) will no longer be checked.

This also moves the version checking into a separate script for cleanliness-- we no longer need to print and re-parse versions, and can do the simplest approach for major and minor version checking.

## Linked Issues?

resolves #403