### PR TITLE
Fix issue #448 to make handling of shell env vars consistently

### DIFF
--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -33,7 +33,7 @@ def _print_version():
     exporter_name = pathlib.PurePath(__main__.__file__).parent.name
 
     repo, ref, commit = (
-        os.environ.get(f"OPENSHIFT_BUILD_{var.upper()}")
+        utils.get_env_var(f"OPENSHIFT_BUILD_{var.upper()}")
         for var in "source reference commit".split()
     )
     if repo and ref and commit:
@@ -47,7 +47,7 @@ def _print_version():
 # region: logging setup
 def _setup_logging():
     _print_version()
-    loglevel = os.getenv("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
+    loglevel = utils.get_env_var("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
     numeric_level = getattr(logging, loglevel, None)
     if not isinstance(numeric_level, int):
         raise ValueError("Invalid log level: %s", loglevel)
@@ -73,7 +73,7 @@ NamespaceSpec = Optional[Sequence[str]]
 
 
 def load_kube_config():
-    if "OPENSHIFT_BUILD_NAME" in os.environ:
+    if utils.get_env_var("OPENSHIFT_BUILD_NAME") is not None:
         config.load_incluster_config()
         file_namespace = open(
             "/run/secrets/kubernetes.io/serviceaccount/namespace", "r"
@@ -108,17 +108,17 @@ def convert_timestamp_to_date_time_str(timestamp, format_string="%Y-%m-%dT%H:%M:
 
 
 def get_app_label():
-    return os.getenv("APP_LABEL", DEFAULT_APP_LABEL)
+    return utils.get_env_var("APP_LABEL", DEFAULT_APP_LABEL)
 
 
 def get_prod_label():
-    return os.getenv("PROD_LABEL", DEFAULT_PROD_LABEL)
+    return utils.get_env_var("PROD_LABEL", DEFAULT_PROD_LABEL)
 
 
 def missing_configs(vars):
     missing_configs = False
     for var in vars:
-        if var not in os.environ:
+        if utils.get_env_var(var) is None:
             logging.error("Missing required environment variable '%s'." % var)
             missing_configs = True
 
@@ -126,14 +126,14 @@ def missing_configs(vars):
 
 
 def upgrade_legacy_vars():
-    username = os.environ.get("GITHUB_USER")
-    token = os.environ.get("GITHUB_TOKEN")
-    api = os.environ.get("GITHUB_API")
-    if username and not os.getenv("GIT_USER"):
+    username = utils.get_env_var("GITHUB_USER")
+    token = utils.get_env_var("GITHUB_TOKEN")
+    api = utils.get_env_var("GITHUB_API")
+    if username and not utils.get_env_var("GIT_USER"):
         os.environ["GIT_USER"] = username
-    if token and not os.getenv("GIT_TOKEN"):
+    if token and not utils.get_env_var("GIT_TOKEN"):
         os.environ["GIT_TOKEN"] = token
-    if api and not os.getenv("GIT_API"):
+    if api and not utils.get_env_var("GIT_API"):
         os.environ["GIT_API"] = api
 
 

--- a/exporters/pelorus/utils.py
+++ b/exporters/pelorus/utils.py
@@ -147,6 +147,16 @@ class SpecializeDebugFormatter(logging.Formatter):
             self._style._fmt = prior_format
 
 
+@overload
+def get_env_var(var_name: str, default_value: str) -> str:
+    ...
+
+
+@overload
+def get_env_var(var_name: str) -> Optional[str]:
+    ...
+
+
 def get_env_var(var_name: str, default_value: Optional[str] = None) -> Optional[str]:
     """
     `get_env_var` modifies standard os.getenv behavior to allow using default python variable values

--- a/exporters/pelorus/utils.py
+++ b/exporters/pelorus/utils.py
@@ -6,10 +6,13 @@ in kubernetes that are not so idiomatic to deal with.
 import contextlib
 import dataclasses
 import logging
+import os
 from typing import Any, Optional, Union, overload
 
 # sentinel value for the default kwarg to get_nested
 __GET_NESTED_NO_DEFAULT = object()
+
+DEFAULT_VAR_KEYWORD = "default"
 
 
 @overload
@@ -142,3 +145,33 @@ class SpecializeDebugFormatter(logging.Formatter):
             return logging.Formatter.format(self, record)
         finally:
             self._style._fmt = prior_format
+
+
+def get_env_var(var_name: str, default_value: Optional[str] = None) -> Optional[str]:
+    """
+    `get_env_var` modifies standard os.getenv behavior to allow using default python variable values
+    when:
+        1. PELORUS_DEFAULT_KEYWORD is set in SHELL env and the value from PELORUS_DEFAULT_KEYWORD
+           is used for other SHELL env value, e.g.
+           export PELORUS_DEFAULT_KEYWORD="custom_default"
+           export LOG_LEVEL="custom_default"
+
+           In which case LOG_LEVEL is set to DEFAULT_LOG_LEVEL
+
+        2. DEFAULT_VAR_KEYWORD keyword is present as the SHELL env variable value, e.g.
+           unset PELORUS_DEFAULT_KEYWORD
+           export LOG_LEVEL="default"
+
+           In which case LOG_LEVEL is set to DEFAULT_LOG_LEVEL
+
+    This is required for the config map to define fallback vars in a consistent way.
+    """
+    default_keyword = os.getenv("PELORUS_DEFAULT_KEYWORD") or DEFAULT_VAR_KEYWORD
+
+    env_var = os.getenv(var_name, default_value)
+    if env_var == default_keyword:
+        if default_value is None:
+            raise ValueError(f"default value not present for SHELL env var: {var_name}")
+        return default_value
+
+    return env_var

--- a/exporters/pelorus/utils.py
+++ b/exporters/pelorus/utils.py
@@ -176,6 +176,19 @@ def get_env_var(var_name: str, default_value: Optional[str] = None) -> Optional[
 
     This is required for the config map to define fallback vars in a consistent way.
     """
+
+    # decision table
+    # substitute PELORUS_DEFAULT_KEYWORD with whatever it is configured to be
+    # | env var value           | default_value | result        |
+    # | ----------------------- | ------------- | ------------- |
+    # | unset                   | None          | None          |
+    # | unset                   | any str       | default_value |
+    # | ""                      | None          | ""            |
+    # | ""                      | any str       | ""            |
+    # | PELORUS_DEFAULT_KEYWORD | None          | ValueError    |
+    # | PELORUS_DEFAULT_KEYWORD | any str       | default_value |
+    # | any other str           | None          | env var value |
+    # | any other str           | any str       | env var value |
     default_keyword = os.getenv("PELORUS_DEFAULT_KEYWORD") or DEFAULT_VAR_KEYWORD
 
     env_var = os.getenv(var_name, default_value)

--- a/exporters/tests/test_pelorus.py
+++ b/exporters/tests/test_pelorus.py
@@ -90,9 +90,9 @@ def unset_envs():
     ]
 
     for var in vars:
-        if os.getenv(var):
+        if pelorus.utils.get_env_var(var):
             del os.environ[var]
-        print("%s: %s" % (var, os.getenv(var)))
+        print("%s: %s" % (var, pelorus.utils.get_env_var(var)))
 
 
 @pytest.mark.parametrize(

--- a/exporters/tests/test_utils.py
+++ b/exporters/tests/test_utils.py
@@ -1,8 +1,12 @@
+import os
+
 import pytest
 
+import pelorus
 from pelorus.utils import (
     BadAttributePathError,
     collect_bad_attribute_path_error,
+    get_env_var,
     get_nested,
 )
 
@@ -36,3 +40,66 @@ def test_nested_lookup_collect():
     error = errors[0]
     assert error.path[error.path_slice] == SLICED_PATH
     assert error.value == VALUE
+
+
+def test_env_var_default():
+    # Empty string should give us empty string
+    os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = ""
+    assert get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT") == ""
+
+    # No default value found
+    os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = pelorus.utils.DEFAULT_VAR_KEYWORD
+    with pytest.raises(ValueError):
+        get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT")
+
+    # Use env variable instead of default value
+    if "PELORUS_DEFAULT_KEYWORD" in os.environ:
+        del os.environ["PELORUS_DEFAULT_KEYWORD"]
+    os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = pelorus.utils.DEFAULT_VAR_KEYWORD
+    assert (
+        get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT", "default_value") == "default_value"
+    )
+
+    # If there is no env variable set, None should be returned
+    if "PELORUS_TEST_ENV_VAR_DEFAULT" in os.environ:
+        del os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"]
+    assert get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT") is None
+
+    # Use non standard default keyword to ensure default value is used
+    os.environ["PELORUS_DEFAULT_KEYWORD"] = "usepelorusdefaultvalue"
+    os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = "usepelorusdefaultvalue"
+    assert (
+        get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT", "test_default_value")
+        == "test_default_value"
+    )
+
+    # Use env variable instead of default value
+    os.environ["PELORUS_DEFAULT_KEYWORD"] = "usepelorusdefaultvalue"
+    os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = "some_value"
+    assert (
+        get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT", "test_default_value")
+        == "some_value"
+    )
+
+    # No default value found with use of custom default keyword
+    os.environ["PELORUS_DEFAULT_KEYWORD"] = "usepelorusdefaultvalue"
+    os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = "usepelorusdefaultvalue"
+    with pytest.raises(ValueError):
+        get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT")
+
+    # Case where the env variable may be exactly the same as the default value:
+    os.environ["PELORUS_DEFAULT_KEYWORD"] = "usepelorusdefaultvalue"
+    os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = pelorus.utils.DEFAULT_VAR_KEYWORD
+    assert (
+        get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT", "other_default_value")
+        == pelorus.utils.DEFAULT_VAR_KEYWORD
+    )
+
+    # If there is no env variable set, default should be returned
+    if "PELORUS_DEFAULT_KEYWORD" in os.environ:
+        del os.environ["PELORUS_DEFAULT_KEYWORD"]
+    if "PELORUS_TEST_ENV_VAR_DEFAULT" in os.environ:
+        del os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"]
+    assert (
+        get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT", "default_value") == "default_value"
+    )


### PR DESCRIPTION
Fix issue #448 to make handling of shell env vars consistently
    
Proposed change makes handling of shell env variables in a consstent way and moves the logic to one function, which may be easily adopted in the future development.


@redhat-cop/mdt
