### PR TITLE
Remove duplicate charts values.yaml file

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.5.0
+version: 1.5.1
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/values.yaml
+++ b/charts/pelorus/charts/exporters/values.yaml
@@ -1,6 +1,0 @@
-instances:
-- app_name: deploytime-exporter
-  source_context_dir: exporters/
-  source_url: https://github.com/konveyor/pelorus.git
-
-scrapeInterval: 5m


### PR DESCRIPTION
The default values.yaml was missing exporters:
on the top line, making a little harder to just add
new configured exporters for users.

https://github.com/konveyor/pelorus/blob/master/docs/Configuration.md


