### PR TITLE
Fix for issue #428 and some minor Makefile nits

### DIFF
--- a/.github/workflows/mockoon-tests.yml
+++ b/.github/workflows/mockoon-tests.yml
@@ -1,17 +1,19 @@
-name: Integration Tests
+name: Mockoon Tests
 on:
   push:
     paths:
       - 'exporters/**'
-      - 'pyproject.toml'
-      - '.github/workflows/integration-tests.yml'
+      - 'mocks/**'
+      - '!mocks/README.md'
+      - '.github/workflows/mockoon-tests.yml'
       - 'Makefile'
 
   pull_request:
     paths:
       - 'exporters/**'
-      - 'pyproject.toml'
-      - '.github/workflows/integration-tests.yml'
+      - 'mocks/**'
+      - '!mocks/README.md'
+      - '.github/workflows/mockoon-tests.yml'
       - 'Makefile'
 
 jobs:
@@ -34,6 +36,6 @@ jobs:
         run: |
           make dev-env
 
-      - name: Run integration-test
+      - name: Run mockoon-test
         run: |
-          make integration-tests
+          make mockoon-tests

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,12 @@ endif
 CHART_TEST=$(shell which ct)
 
 SHELLCHECK=$(shell which shellcheck)
-SHELL_SCRIPTS=./scripts/pre-commit ./scripts/setup-pre-commit-hook ./demo/demo-tekton ./scripts/run-integration-tests
-
+SHELL_SCRIPTS=./demo/demo-tekton \
+       scripts/create_release_pr \
+       scripts/install_dev_tools \
+       scripts/pre-commit \
+       scripts/run-mockoon-tests \
+       scripts/setup-pre-commit-hook
 
 .PHONY: default
 default: \
@@ -82,12 +86,18 @@ minor-release:
 major-release:
 	./scripts/create_release_pr -m
 
+.PHONY: mockoon-tests
+mockoon-tests: $(PELORUS_VENV)
+	. ${PELORUS_VENV}/bin/activate && \
+	./scripts/run-mockoon-tests
+
 # Integration tests
 
 .PHONY: integration-tests
 integration-tests: $(PELORUS_VENV)
 	. ${PELORUS_VENV}/bin/activate && \
-	./scripts/run-integration-tests
+	coverage run -m pytest -rap -m "integration" && \
+	coverage report
 
 # Unit tests
 .PHONY: unit-tests
@@ -96,7 +106,7 @@ unit-tests: $(PELORUS_VENV)
   # because using (A)ll includes stdout
   # -m filters out integration tests
 	. ${PELORUS_VENV}/bin/activate && \
-	coverage run -m pytest -rap -m "not integration" && \
+	coverage run -m pytest -rap -m "not integration and not mockoon" && \
 	coverage report
 
 # Prometheus ruels

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -80,7 +80,7 @@ class CommitMetricEssentials:
         return CommitMetricEssentials(**args)
 
 
-@pytest.mark.integration
+@pytest.mark.mockoon
 def test_github_provider():
     collector = setup_collector()
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,29 +2,33 @@
 
 Various scripts for development reside here.
 
-## setup-dev-env
-
-Sets up a python3.9 virtual environment, installs dependencies, and sets up the pre-commit hook.
-
-## install_dev_tools
-
-Installs required packages for deploying and testing Pelorus inside virtual environment.
-
-## pre-commit
-
-A pre-commit hook for git. Will lint helm charts, and check if formatting is correct.
-
 ## bump-version
 
 Bumps the patch version of the given charts.
+
+## chart-check-and-bump
+
+Lints helm charts, attempting to bump their versions if required.
 
 ## chart-lint
 
 Lints helm charts.
 
-## chart-check-and-bump
+## create_release_pr
 
-Lints helm charts, attempting to bump their versions if required.
+Prepares pull request that is used to create Pelorus release
+
+## install_dev_tools
+
+Installs required packages for deploying and testing Pelorus inside virtual environment.
+
+## lib
+
+Contains common code used by python scripts.
+
+## pre-commit
+
+A pre-commit hook for git. Will lint helm charts, and check if formatting is correct.
 
 ## python-version-check.py
 
@@ -32,6 +36,14 @@ Used by the makefile to check if the python version is valid.
 
 Not meant to be used directly.
 
-## lib
+## run-mockoon-tests
 
-Contains common code used by python scripts.
+Used to create mockoon pod on the localhost and then runs mockoon tests
+
+for the commit time exporter using mocked data from mockoon server.
+
+## setup-pre-commit-hook
+
+Used by the makefile to setup pre-commit hook for local lint tests that are
+
+invoked before commit is prepared.

--- a/scripts/install_dev_tools
+++ b/scripts/install_dev_tools
@@ -286,12 +286,12 @@ if should_cli_be_installed "bats" "${cli_tools_arr[@]}" && \
     # Get the absolute path of VENV. This should be platform independent
     pushd "${VENV}" || exit
       ABS_VENV_PATH=$(pwd)
-    popd
+    popd || exit
     pushd "${DWN_DIR}" || exit
       git clone "${BATS_REPO_URL}" bats-core-upstream
       pushd bats-core-upstream || exit
         ./install.sh "${ABS_VENV_PATH}"
-      popd
+      popd || exit
       rm -rf bats-core-upstream
-    popd
+    popd || exit
 fi

--- a/scripts/run-mockoon-tests
+++ b/scripts/run-mockoon-tests
@@ -106,7 +106,7 @@ done
 # Remove exit trap, so we can propagate exit value from pytest
 trap - EXIT
 
-# Run integration tests
-pytest -m integration
+# Run mockoon tests
+pytest -rap -m mockoon
 pytest_exit=$?
 cleanup_and_exit $pytest_exit


### PR DESCRIPTION
Split of mockoon tests from integration tests, which allows to run e.g. failure integration tests easilly from makefile.
This requires creation of new GitHub workflow to run the Mockoon tests separatelly.

Updated README.md to reflect current set of scripts in the scripts/ directory.

Added missing shell scripts in the Makefile, that required small nit change in the install_dev_tools script.

resolves #428

@redhat-cop/mdt
