### PR TITLE
Log resources that are missing app labels

### DIFF
--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
@@ -38,7 +40,7 @@ class DeployTimeCollector:
         if not namespaces:
             return []
 
-        metrics = generate_metrics(namespaces, self.client)
+        metrics = self.generate_metrics(namespaces)
         for m in metrics:
             logging.info(
                 "Collected deploy_timestamp{namespace=%s, app=%s, image=%s} %s"
@@ -79,7 +81,7 @@ class DeployTimeCollector:
             )
             query_args = dict()
 
-        all_namespaces = dyn_client.resources.get(api_version="v1", kind="Namespace")
+        all_namespaces = self.client.resources.get(api_version="v1", kind="Namespace")
         namespaces = {
             namespace.metadata.name
             for namespace in all_namespaces.get(**query_args).items
@@ -90,6 +92,87 @@ class DeployTimeCollector:
                 "No NAMESPACES given and PROD_LABEL did not return any matching namespaces."
             )
         return namespaces
+
+    def generate_metrics(
+        self,
+        namespaces: set[str],
+    ) -> Iterable[DeployTimeMetric]:
+        visited_replicas = set()
+
+        def already_seen(full_path: str) -> bool:
+            return full_path in visited_replicas
+
+        def mark_as_seen(full_path: str):
+            visited_replicas.add(full_path)
+
+        logging.info("generate_metrics: start")
+
+        # get all running Pods with the app label
+        v1_pods = self.client.resources.get(api_version="v1", kind="Pod")
+        pods = v1_pods.get(
+            label_selector=pelorus.get_app_label(),
+            field_selector="status.phase=Running",
+        ).items
+
+        replicas_dict = (
+            get_replicas(self.client, "v1", "ReplicationController")
+            | get_replicas(self.client, "apps/v1", "ReplicaSet")
+            | get_replicas(self.client, "extensions/v1beta1", "ReplicaSet")
+        )
+
+        for pod in pods:
+            namespace = pod.metadata.namespace
+            owner_refs = pod.metadata.ownerReferences
+            if namespace not in namespaces or not owner_refs:
+                continue
+
+            logging.debug(
+                "Getting Replicas for pod: %s in namespace: %s",
+                pod.metadata.name,
+                pod.metadata.namespace,
+            )
+
+            # Get deploytime from the owning controller of the pod.
+            # We track all already-visited controllers to not duplicate metrics per-pod.
+            for ref in owner_refs:
+                full_path = f"{namespace}/{ref.name}"
+
+                if ref.kind not in supported_replica_objects or already_seen(full_path):
+                    continue
+
+                logging.debug(
+                    "Getting replica: %s, kind: %s, namespace: %s",
+                    ref.name,
+                    ref.kind,
+                    namespace,
+                )
+
+                if not (rc := replicas_dict.get(full_path)):
+                    continue
+
+                mark_as_seen(full_path)
+                container_shas = (
+                    image_sha(container.image) for container in pod.spec.containers
+                )
+                container_status_shas = (
+                    image_sha(status.imageID) for status in pod.status.containerStatuses
+                )
+                images = {sha for sha in container_shas if sha} | {
+                    sha for sha in container_status_shas if sha
+                }
+
+                # Since a commit will be built into a particular image and there could be multiple
+                # containers (images) per pod, we will push one metric per image/container in the
+                # pod template
+                for sha in images:
+                    metric = DeployTimeMetric(
+                        name=rc.metadata.labels[pelorus.get_app_label()],
+                        namespace=namespace,
+                        labels=rc.metadata.labels,
+                        deploy_time=rc.metadata.creationTimestamp,
+                        image_sha=sha,
+                    )
+                    yield metric
 
 
 @attr.frozen(kw_only=True)
@@ -128,87 +211,6 @@ def image_sha(image_url_or_id: str) -> Optional[str]:
         # But since it's only in debug logs, it doesn't matter.
         logging.debug("Skipping unresolved image reference: %s", image_url_or_id)
         return None
-
-
-def generate_metrics(
-    namespaces: set[str],
-    dyn_client: DynamicClient,
-) -> Iterable[DeployTimeMetric]:
-    visited_replicas = set()
-
-    def already_seen(full_path: str) -> bool:
-        return full_path in visited_replicas
-
-    def mark_as_seen(full_path: str):
-        visited_replicas.add(full_path)
-
-    logging.info("generate_metrics: start")
-
-    # get all running Pods with the app label
-    v1_pods = dyn_client.resources.get(api_version="v1", kind="Pod")
-    pods = v1_pods.get(
-        label_selector=pelorus.get_app_label(), field_selector="status.phase=Running"
-    ).items
-
-    replicas_dict = (
-        get_replicas(dyn_client, "v1", "ReplicationController")
-        | get_replicas(dyn_client, "apps/v1", "ReplicaSet")
-        | get_replicas(dyn_client, "extensions/v1beta1", "ReplicaSet")
-    )
-
-    for pod in pods:
-        namespace = pod.metadata.namespace
-        owner_refs = pod.metadata.ownerReferences
-        if namespace not in namespaces or not owner_refs:
-            continue
-
-        logging.debug(
-            "Getting Replicas for pod: %s in namespace: %s",
-            pod.metadata.name,
-            pod.metadata.namespace,
-        )
-
-        # Get deploytime from the owning controller of the pod.
-        # We track all already-visited controllers to not duplicate metrics per-pod.
-        for ref in owner_refs:
-            full_path = f"{namespace}/{ref.name}"
-
-            if ref.kind not in supported_replica_objects or already_seen(full_path):
-                continue
-
-            logging.debug(
-                "Getting replica: %s, kind: %s, namespace: %s",
-                ref.name,
-                ref.kind,
-                namespace,
-            )
-
-            if not (rc := replicas_dict.get(full_path)):
-                continue
-
-            mark_as_seen(full_path)
-            container_shas = (
-                image_sha(container.image) for container in pod.spec.containers
-            )
-            container_status_shas = (
-                image_sha(status.imageID) for status in pod.status.containerStatuses
-            )
-            images = {sha for sha in container_shas if sha} | {
-                sha for sha in container_status_shas if sha
-            }
-
-            # Since a commit will be built into a particular image and there could be multiple
-            # containers (images) per pod, we will push one metric per image/container in the
-            # pod template
-            for sha in images:
-                metric = DeployTimeMetric(
-                    name=rc.metadata.labels[pelorus.get_app_label()],
-                    namespace=namespace,
-                    labels=rc.metadata.labels,
-                    deploy_time=rc.metadata.creationTimestamp,
-                    image_sha=sha,
-                )
-                yield metric
 
 
 def get_replicas(

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import time
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import attr
 from kubernetes import client
@@ -19,14 +19,15 @@ supported_replica_objects = {"ReplicaSet", "ReplicationController"}
 
 
 class DeployTimeCollector:
-    _namespaces: set[str]
+    _warned_missing_replicas: set[str]
+    """Replicas with missing app labels that we've already warned about"""
 
-    def __init__(
-        self, namespaces: Iterable[str], client: DynamicClient, prod_label: str
-    ):
-        self._namespaces = set(namespaces)
+    def __init__(self, namespaces: set[str], client: DynamicClient, prod_label: str):
+        self._namespaces = namespaces
         self.client = client
         self.prod_label = prod_label
+        self._warned_missing_replicas = set()
+        self.app_label = pelorus.get_app_label()
 
     def collect(self) -> Iterable[GaugeMetricFamily]:
         logging.info("collect: start")
@@ -93,6 +94,23 @@ class DeployTimeCollector:
             )
         return namespaces
 
+    def _get_rc_app_label_or_warn(self, rc) -> Optional[str]:
+        """
+        Get the application label from the given replicator,
+        or log a warning once if it's not present.
+        """
+        if name := rc.metadata.labels[self.app_label]:
+            return name
+
+        full_path = f"{rc.metadata.namespace}/{rc.metadata.name}"
+        if full_path not in self._warned_missing_replicas:
+            logging.warn(
+                f"{rc.kind} {full_path} is missing app label {self.app_label}, skipping."
+            )
+            self._warned_missing_replicas.add(full_path)
+
+        return None
+
     def generate_metrics(
         self,
         namespaces: set[str],
@@ -110,7 +128,7 @@ class DeployTimeCollector:
         # get all running Pods with the app label
         v1_pods = self.client.resources.get(api_version="v1", kind="Pod")
         pods = v1_pods.get(
-            label_selector=pelorus.get_app_label(),
+            label_selector=self.app_label,
             field_selector="status.phase=Running",
         ).items
 
@@ -120,59 +138,67 @@ class DeployTimeCollector:
             | get_replicas(self.client, "extensions/v1beta1", "ReplicaSet")
         )
 
-        for pod in pods:
-            namespace = pod.metadata.namespace
-            owner_refs = pod.metadata.ownerReferences
-            if namespace not in namespaces or not owner_refs:
-                continue
+        pods = (
+            pod
+            for pod in pods
+            if pod.metadata.namespace in namespaces and pod.metadata.ownerReferences
+        )
+        pods_and_owners = (
+            (pod, owner_ref)
+            for pod in pods
+            for owner_ref in pod.metadata.ownerReferences
+        )
 
-            logging.debug(
-                "Getting Replicas for pod: %s in namespace: %s",
-                pod.metadata.name,
-                pod.metadata.namespace,
-            )
+        for pod, owner_ref in pods_and_owners:
+            namespace = pod.metadata.namespace
 
             # Get deploytime from the owning controller of the pod.
             # We track all already-visited controllers to not duplicate metrics per-pod.
-            for ref in owner_refs:
-                full_path = f"{namespace}/{ref.name}"
+            full_path = f"{namespace}/{owner_ref.name}"
 
-                if ref.kind not in supported_replica_objects or already_seen(full_path):
-                    continue
+            if owner_ref.kind not in supported_replica_objects or already_seen(
+                full_path
+            ):
+                continue
 
-                logging.debug(
-                    "Getting replica: %s, kind: %s, namespace: %s",
-                    ref.name,
-                    ref.kind,
-                    namespace,
+            logging.debug(
+                "Examining replica %s of kind %s for pod %s in namespace: %s",
+                owner_ref.name,
+                owner_ref.kind,
+                pod.metadata.name,
+                namespace,
+            )
+
+            if not (rc := replicas_dict.get(full_path)):
+                continue
+
+            mark_as_seen(full_path)
+
+            if not (name := self._get_rc_app_label_or_warn(rc)):
+                continue
+
+            container_shas = (
+                image_sha(container.image) for container in pod.spec.containers
+            )
+            container_status_shas = (
+                image_sha(status.imageID) for status in pod.status.containerStatuses
+            )
+            images = {sha for sha in container_shas if sha} | {
+                sha for sha in container_status_shas if sha
+            }
+
+            # Since a commit will be built into a particular image and there could be multiple
+            # containers (images) per pod, we will push one metric per image/container in the
+            # pod template
+            for sha in images:
+                metric = DeployTimeMetric(
+                    name=name,
+                    namespace=namespace,
+                    labels=rc.metadata.labels,
+                    deploy_time=rc.metadata.creationTimestamp,
+                    image_sha=sha,
                 )
-
-                if not (rc := replicas_dict.get(full_path)):
-                    continue
-
-                mark_as_seen(full_path)
-                container_shas = (
-                    image_sha(container.image) for container in pod.spec.containers
-                )
-                container_status_shas = (
-                    image_sha(status.imageID) for status in pod.status.containerStatuses
-                )
-                images = {sha for sha in container_shas if sha} | {
-                    sha for sha in container_status_shas if sha
-                }
-
-                # Since a commit will be built into a particular image and there could be multiple
-                # containers (images) per pod, we will push one metric per image/container in the
-                # pod template
-                for sha in images:
-                    metric = DeployTimeMetric(
-                        name=rc.metadata.labels[pelorus.get_app_label()],
-                        namespace=namespace,
-                        labels=rc.metadata.labels,
-                        deploy_time=rc.metadata.creationTimestamp,
-                        image_sha=sha,
-                    )
-                    yield metric
+                yield metric
 
 
 @attr.frozen(kw_only=True)
@@ -215,7 +241,7 @@ def image_sha(image_url_or_id: str) -> Optional[str]:
 
 def get_replicas(
     dyn_client: DynamicClient, apiVersion: str, objectName: str
-) -> dict[str, object]:
+) -> dict[str, Any]:
     """Process Replicas for given Api Version and Object type (ReplicaSet or ReplicationController)"""
     try:
         apiResource = dyn_client.resources.get(api_version=apiVersion, kind=objectName)


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Logs warnings for resources that are missing the required app label.

Currently only handles deploytime resources (pods and replicators).

Remaining work / open questions:

- Do we envision gradual adoption of Pelorus, and is this presenting the information too much like a firehose?
  - Was the current design chosen in order to make pelorus opt-in?
  - If so, perhaps we could have a separate tool to check for issues?
- [ ] We already only ask for replicators with the label. The check is currently pointless.
  - Should we be logging when an ownerReference doesn't have the required label, then?
  - Wouldn't the value always be the same as the pod anyway?
  - Why don't we look up the replicators lazily? Why all at the same time?
- Is this too expensive to do?
  - For deploytime, logging per replicator is relatively low-cost.
  - For deploytime, logging per _pod_ that doesn't have the label should be fine since it only tracks running pods.
  - For committime, we need to look at _every_ build. That might be a bit much. Right now this PR only has it done for deploytime.
- [ ] This will generate a lot of logs for well-used clusters / namespaces.
We should use a child logger for this so these warnings can be silenced.
- Do we want this for the committime exporter as well? See above.

## Linked Issues?

related to #436 (if we sufficiently handle these cases in every collector, it will close it)

## Testing Instructions

For deploytime:
1. Create pods that are missing the configured APP_LABEL (or, just set the APP_LABEL to something else)
2. Validate that pods without the label are logged.
