### PR TITLE
Make chart-lint github action trigger on changes to requirements-dev.txt

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -7,6 +7,7 @@ on:
       - 'lintconf.yaml'
       - '.github/workflows/chart-lint.yml'
       - 'exporters/requirements-dev.txt' # yamllint and yamale
+      - Makefile
   pull_request:
     branches: [ master ]
     paths: 
@@ -14,6 +15,7 @@ on:
       - 'lintconf.yaml'
       - '.github/workflows/chart-lint.yml'
       - 'exporters/requirements-dev.txt' # yamllint and yamale
+      - Makefile
 
 jobs:
   lint:

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -6,12 +6,14 @@ on:
       - 'charts/**'
       - 'lintconf.yaml'
       - '.github/workflows/chart-lint.yml'
+      - 'exporters/requirements-dev.txt' # yamllint and yamale
   pull_request:
     branches: [ master ]
     paths: 
       - 'charts/**'
       - 'lintconf.yaml'
       - '.github/workflows/chart-lint.yml'
+      - 'exporters/requirements-dev.txt' # yamllint and yamale
 
 jobs:
   lint:

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Lint charts
         run: make chart-lint


### PR DESCRIPTION
PR #406 showed that this dependency is important.

## Describe the behavior changes introduced in this PR

The chart-lint github action will now run when requirements-dev.txt is changed,
because that could affect the yamllint and yamale versions.
