### PR TITLE
More commit debug logs, exit Build inspection early if not yet ready

### DIFF
--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -17,9 +17,9 @@ class CommitMetric:
     labels: dict = attr.field(default=None, kw_only=True)
     namespace: Optional[str] = attr.field(default=None, kw_only=True)
 
-    __repo_url = attr.field(default=None, init=False)
+    __repo_url: str = attr.field(default=None, init=False)
     __repo_protocol = attr.field(default=None, init=False)
-    __repo_fqdn = attr.field(default=None, init=False)
+    __repo_fqdn: str = attr.field(default=None, init=False)
     __repo_group = attr.field(default=None, init=False)
     __repo_name = attr.field(default=None, init=False)
     __repo_project = attr.field(default=None, init=False)
@@ -76,12 +76,12 @@ class CommitMetric:
         return str(self.__repo_protocol + "://" + self.__repo_fqdn)
 
     def __parse_repourl(self):
-        logging.debug(self.__repo_url)
         """Parse the repo_url into individual pieces"""
+        logging.debug("repo url = %s", self.__repo_url)
         if self.__repo_url is None:
             return
         parsed = giturlparse.parse(self.__repo_url)
-        logging.debug(self.__repo_url)
+        logging.debug("Parsed: %s", parsed)
         if len(parsed.protocols) > 0 and parsed.protocols[0] not in SUPPORTED_PROTOCOLS:
             raise ValueError("Unsupported protocol %s", parsed.protocols[0])
         self.__repo_protocol = parsed.protocol

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import logging.config
 import os
 from abc import ABC
 from datetime import datetime, timezone
@@ -20,43 +19,24 @@ DEFAULT_TRACKER = "jira"
 DEFAULT_TRACKER_APP_LABEL = "unknown"
 DEFAULT_TRACKER_APP_FIELD = "u_application"
 
-# region: logging setup
-loglevel = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
-numeric_level = getattr(logging, loglevel, None)
-if not isinstance(numeric_level, int):
-    raise ValueError("Invalid log level: %s", loglevel)
-# logging.basicConfig(
-#     format=DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATE_FORMAT, level=numeric_level
-# )
-# logging.config.dictConfig(
-#     dict(
-#         version=1,
-#         formatters={
-#             "specialize_debug": {
-#                 "format": DEFAULT_LOG_FORMAT,
-#                 "datefmt": DEFAULT_LOG_DATE_FORMAT,
-#                 "class": "pelorus.utils.SpecializeDebugFormatter",
-#             }
-#         },
-#         handlers={
-#             "stderr": {
-#                 "class": "logging.StreamHandler",
-#                 "formatter": "specialize_debug",
-#             }
-#         },
-#         root={"level": logging.DEBUG, "handlers": ["stderr"]},
-#     )
-# )
-root_logger = logging.getLogger()
-formatter = utils.SpecializeDebugFormatter(
-    fmt=DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATE_FORMAT
-)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-root_logger.addHandler(handler)
-root_logger.setLevel(numeric_level)
-print(f"Initializing Logger with LogLevel: {loglevel}")
 
+def _setup_logging():
+    loglevel = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
+    numeric_level = getattr(logging, loglevel, None)
+    if not isinstance(numeric_level, int):
+        raise ValueError("Invalid log level: %s", loglevel)
+    root_logger = logging.getLogger()
+    formatter = utils.SpecializeDebugFormatter(
+        fmt=DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATE_FORMAT
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
+    root_logger.setLevel(numeric_level)
+    print(f"Initializing Logger with LogLevel: {loglevel}")
+
+
+_setup_logging()
 # endregion
 
 # A NamespaceSpec lists namespaces to restrict the search to.

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -1,10 +1,13 @@
 import logging
+import logging.config
 import os
 from abc import ABC
 from datetime import datetime, timezone
 from typing import Optional, Sequence
 
 from kubernetes import config
+
+from . import utils
 
 DEFAULT_APP_LABEL = "app.kubernetes.io/name"
 DEFAULT_PROD_LABEL = ""
@@ -17,14 +20,44 @@ DEFAULT_TRACKER = "jira"
 DEFAULT_TRACKER_APP_LABEL = "unknown"
 DEFAULT_TRACKER_APP_FIELD = "u_application"
 
-loglevel = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL)
-numeric_level = getattr(logging, loglevel.upper(), None)
+# region: logging setup
+loglevel = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
+numeric_level = getattr(logging, loglevel, None)
 if not isinstance(numeric_level, int):
-    raise ValueError("Invalid log level: %s" % loglevel)
-logging.basicConfig(
-    format=DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATE_FORMAT, level=numeric_level
+    raise ValueError("Invalid log level: %s", loglevel)
+# logging.basicConfig(
+#     format=DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATE_FORMAT, level=numeric_level
+# )
+# logging.config.dictConfig(
+#     dict(
+#         version=1,
+#         formatters={
+#             "specialize_debug": {
+#                 "format": DEFAULT_LOG_FORMAT,
+#                 "datefmt": DEFAULT_LOG_DATE_FORMAT,
+#                 "class": "pelorus.utils.SpecializeDebugFormatter",
+#             }
+#         },
+#         handlers={
+#             "stderr": {
+#                 "class": "logging.StreamHandler",
+#                 "formatter": "specialize_debug",
+#             }
+#         },
+#         root={"level": logging.DEBUG, "handlers": ["stderr"]},
+#     )
+# )
+root_logger = logging.getLogger()
+formatter = utils.SpecializeDebugFormatter(
+    fmt=DEFAULT_LOG_FORMAT, datefmt=DEFAULT_LOG_DATE_FORMAT
 )
-print("Initializing Logger wit LogLevel: %s" % loglevel.upper())
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+root_logger.addHandler(handler)
+root_logger.setLevel(numeric_level)
+print(f"Initializing Logger with LogLevel: {loglevel}")
+
+# endregion
 
 # A NamespaceSpec lists namespaces to restrict the search to.
 # Use None or an empty list to include all namespaces.

--- a/exporters/pelorus/utils.py
+++ b/exporters/pelorus/utils.py
@@ -5,6 +5,7 @@ in kubernetes that are not so idiomatic to deal with.
 """
 import contextlib
 import dataclasses
+import logging
 from typing import Any, Optional, Union, overload
 
 # sentinel value for the default kwarg to get_nested
@@ -122,3 +123,22 @@ def collect_bad_attribute_path_error(error_list: list):
         yield
     except BadAttributePathError as e:
         error_list.append(e)
+
+
+class SpecializeDebugFormatter(logging.Formatter):
+    """
+    Uses a different format for DEBUG messages that has more information.
+    """
+
+    DEBUG_FORMAT = "%(asctime)-15s %(levelname)-8s %(pathname)s:%(lineno)d %(funcName)s() %(message)s"
+
+    def format(self, record):
+        prior_format = self._style._fmt
+
+        try:
+            if record.levelno == logging.DEBUG:
+                self._style._fmt = self.DEBUG_FORMAT
+
+            return logging.Formatter.format(self, record)
+        finally:
+            self._style._fmt = prior_format


### PR DESCRIPTION
Adds more committime debug logs and adds some verbosity to debug logging in general.

Also skips Builds that aren't ready yet, without further inspection. This avoids cluttering logs for builds that have failed or haven't completed yet.

Closes #419.