### PR TITLE
Fix issue #430 to allow running Mockoon container without SELinux

### DIFF
--- a/scripts/run-mockoon-tests
+++ b/scripts/run-mockoon-tests
@@ -83,7 +83,7 @@ fi
 
 # Run Mockoon container
 echo "Running mockoon container"
-RUNNING_ID=$("${CONTAINER_ENGINE}" run --name="${TEST_CONTAINER_NAME}" -d -v "${MOCK_JSON}":/data -p "${MOCKOON_PORT}":"${MOCKOON_PORT}" "${MOCKOON_CONTAINER}" -d /data)
+RUNNING_ID=$("${CONTAINER_ENGINE}" run --name="${TEST_CONTAINER_NAME}" -d -v "${MOCK_JSON}":/data:Z -p "${MOCKOON_PORT}":"${MOCKOON_PORT}" "${MOCKOON_CONTAINER}" -d /data)
 
 if [ "${RUNNING_ID}" == "" ]; then
     echo "Mockoon is not working as expected."


### PR DESCRIPTION
Fix issue #430 to allow running Mockoon container without SELinux

SELinux causes EACCES: permission denied error to access /data folder in a container when it's not disabled. For running tests it's ok to run it with selinux disabled.

resolves #430

@redhat-cop/mdt