### PR TITLE
Use ConfigMap as means for configuration

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.5.1
+version: 1.5.3
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -15,10 +15,10 @@ spec:
       kind: ImageStreamTag
       name: {{ .app_name }}:latest
   source:
-    contextDir: {{ .source_context_dir }}
+    contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
       ref: {{ .source_ref | default "v1.5.0" }}
-      uri: {{ .source_url }}
+      uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:
     sourceStrategy:

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -27,14 +27,24 @@ spec:
       containers:
       - name: {{ .app_name }}
         imagePullPolicy: Always
-      {{- if .env_from_secrets }}
         envFrom:
-        {{- range .env_from_secrets }}  
+      {{- if .env_from_secrets }}
+        {{- range .env_from_secrets }}
         - secretRef:
             name: {{ . }}
         {{- end}}
       {{- end}}
+      {{- if .env_from_configmaps }}
+        {{- range .env_from_configmaps }}
+        - configMapRef:
+            name: {{ . }}
+        {{- end}}
+      {{- end}}
         env:
+{{- if .exporter_type }}
+        - name: APP_FILE
+          value: {{ .exporter_type }}/app.py
+{{- end }}
 {{- if .extraEnv }}
 {{ toYaml .extraEnv | indent 8 }}
 {{- end }}

--- a/charts/pelorus/configmaps/committime.yaml
+++ b/charts/pelorus/configmaps/committime.yaml
@@ -1,0 +1,15 @@
+# For details refer to the documentation:
+#       https://pelorus.readthedocs.io/en/latest/Configuration/#commit-time-exporter
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: committime-config
+  namespace: pelorus
+data:
+  GIT_USER: "default"        # ""  |  User's github username, can be overriden by env_from_secrets
+  GIT_TOKEN: "default"       # ""  |  User's Github API Token, can be overriden by env_from_secrets
+  GIT_API: "default"         # api.github.com  |  Github Enterprise API FQDN, can be overriden by env_from_secrets
+  GIT_PROVIDER: "default"    # github  |  github, gitlab, or bitbucket
+  TLS_VERIFY: "default"      # True
+  NAMESPACES:                #     | Restricts the set of namespaces,  comma separated value "myapp-ns-dev,otherapp-ci"

--- a/charts/pelorus/configmaps/deploytime.yaml
+++ b/charts/pelorus/configmaps/deploytime.yaml
@@ -1,0 +1,11 @@
+# For details refer to the documentation:
+#       https://pelorus.readthedocs.io/en/latest/Configuration/#deploy-time-exporter
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deploytime-config
+  namespace: pelorus
+data:
+  PROD_LABEL: "default"    # "" | PROD_LABEL is ignored if NAMESPACES are provided
+  NAMESPACES: "default"    # "" | Restricts the set of namespaces,  comma separated value "myapp-ns-dev,otherapp-ci"

--- a/charts/pelorus/configmaps/failuretime.yaml
+++ b/charts/pelorus/configmaps/failuretime.yaml
@@ -1,0 +1,15 @@
+# For details refer to the documentation:
+#       https://pelorus.readthedocs.io/en/latest/Configuration/#failure-time-exporter
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: failuretime-config
+  namespace: pelorus
+data:
+  PROVIDER: "default"    # jira  |  jira or servicenow
+  SERVER:                #       |  URL to the Jira or ServiceNowServer, can be overriden by env_from_secrets
+  USER:                  #       |  Tracker Username, can be overriden by env_from_secrets
+  TOKEN:                 #       |  User's API Token, can be overriden by env_from_secrets
+  PROJECTS:              #       |  Only for jira provider, comma separated list, e.g. "PROJECTKEY1,PROJECTKEY2"
+  APP_FIELD: "default"   # u_application  | Required for ServiceNow,  used for the Application label. ex: "u_appName"

--- a/charts/pelorus/configmaps/pelorus.yaml
+++ b/charts/pelorus/configmaps/pelorus.yaml
@@ -1,0 +1,12 @@
+# For details refer to the documentation:
+#       https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pelorus-config
+  namespace: pelorus
+data:
+  PELORUS_DEFAULT_KEYWORD: "default"   # default  |  Other ConfigMap values "default" keyword
+  APP_LABEL: "default"                 # app.kubernetes.io/name  |  Deploy and Commit time exporters - label key used to identify applications
+  LOG_LEVEL: "default"                 # INFO  |  Log level, DEBUG, INFO, WARNING or ERROR

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -18,12 +18,26 @@ deployment:
 
 exporters:
   instances:
-    # Values file for exporter helm chart
   - app_name: deploytime-exporter
-    source_context_dir: exporters/
-    extraEnv:
-    - name: APP_FILE
-      value: deploytime/app.py
-    source_url: https://github.com/konveyor/pelorus.git
+    exporter_type: deploytime
+    env_from_configmaps:
+    - pelorus-config
+    - deploytime-config
+
+#  - app_name: failuretime-exporter
+#    exporter_type: failure
+#    env_from_configmaps:
+#    - pelorus-config
+#    - failuretime-config
+#    env_from_secrets:
+#    - jira-secret
+
+#  - app_name: committime-exporter
+#    exporter_type: committime
+#    env_from_configmaps:
+#    - pelorus-config
+#    - committime-config
+#    env_from_secrets:
+#    - github-secret
 
 snapshot_schedule: "@monthly"

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import logging
-import os
 import time
 from distutils.util import strtobool
 
@@ -50,20 +49,22 @@ if __name__ == "__main__":
     k8s_client = client.api_client.ApiClient(configuration=k8s_config)
     dyn_client = DynamicClient(k8s_client)
 
-    username = os.environ.get("GIT_USER", "")
-    token = os.environ.get("GIT_TOKEN", "")
+    username = pelorus.utils.get_env_var("GIT_USER", "")
+    token = pelorus.utils.get_env_var("GIT_TOKEN", "")
     if not username and not token:
         logging.info(
             "No GIT_USER and no GIT_TOKEN given. This is okay for public repositories only."
         )
-    git_api = os.environ.get("GIT_API")
-    git_provider = os.environ.get("GIT_PROVIDER", pelorus.DEFAULT_GIT)
+    git_api = pelorus.utils.get_env_var("GIT_API", pelorus.DEFAULT_GIT_API)
+    git_provider = pelorus.utils.get_env_var("GIT_PROVIDER", pelorus.DEFAULT_GIT)
     tls_verify = bool(
-        strtobool(os.environ.get("TLS_VERIFY", pelorus.DEFAULT_TLS_VERIFY))
+        strtobool(pelorus.utils.get_env_var("TLS_VERIFY", pelorus.DEFAULT_TLS_VERIFY))
     )
     namespaces = None
-    if os.environ.get("NAMESPACES") is not None:
-        namespaces = [proj.strip() for proj in os.environ.get("NAMESPACES").split(",")]
+    if pelorus.utils.get_env_var("NAMESPACES") is not None:
+        namespaces = [
+            proj.strip() for proj in pelorus.utils.get_env_var("NAMESPACES").split(",")
+        ]
     apps = None
     start_http_server(8080)
 

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 import time
 from typing import Iterable, Optional
@@ -236,7 +235,7 @@ if __name__ == "__main__":
     dyn_client = DynamicClient(k8s_client)
     namespaces = {
         stripped
-        for proj in os.environ.get("NAMESPACES", "").split(",")
+        for proj in pelorus.utils.get_env_var("NAMESPACES", "").split(",")
         if (stripped := proj.strip())
     }
     prod_label = pelorus.get_prod_label()

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -16,7 +16,6 @@
 #
 
 import logging
-import os
 import sys
 import time
 from typing import Union
@@ -52,16 +51,16 @@ if __name__ == "__main__":
         print("This program will exit.")
         sys.exit(1)
     projects = None
-    if os.environ.get("PROJECTS") is not None:
+    if pelorus.utils.get_env_var("PROJECTS") is not None:
         logging.info(
             "Querying issues from '%s' projects.",
-            os.environ.get("PROJECTS"),
+            pelorus.utils.get_env_var("PROJECTS"),
         )
-        projects = os.environ.get("PROJECTS")
-    username = os.environ.get("USER")
-    token = os.environ.get("TOKEN")
-    tracker_api = os.environ.get("SERVER")
-    tracker_provider = os.environ.get("PROVIDER", pelorus.DEFAULT_TRACKER)
+        projects = pelorus.utils.get_env_var("PROJECTS")
+    username = pelorus.utils.get_env_var("USER")
+    token = pelorus.utils.get_env_var("TOKEN")
+    tracker_api = pelorus.utils.get_env_var("SERVER")
+    tracker_provider = pelorus.utils.get_env_var("PROVIDER", pelorus.DEFAULT_TRACKER)
     logging.info("Server: " + tracker_api)
     logging.info("User: " + username)
     start_http_server(8080)

--- a/exporters/failure/collector_servicenow.py
+++ b/exporters/failure/collector_servicenow.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from datetime import datetime
 
 import pytz
@@ -21,14 +20,14 @@ class ServiceNowFailureCollector(AbstractFailureCollector):
     """
 
     def __init__(self, user, apikey, server):
-        if not os.environ.get("APP_FIELD"):
+        if not pelorus.utils.get_env_var("APP_FIELD"):
             logging.warn(
                 "Missing Application Name Field Parameter defaulting to '%s'",
                 pelorus.DEFAULT_TRACKER_APP_FIELD,
             )
             self.app_name_field = pelorus.DEFAULT_TRACKER_APP_FIELD
         else:
-            self.app_name_field = os.environ.get("APP_FIELD")
+            self.app_name_field = pelorus.utils.get_env_var("APP_FIELD")
         self.page_size = 100
         super().__init__(server, user, apikey)
 

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -15,6 +15,7 @@ DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_LOG_FORMAT = "%(asctime)-15s %(levelname)-8s %(message)s"
 DEFAULT_LOG_DATE_FORMAT = "%m-%d-%Y %H:%M:%S"
 DEFAULT_GIT = "github"
+DEFAULT_GIT_API = ""
 DEFAULT_TLS_VERIFY = "True"
 DEFAULT_TRACKER = "jira"
 DEFAULT_TRACKER_APP_LABEL = "unknown"
@@ -128,7 +129,7 @@ def missing_configs(vars):
 def upgrade_legacy_vars():
     username = utils.get_env_var("GITHUB_USER")
     token = utils.get_env_var("GITHUB_TOKEN")
-    api = utils.get_env_var("GITHUB_API")
+    api = utils.get_env_var("GITHUB_API", DEFAULT_GIT_API)
     if username and not utils.get_env_var("GIT_USER"):
         os.environ["GIT_USER"] = username
     if token and not utils.get_env_var("GIT_TOKEN"):


### PR DESCRIPTION
Use ConfigMap as means for configuration
    
Exporters are configured in a similar way to secrets and are using OpenShift ConfigMap objects for their values.
    
Change backwards compatible to accept older values.yaml.

@redhat-cop/mdt

Depends on: https://github.com/konveyor/pelorus/pull/449