### PR TITLE
Fix Issue #446 where committime exporter had to be restarted

### DIFF
--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -86,7 +86,7 @@ def test_github_provider():
 
     actual = [
         CommitMetricEssentials.from_commit_metric(cm)
-        for cm in collector.generate_metrics()
+        for cm in collector.generate_metrics(collector._namespaces)
     ]
 
     actual.sort(key=lambda commit: commit.commit_timestamp)


### PR DESCRIPTION
The issue with commit time exporter is that new namespace could not be registered because object created at the very first step by GitFactory assigned watched namespaces and they were not updated during lifetime of the application. Similar problem occurred when there were no NAMESPACES passed to the application in which case object was assigned with all namespaces, but never freed. This change fixes the issue where we don't associate instance variable and gather this value every time collector is generating metrics.

resolves #446

@redhat-cop/mdt