### PR TITLE
Cleanup and documentation of the python requirements

### DIFF
--- a/exporters/requirements-dev.txt
+++ b/exporters/requirements-dev.txt
@@ -1,9 +1,21 @@
+# Needed by exporters/tests
 pytest
+
+# Mentioned in the docs/Development.md
+# Also used by the github unittests.yml workflow
 coverage
+
+# Used by ./scripts/lib/charts.py
 semver
+
+# Used manually, mentioned in the docs/Development.md
 mkdocs
+
+# Makefile uses those in static code analysis - linting and formatting
 black
 isort
 pylava
+
+# Required by `ct lint` command
 yamale
 yamllint

--- a/exporters/requirements.txt
+++ b/exporters/requirements.txt
@@ -1,10 +1,19 @@
-requests
-prometheus_client
-openshift < 0.12
-jsonpath_ng
-jira
-pytz
-python-gitlab >= 2.4.0
-git-url-parse
-azure-devops
-attrs
+# Used by all exporters
+openshift < 0.12       # module openshift
+prometheus_client      # module prometheus_client
+
+# Committime exporter
+attrs                  # module @attr.define
+azure-devops           # module azure
+git-url-parse          # module giturlparse
+jsonpath_ng            # module jsonpath_ng
+python-gitlab >= 2.4.0 # module gitlab
+requests               # module requests
+
+# Deploytime exporter
+attrs                  # module @attr.define
+
+# Failure exporter
+jira                   # module jira
+pytz                   # module pytz
+requests               # module requests


### PR DESCRIPTION
Fixes #359

Scanned the code to check every usage of the particular
import, then used mixture of pipreqs and pipdeptree to find
appropriate packages.

Note that pipreqs can not be used for this project as some
dependencies found by this tool are obsolete, examples are
azure_storage, gitlab.

@redhat-cop/mdt
