### PR TITLE
Better missing attribute errors

### DIFF
--- a/exporters/pelorus/utils.py
+++ b/exporters/pelorus/utils.py
@@ -1,0 +1,124 @@
+"""
+Module utils contains helper utilities for common tasks in the codebase.
+They are mainly to help with type information and to deal with data structures
+in kubernetes that are not so idiomatic to deal with.
+"""
+import contextlib
+import dataclasses
+from typing import Any, Optional, Union, overload
+
+# sentinel value for the default kwarg to get_nested
+__GET_NESTED_NO_DEFAULT = object()
+
+
+@overload
+def get_nested(
+    root: Any,
+    path: Union[list[Any], str],
+    *,
+    name: Optional[str] = None,
+) -> Any:
+    ...
+
+
+@overload
+def get_nested(
+    root: Any,
+    path: Union[list[Any], str],
+    *,
+    default: Any,
+    name: Optional[str] = None,
+) -> Any:
+    ...
+
+
+def get_nested(
+    root: Any,
+    path: Union[list[Any], str],
+    *,
+    default: Any = __GET_NESTED_NO_DEFAULT,
+    name: Optional[str] = None,
+) -> Any:
+    """
+    `get_nested` helps you safely traverse a deeply nested object that is indexable.
+    If `TypeError`, `KeyError`, or `IndexError` are thrown, then `default` will be returned.
+    If `default` is not given, a `MissingAttributeError` will be thrown,
+    which includes information about where in the path things went wrong, and a human-readable name (if included).
+
+    You may specify the path as either an iterable of keys / indexes, or a single string.
+    The string will be split on '.' so you can emulate the nested attribute lookup `ResourceField`
+    would offer.
+
+    A `name` for the item, if specified, makes the error message in the exception more useful.
+
+    Kubernetes API items often are deeply nested, with any number of fields that could be absent.
+    When using an `openshift.dynamic.ResourceField`, it will turn attribute accesses into
+    dictionary accesses. Normally, a deeply nested access like item.status.ref.foo.bar has four different spots
+    you could get an `AttributeError`. With a `ResourceField`, there are actually only three, since `item.status`
+    will return `None` if `status` is absent, but `None` will not have a `ref` field, leading to an
+    AttributeError.
+
+    This all may be unnecessary once Python 3.11 comes out, because of PEP-0647:
+    https://www.python.org/dev/peps/pep-0657/
+    """
+    item = root
+    if isinstance(path, str):
+        # filter out leading dot (or accidental double dots, technically)
+        path = [part for part in path.split(".") if part]
+    for i, key in enumerate(path):
+        try:
+            item = item[key]
+        except (TypeError, IndexError, KeyError) as e:
+            if default is not __GET_NESTED_NO_DEFAULT:
+                return default
+
+            raise BadAttributePathError(
+                root=root,
+                path=path,
+                path_slice=slice(i),
+                value=item,
+                root_name=name,
+            ) from e
+
+    return item
+
+
+@dataclasses.dataclass
+class BadAttributePathError(Exception):
+    """
+    An error representing a nested lookup that went wrong.
+
+    root is the root item the attribute accesses started from.
+    path is the whole path that was meant to be accessed.
+    path_slice represents how far in the path we got before an issue was encountered.
+    value is the value that the last good attribute access returned.
+    root_name is the name of the root item, which makes the error message more helpful.
+    """
+
+    root: Any
+    path: list[Any]
+    path_slice: slice
+    value: Any
+    root_name: Optional[str] = None
+
+    @property
+    def message(self):
+        return (
+            f"{self.root_name + ' is missing' if self.root_name else 'Missing'}"
+            f" {'.'.join(self.path)} because "
+            f"{'.'.join(self.path[self.path_slice])} was {self.value}"
+        )
+
+    def __str__(self):
+        return self.message
+
+
+@contextlib.contextmanager
+def collect_bad_attribute_path_error(error_list: list):
+    """
+    If a BadAttributePathError is raised, append it to the list and continue.
+    """
+    try:
+        yield
+    except BadAttributePathError as e:
+        error_list.append(e)

--- a/exporters/tests/test_utils.py
+++ b/exporters/tests/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from pelorus.utils import (
+    BadAttributePathError,
+    collect_bad_attribute_path_error,
+    get_nested,
+)
+
+ROOT = dict(foo=dict(bar=dict()))
+PATH = "foo.bar.baz.quux"
+SLICED_PATH = ["foo", "bar"]
+VALUE = dict()
+
+
+def test_nested_lookup_default():
+    assert get_nested(ROOT, PATH, default=None) is None
+
+
+def test_nested_lookup_exception():
+    with pytest.raises(BadAttributePathError) as e:
+        get_nested(ROOT, PATH)
+
+    error = e.value
+    print(error.message)
+    assert error.path[error.path_slice] == SLICED_PATH
+    assert error.value == VALUE
+
+
+def test_nested_lookup_collect():
+    errors = []
+
+    with collect_bad_attribute_path_error(errors):
+        get_nested(ROOT, PATH)
+
+    assert len(errors) == 1
+    error = errors[0]
+    assert error.path[error.path_slice] == SLICED_PATH
+    assert error.value == VALUE


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

This adds `get_nested` and uses it to give us better error messages for the committime collector.

We often have to deal with heavily nested data, that may or may not be present or properly formed.  When something goes wrong, we often deal with unhelpful error messages like `AttributeError: None does not contain attribute foo`. This issue even motivated the python folks to give [better error messages for similar errors in 3.11](https://peps.python.org/pep-0657/).

Another problem is with how most validation / conversion processes work: if it fails at the first issue, then you fix that... and it just fails at the next issue... it'll take forever to get through. That's not necessary if later steps are independent of the earlier ones! The python folks also recognize this issue and are introducing [exception groups](https://peps.python.org/pep-0654/) because of it.

Our committime collector deals with _tons_ of nested data, and its error messages have been limited to telling you which build had an issue-- but nothing else.

This PR addresses all of the above:

- make it easy to find where in a nested access things went wrong
- collect all data issues at once instead of failing early
- improve error messages for the committime collector

## Testing Instructions

Run the committime integration test and observe that the results are the same.

Remove some nested field from the mocked build response, such as the git author, and observe the error message (you'll need to run pytest with `-s` to capture output.)