### PR TITLE
Fix JIRA query string to accept project FIRST and allow more then one project

### DIFF
--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -38,7 +38,11 @@ class TrackerFactory:
     ) -> Union[JiraFailureCollector, ServiceNowFailureCollector]:
         if tracker_provider == "jira":
             return JiraFailureCollector(
-                server=tracker_api, user=username, apikey=token, projects=projects
+                server=tracker_api,
+                user=username,
+                apikey=token,
+                projects=projects,
+                jql_query_string=None,
             )
         elif tracker_provider == "servicenow":
             return ServiceNowFailureCollector(username, token, tracker_api)

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -85,7 +85,11 @@ def test_jira_prometheus_register(
 
     monkeypatch.setattr(JiraFailureCollector, "search_issues", mock_search_issues)
     collector = JiraFailureCollector(
-        user=username, apikey=apikey, server=server, projects=None
+        user=username,
+        apikey=apikey,
+        server=server,
+        projects=None,
+        jql_query_string=None,
     )
 
     REGISTRY.register(collector)  # type: ignore
@@ -112,6 +116,10 @@ def test_jira_exception(server, username, apikey, monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(JiraFailureCollector, "_connect_to_jira", mock_jira_connect)
 
     collector = JiraFailureCollector(
-        user=username, apikey=apikey, server=server, projects=None
+        user=username,
+        apikey=apikey,
+        server=server,
+        projects=None,
+        jql_query_string=None,
     )
     collector.search_issues()


### PR DESCRIPTION
JIRA projecect with reserved key "FIRST" must be surrounded by quotes in order to work. This behaviour is also accepted for other project keys/names.

Fixes issue #450
Fixes issue #454 

This is also preparation for getting jql query from configmap or env variable after PR #445 is merged, but at the moment did not want to have many dependent PRs open.

@redhat-cop/mdt
