### PR TITLE
Fix issue #278 - failure pod crashing

### DIFF
--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
     collector = TrackerFactory.getCollector(
         username, token, tracker_api, projects, tracker_provider
     )
+
     REGISTRY.register(collector)
 
     while True:

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -111,9 +111,7 @@ def test_jira_prometheus_register(
         )
     ],
 )
-def test_jira_exception(
-    server, username, apikey, monkeypatch: pytest.MonkeyPatch
-):
+def test_jira_exception(server, username, apikey, monkeypatch: pytest.MonkeyPatch):
     class FakeJira(object):
         def search_issues(self, issues):
             raise JIRAError(status_code=400, text="Fake search error")
@@ -126,7 +124,4 @@ def test_jira_exception(
     collector = JiraFailureCollector(
         user=username, apikey=apikey, server=server, projects=None
     )
-    with pytest.raises(JIRAError) as context_ex:
-        collector.search_issues()
-    assert "Fake search error" in str(context_ex.value)
-    assert context_ex.value.status_code == 400
+    collector.search_issues()

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -99,3 +99,34 @@ def test_jira_prometheus_register(
     )
 
     REGISTRY.register(collector)  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "server, username, apikey",
+    [
+        (
+            "https://pelorustest.atlassian.net",
+            "fake@user.com",
+            "WIEds4uZHiCGnrtmgQPn9E7D",
+        )
+    ],
+)
+def test_jira_exception(
+    server, username, apikey, monkeypatch: pytest.MonkeyPatch
+):
+    class FakeJira(object):
+        def search_issues(self, issues):
+            raise JIRAError(status_code=400, text="Fake search error")
+
+    def mock_jira_connect(self):
+        return FakeJira()
+
+    monkeypatch.setattr(JiraFailureCollector, "_connect_to_jira", mock_jira_connect)
+
+    collector = JiraFailureCollector(
+        user=username, apikey=apikey, server=server, projects=None
+    )
+    with pytest.raises(JIRAError) as context_ex:
+        collector.search_issues()
+    assert "Fake search error" in str(context_ex.value)
+    assert context_ex.value.status_code == 400

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,8 @@ src_paths = ["exporters" ,"scripts"]
 known_first_party = ["pelorus"]
 
 [tool.pytest.ini_options]
-pythonpath = [
-    "exporters/comitttime",
-    "exporters/deploytime",
-    "exporters/failure",
-    "exporters/pelorus"
-]
 testpaths = ["exporters/tests"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
 ]
+log_cli = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ src_paths = ["exporters" ,"scripts"]
 known_first_party = ["pelorus"]
 
 [tool.pytest.ini_options]
+pythonpath = [
+    "exporters/comitttime",
+    "exporters/deploytime",
+    "exporters/failure",
+    "exporters/pelorus"
+]
 testpaths = ["exporters/tests"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"


### PR DESCRIPTION
Fix issue #278 - failure pod crashing
    
We should log error rather then crash pod if JIRA is missing type required by failure exporter. JIRA type may be added after pelorus deployment.

Depends on #424 

@redhat-cop/mdt
