### PR TITLE
Test to cover JIRA token and password authentication.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -159,7 +159,7 @@ Create a secret containing your Jira information.
 ```shell
 oc create secret generic jira-secret \
 --from-literal=SERVER=<Jira Server> \
---from-literal=USER=<username> \
+--from-literal=USER=<username/e-mail> \
 --from-literal=TOKEN=<personal access token> \
 -n pelorus
 ```

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -19,9 +19,8 @@ import logging
 import os
 import sys
 import time
+from typing import Union
 
-from failure.collector_jira import JiraFailureCollector
-from failure.collector_servicenow import ServiceNowFailureCollector
 from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
@@ -34,13 +33,17 @@ REQUIRED_CONFIG = ["USER", "TOKEN", "SERVER"]
 
 class TrackerFactory:
     @staticmethod
-    def getCollector(username, token, tracker_api, projects, tracker_provider):
+    def getCollector(
+        username, token, tracker_api, projects, tracker_provider
+    ) -> Union[JiraFailureCollector, ServiceNowFailureCollector]:
         if tracker_provider == "jira":
             return JiraFailureCollector(
                 server=tracker_api, user=username, apikey=token, projects=projects
             )
-        if tracker_provider == "servicenow":
+        elif tracker_provider == "servicenow":
             return ServiceNowFailureCollector(username, token, tracker_api)
+        else:
+            raise ValueError(f"Unknown provider {tracker_provider}")
 
 
 if __name__ == "__main__":

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -1,4 +1,20 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
 import logging
 import os
 import sys
@@ -18,7 +34,9 @@ class TrackerFactory:
     @staticmethod
     def getCollector(username, token, tracker_api, projects, tracker_provider):
         if tracker_provider == "jira":
-            return JiraFailureCollector(username, token, tracker_api, projects)
+            return JiraFailureCollector(
+                server=tracker_api, user=username, apikey=token, projects=projects
+            )
         if tracker_provider == "servicenow":
             return ServiceNowFailureCollector(username, token, tracker_api)
 

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -20,12 +20,14 @@ import os
 import sys
 import time
 
-from collector_jira import JiraFailureCollector
-from collector_servicenow import ServiceNowFailureCollector
+from failure.collector_jira import JiraFailureCollector
+from failure.collector_servicenow import ServiceNowFailureCollector
 from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
 import pelorus
+from failure.collector_jira import JiraFailureCollector
+from failure.collector_servicenow import ServiceNowFailureCollector
 
 REQUIRED_CONFIG = ["USER", "TOKEN", "SERVER"]
 

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -54,7 +54,7 @@ class JiraFailureCollector(AbstractFailureCollector):
             logging.error(
                 "Status: %s, Error Response: %s", error.status_code, error.text
             )
-            raise error
+            raise
 
         return jira_client
 

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -19,11 +19,11 @@ import logging
 from datetime import datetime
 
 import pytz
-from collector_base import AbstractFailureCollector, TrackerIssue
 from jira import JIRA
 from jira.exceptions import JIRAError
 
 import pelorus
+from failure.collector_base import AbstractFailureCollector, TrackerIssue
 
 
 class JiraFailureCollector(AbstractFailureCollector):

--- a/exporters/failure/collector_servicenow.py
+++ b/exporters/failure/collector_servicenow.py
@@ -4,9 +4,9 @@ from datetime import datetime
 
 import pytz
 import requests
-from collector_base import AbstractFailureCollector, TrackerIssue
 
 import pelorus
+from failure.collector_base import AbstractFailureCollector, TrackerIssue
 
 SN_HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
 SN_QUERY = "/api/now/table/incident?sysparm_fields={0}%2C{1}%2Cstate%2Cnumber%2C{2} \

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -15,9 +15,9 @@
 #    under the License.
 #
 
+from typing import cast
+
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
-from jira import JIRA
 from jira.exceptions import JIRAError
 from prometheus_client.core import REGISTRY
 
@@ -25,7 +25,7 @@ from failure.app import TrackerFactory
 from failure.collector_jira import JiraFailureCollector
 
 
-def setup_jira_collector(server, username, apikey) -> JIRA:
+def setup_jira_collector(server, username, apikey) -> JiraFailureCollector:
     tracker_provider = "jira"
 
     projects = None
@@ -34,7 +34,7 @@ def setup_jira_collector(server, username, apikey) -> JIRA:
         username, apikey, server, projects, tracker_provider
     )
 
-    return jira_collector
+    return cast(JiraFailureCollector, jira_collector)
 
 
 @pytest.mark.parametrize(
@@ -98,4 +98,4 @@ def test_jira_prometheus_register(server, username, apikey):
         user=username, apikey=apikey, server=server, projects=None
     )
 
-    REGISTRY.register(collector)
+    REGISTRY.register(collector)  # type: ignore

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -86,11 +86,11 @@ def test_jira_pass_connection(server, username, apikey):
         )
     ],
 )
-def test_jira_prometheus_register(server, username, apikey):
+def test_jira_prometheus_register(
+    server, username, apikey, monkeypatch: pytest.MonkeyPatch
+):
     def mock_search_issues(self):
         return []
-
-    monkeypatch = MonkeyPatch()
 
     monkeypatch.setattr(JiraFailureCollector, "search_issues", mock_search_issues)
 

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from jira import JIRA
+from jira.exceptions import JIRAError
+from prometheus_client.core import REGISTRY
+
+from failure.app import TrackerFactory
+from failure.collector_jira import JiraFailureCollector
+
+
+def setup_jira_collector(server, username, apikey) -> JIRA:
+    tracker_provider = "jira"
+
+    projects = None
+
+    jira_collector = TrackerFactory.getCollector(
+        username, apikey, server, projects, tracker_provider
+    )
+
+    return jira_collector
+
+
+@pytest.mark.parametrize(
+    "server, username, apikey",
+    [
+        (
+            "https://pelorustest.atlassian.net",
+            "fake@user.com",
+            "WIEds4uZHiCGnrtmgQPn9E7D",
+        )
+    ],
+)
+@pytest.mark.integration
+def test_jira_connection(server, username, apikey):
+
+    collector = setup_jira_collector(server, username, apikey)
+
+    with pytest.raises(JIRAError) as context_ex:
+        collector._connect_to_jira()
+
+    assert (
+        "You are not authenticated. Authentication required to perform this operation."
+        in str(context_ex.value)
+    )
+
+
+@pytest.mark.parametrize(
+    "server, username, apikey",
+    [("https://pelorustest.atlassian.net", "fake@user.com", "fakepass")],
+)
+@pytest.mark.integration
+def test_jira_pass_connection(server, username, apikey):
+
+    collector = setup_jira_collector(server, username, apikey)
+
+    with pytest.raises(JIRAError) as context_ex:
+        collector._connect_to_jira()
+
+    assert "Basic authentication with passwords is deprecated" in str(context_ex.value)
+
+
+@pytest.mark.parametrize(
+    "server, username, apikey",
+    [
+        (
+            "https://pelorustest.atlassian.net",
+            "fake@user.com",
+            "WIEds4uZHiCGnrtmgQPn9E7D",
+        )
+    ],
+)
+def test_jira_prometheus_register(server, username, apikey):
+    def mock_search_issues(self):
+        return []
+
+    monkeypatch = MonkeyPatch()
+
+    monkeypatch.setattr(JiraFailureCollector, "search_issues", mock_search_issues)
+
+    collector = JiraFailureCollector(
+        user=username, apikey=apikey, server=server, projects=None
+    )
+
+    REGISTRY.register(collector)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ src_paths = ["exporters" ,"scripts"]
 known_first_party = ["pelorus"]
 
 [tool.pytest.ini_options]
+pythonpath = [
+    "exporters/comitttime",
+    "exporters/deploytime",
+    "exporters/failure",
+    "exporters/pelorus"
+]
 testpaths = ["exporters/tests"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,6 @@ src_paths = ["exporters" ,"scripts"]
 known_first_party = ["pelorus"]
 
 [tool.pytest.ini_options]
-pythonpath = [
-    "exporters/comitttime",
-    "exporters/deploytime",
-    "exporters/failure",
-    "exporters/pelorus"
-]
 testpaths = ["exporters/tests"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"


### PR DESCRIPTION
Added test which checks for the deprecated password authentication.

JIRA uses same method to authenticate in the cloud jira instance for both deprecated password authentication and token based auth.

This may lead to the situation where wrong API key is actually considered password and then failure exporter is presenting deprecation error.

This change also moves connection func to separate private one for easy testing and readibility + may in the future include more sophisticated auth methods.

Added proper headers to the files which were modified.

resolves #423

@redhat-cop/mdt
