### PR TITLE
Refactor bitbucket collector to not swallow errors & have nicer logging

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.5
+version: 1.6.6
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/configmaps/committime.yaml
+++ b/charts/pelorus/configmaps/committime.yaml
@@ -7,7 +7,7 @@ metadata:
   name: committime-config
   namespace: pelorus
 data:
-  USER: "default"            # ""  |  User's github username, can be overriden by env_from_secrets
+  API_USER: "default"            # ""  |  User's github username, can be overriden by env_from_secrets
   TOKEN: "default"           # ""  |  User's Github API Token, can be overriden by env_from_secrets
   GIT_API: "default"         # api.github.com  |  Github Enterprise API FQDN, can be overriden by env_from_secrets
   GIT_PROVIDER: "default"    # github  |  github, gitlab, or bitbucket

--- a/charts/pelorus/configmaps/failuretime.yaml
+++ b/charts/pelorus/configmaps/failuretime.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   PROVIDER: "default"    # jira  |  jira, github, servicenow
   SERVER:                #       |  URL to the Jira or ServiceNowServer, can be overriden by env_from_secrets
-  USER:                  #       |  Tracker Username, can be overriden by env_from_secrets
+  API_USER:                  #       |  Tracker Username, can be overriden by env_from_secrets
   TOKEN:                 #       |  User's API Token, can be overriden by env_from_secrets
   APP_FIELD: "default"   # u_application  | Required for ServiceNow,  used for the Application label. ex: "u_appName"
   PROJECTS:

--- a/charts/pelorus/secrets/github_example.yaml
+++ b/charts/pelorus/secrets/github_example.yaml
@@ -8,5 +8,5 @@ metadata:
   namespace: pelorus
 type: Opaque
 stringData:
-  USER: "pelorus@jira.username.io"             # Github Username
+  API_USER: "pelorus@jira.username.io"             # Github Username
   TOKEN: "secret_token"                        # Github Token

--- a/charts/pelorus/secrets/jira_example.yaml
+++ b/charts/pelorus/secrets/jira_example.yaml
@@ -9,5 +9,5 @@ metadata:
 type: Opaque
 stringData:
   SERVER: "https://pelorustest.atlassian.net/" # Provide JIRA Server endpoint
-  USER: "pelorus@jira.username.io"             # JIRA Username
+  API_USER: "pelorus@jira.username.io"             # JIRA Username
   TOKEN: "secret_token"                        # JIRA Token

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -114,7 +114,7 @@ oc create secret generic github-secret --from-literal=TOKEN=<personal access tok
 ```
 
 A Pelorus exporter can require additional information to collect data such as the 
-remote `GIT_API` or `USER` information.  It is recommended to consult the requirements
+remote `GIT_API` or `API_USER` information.  It is recommended to consult the requirements
 for each Pelorus exporter in this guide and include the additional key / value information in the Openshift secret. An API example is `github.mycompany.com/api/v3`
 
 The cli commands can also be substituted with Secret templates. Example files can be found [here](https://github.com/konveyor/pelorus/tree/master/charts/pelorus/secrets)
@@ -122,14 +122,14 @@ The cli commands can also be substituted with Secret templates. Example files ca
 Create a secret containing your Git username, token, and API example:  
 
 ```shell
-oc create secret generic github-secret --from-literal=USER=<username> --from-literal=TOKEN=<personal access token> --from-literal=GIT_API=<api> -n pelorus
+oc create secret generic github-secret --from-literal=API_USER=<username> --from-literal=TOKEN=<personal access token> --from-literal=GIT_API=<api> -n pelorus
 ```
 
 A Jira example:
 ```shell
 oc create secret generic jira-secret \
 --from-literal=SERVER=<Jira Server> \
---from-literal=USER=<username/e-mail> \
+--from-literal=API_USER=<username/e-mail> \
 --from-literal=TOKEN=<personal access token> \
 -n pelorus
 ```
@@ -138,7 +138,7 @@ A ServiceNow example:
 ```shell
 oc create secret generic snow-secret \
 --from-literal=SERVER=<ServiceNow Server> \
---from-literal=USER=<username> \
+--from-literal=API_USER=<username> \
 --from-literal=TOKEN=<personal access token> \
 --from-literal=TRACKER_PROVICER=servicenow \
 --from-literal=APP_FIELD=<Custom app label field> \
@@ -190,7 +190,7 @@ This exporter provides several configuration options, passed via `pelorus-config
 
 | Variable | Required | Explanation | Default Value |
 |---|---|---|---|
-| `USER` | yes | User's github username | unset |
+| `API_USER` | yes | User's github username | unset |
 | `TOKEN` | yes | User's Github API Token | unset |
 | `GIT_API` | no | Github API FQDN.  This allows the override for Github Enterprise users.  Currently only applicable to `github` provider type. | `api.github.com` |
 | `GIT_PROVIDER` | no | Set Git provider type. Can be `github`, `gitlab`, or `bitbucket` | `github` |
@@ -280,7 +280,7 @@ This exporter provides several configuration options, passed via `pelorus-config
 | `PROVIDER` | no | Set the type of failure provider. One of `jira`, `servicenow` | `jira` |
 | `LOG_LEVEL` | no | Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR` | `INFO` |
 | `SERVER` | yes | URL to the Jira or ServiceNowServer  | unset  |
-| `USER` | yes | Tracker Username | unset |
+| `API_USER` | yes | Tracker Username | unset |
 | `TOKEN` | yes | User's API Token | unset |
 | `APP_LABEL` | no | Used in GitHub and JIRA only. Changes the label key used to identify applications  | `app.kubernetes.io/name`  |
 | `APP_FIELD` | no | Required for ServiceNow, field used for the Application label. ex: "u_appName" | 'u_application' |
@@ -303,7 +303,7 @@ metadata:
 data:
   PROVIDER: "github"     # jira  |  jira, github, servicenow
   SERVER:                #       |  URL to the Jira or ServiceNowServer, can be overriden by env_from_secrets
-  USER:                  #       |  Tracker Username, can be overriden by env_from_secrets
+  API_USER:                  #       |  Tracker Username, can be overriden by env_from_secrets
   TOKEN:                 #       |  User's API Token, can be overriden by env_from_secrets
   PROJECTS: "konveyor/todolist-mongo-go,konveyor/todolist-mariadb-go"
   APP_FIELD: "todolist"  #       |  This is optional for the Github failure exporter

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -213,7 +213,7 @@ Code also comes with a nice debugger feature. Here is a starter configuration to
             "env": {
                 "SERVER": "<Jira server url>",
                 "PROJECT": "<Jira project ID>",
-                "USER": "<Jira username>",
+                "API_USER": "<Jira username>",
                 "TOKEN": "<Jira personal access token>",
                 "LOG_LEVEL": "INFO",
                 "APP_LABEL": "app.kubernetes.io/name"
@@ -241,7 +241,7 @@ Running an exporter on your local machine should follow this process:
 
         export LOG_LEVEL=debug
         export TOKEN=xxxx
-        export USER=xxxx
+        export API_USER=xxxx
 
 4. Log in to your OpenShift cluster  OR export KUBECONFIG environment variable
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -95,7 +95,7 @@ metadata:
 data:
   PROVIDER: "servicenow"    # jira
   SERVER:
-  USER:
+  API_USER:
   TOKEN:
   PROJECTS:              # Only for jira provider, comma separated list
   APP_FIELD: "default"   # u_application / only for ServiceNow provider

--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -127,14 +127,14 @@ class CommitMetric:
     # commit_timestamp: very special handling, the main purpose of each committime collector
     # comitter: not required to calculate committime
     _BUILD_MAPPING = dict(
-        build_name=["metadata.name", True],
-        build_config_name=["metadata.labels.buildconfig", True],
-        namespace=["metadata.namespace", True],
-        image_location=["status.outputDockerImageReference", True],
-        image_hash=["status.output.to.imageDigest", True],
-        commit_hash=["spec.revision.git.commit", False],
-        repo_url=["spec.source.git.uri", False],
-        committer=["spec.revision.git.author.name", False],
+        build_name=("metadata.name", True),
+        build_config_name=("metadata.labels.buildconfig", True),
+        namespace=("metadata.namespace", True),
+        image_location=("status.outputDockerImageReference", True),
+        image_hash=("status.output.to.imageDigest", True),
+        commit_hash=("spec.revision.git.commit", False),
+        repo_url=("spec.source.git.uri", False),
+        committer=("spec.revision.git.author.name", False),
     )
 
     _ANNOTATION_MAPPIG = dict(
@@ -152,9 +152,9 @@ def commit_metric_from_build(app: str, build, errors: list) -> CommitMetric:
     # lookup path.
     # Collect all errors to be reported at once instead of failing fast.
     metric = CommitMetric(app)
-    for attr_name, path in CommitMetric._BUILD_MAPPING.items():
-        with collect_bad_attribute_path_error(errors, path[1]):
-            value = get_nested(build, path[0], name="build")
+    for attr_name, (path, required) in CommitMetric._BUILD_MAPPING.items():
+        with collect_bad_attribute_path_error(errors, required):
+            value = get_nested(build, path, name="build")
             setattr(metric, attr_name, value)
 
     return metric

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -44,11 +44,11 @@ if __name__ == "__main__":
 
     dyn_client = pelorus.utils.get_k8s_client()
 
-    username = pelorus.utils.get_env_var("USER", "")
+    username = pelorus.utils.get_env_var("API_USER", "")
     token = pelorus.utils.get_env_var("TOKEN", "")
     if not username and not token:
         logging.info(
-            "No USER and no TOKEN given. This is okay for public repositories only."
+            "No API_USER and no TOKEN given. This is okay for public repositories only."
         )
     git_api = pelorus.utils.get_env_var("GIT_API", pelorus.DEFAULT_GIT_API)
     git_provider = pelorus.utils.get_env_var("GIT_PROVIDER", pelorus.DEFAULT_GIT)

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -55,11 +55,13 @@ if __name__ == "__main__":
     tls_verify = bool(
         strtobool(pelorus.utils.get_env_var("TLS_VERIFY", pelorus.DEFAULT_TLS_VERIFY))
     )
-    namespaces = None
-    if pelorus.utils.get_env_var("NAMESPACES") is not None:
-        namespaces = [
-            proj.strip() for proj in pelorus.utils.get_env_var("NAMESPACES").split(",")
-        ]
+
+    namespaces_env = pelorus.utils.get_env_var("NAMESPACES", "")
+    if namespaces_env:
+        namespaces = [proj.strip() for proj in namespaces_env.split(",")]
+    else:
+        namespaces = []
+
     apps = None
     start_http_server(8080)
 

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -17,7 +17,14 @@ from committime.collector_gitlab import GitLabCommitCollector
 class GitFactory:
     @staticmethod
     def getCollector(
-        kube_client, username, token, namespaces, apps, git_api, git_provider
+        kube_client,
+        username,
+        token,
+        namespaces,
+        apps,
+        git_api,
+        git_provider,
+        tls_verify: bool,
     ):
         if git_provider == "gitlab":
             return GitLabCommitCollector(kube_client, username, token, namespaces, apps)
@@ -27,7 +34,7 @@ class GitFactory:
             )
         if git_provider == "bitbucket":
             return BitbucketCommitCollector(
-                kube_client, username, token, namespaces, apps
+                kube_client, username, token, namespaces, apps, tls_verify=tls_verify
             )
         if git_provider == "gitea":
             return GiteaCommitCollector(
@@ -66,7 +73,7 @@ if __name__ == "__main__":
     start_http_server(8080)
 
     collector = GitFactory.getCollector(
-        dyn_client, username, token, namespaces, apps, git_api, git_provider
+        dyn_client, username, token, namespaces, apps, git_api, git_provider, tls_verify
     )
     REGISTRY.register(collector)
 

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -18,8 +18,8 @@ class GitFactory:
     @staticmethod
     def getCollector(
         kube_client,
-        username,
-        token,
+        username: str,
+        token: str,
         namespaces,
         apps,
         git_api,

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -156,7 +156,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
         return metrics
 
     @abstractmethod
-    def get_commit_time(self, metric) -> CommitMetric:
+    def get_commit_time(self, metric) -> Optional[CommitMetric]:
         # This will perform the API calls and parse out the necessary fields into metrics
         pass
 

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -44,8 +44,8 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
     def __init__(
         self,
         kube_client,
-        username,
-        token,
+        username: str,
+        token: str,
         namespaces: list[str],
         apps,
         collector_name,

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -46,7 +46,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
         kube_client,
         username,
         token,
-        namespaces,
+        namespaces: list[str],
         apps,
         collector_name,
         timedate_format,
@@ -96,7 +96,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
             yield commit_metric
 
     def generate_metrics(
-        self, watched_namespaces: Optional[str] = None
+        self, watched_namespaces: Optional[list[str]] = None
     ) -> Iterable[CommitMetric]:
         """Method called by the collect to create a list of metrics to publish"""
         # This will loop and look at OCP builds (calls get_git_commit_time)

--- a/exporters/committime/collector_bitbucket.py
+++ b/exporters/committime/collector_bitbucket.py
@@ -181,7 +181,7 @@ class BitbucketCommitCollector(AbstractCommitCollector):
             logging.debug(
                 (
                     "For project %(project)s, repo %(repo)s, build %(build)s, "
-                    "commit %(commit)s BitBucket returned %(response)s",
+                    "commit %(commit)s BitBucket returned %(response)s"
                 ),
                 dict(
                     project=project_name,
@@ -197,7 +197,7 @@ class BitbucketCommitCollector(AbstractCommitCollector):
             logging.error(
                 (
                     "HTTP Error while searching for project %(project)s, repo %(repo)s, build %(build)s, "
-                    "commit %(commit)s: %(http_err)s",
+                    "commit %(commit)s: %(http_err)s"
                 ),
                 dict(
                     project=project_name,
@@ -211,7 +211,7 @@ class BitbucketCommitCollector(AbstractCommitCollector):
             logging.error(
                 (
                     "Response for project %(project)s, repo %(repo)s, build %(build)s, "
-                    "commit %(commit)s was not valid JSON: %(json_err)s",
+                    "commit %(commit)s was not valid JSON: %(json_err)s"
                 ),
                 dict(
                     project=project_name,

--- a/exporters/committime/collector_bitbucket.py
+++ b/exporters/committime/collector_bitbucket.py
@@ -50,7 +50,9 @@ class BitbucketCommitCollector(AbstractCommitCollector):
     # Default http headers needed for API calls
     DEFAULT_HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
 
-    def __init__(self, kube_client, username, token, namespaces, apps, tls_verify=True):
+    def __init__(
+        self, kube_client, username: str, token: str, namespaces, apps, tls_verify=True
+    ):
         super().__init__(
             kube_client,
             username,
@@ -64,7 +66,8 @@ class BitbucketCommitCollector(AbstractCommitCollector):
         self.__session = requests.Session()
         self.__session.verify = tls_verify
         self.__session.headers.update(self.DEFAULT_HEADERS)
-        self.__session.auth = (self._username, self._token)
+        if self._username and self._token:
+            self.__session.auth = (self._username, self._token)
 
     def get_commit_time(self, metric: CommitMetric):
         git_server = metric.git_server

--- a/exporters/committime/collector_bitbucket.py
+++ b/exporters/committime/collector_bitbucket.py
@@ -1,4 +1,3 @@
-import enum
 import logging
 from typing import Optional, cast
 
@@ -10,39 +9,12 @@ from committime import CommitMetric
 from committime.collector_base import AbstractCommitCollector
 
 
-class ApiVersion(enum.Enum):
-    """Known versions of the Bitbucket API."""
-
-    root: str
-    test: str
-    pattern: str
-
-    def __init__(self, root, test, pattern):
-        self.root = root
-        self.test = test
-        self.pattern = pattern
-
-    V_2_0 = (
-        "api",
-        "2.0/repositories",
-        "2.0/repositories/{group}/{project}/commit/{commit}",
+def commit_url(server: str, group: str, project: str, commit: str) -> str:
+    "Get the API endpoint for the given commit"
+    return pelorus.url_joiner(
+        server,
+        f"api/2.0/repositories/{group}/{project}/commit/{commit}",
     )
-
-    V_1_0 = (
-        "rest/api",
-        "1.0/projects",
-        "1.0/projects/{group}/repos/{project}/commits/{commit}",
-    )
-
-    def commit_url(self, server: str, group: str, project: str, commit: str) -> str:
-        return pelorus.url_joiner(
-            server,
-            self.root,
-            self.pattern.format(group=group, project=project, commit=commit),
-        )
-
-    def test_url(self, server: str) -> str:
-        return pelorus.url_joiner(server, self.root, self.test)
 
 
 class BitbucketCommitCollector(AbstractCommitCollector):
@@ -62,7 +34,6 @@ class BitbucketCommitCollector(AbstractCommitCollector):
             "BitBucket",
             "%Y-%m-%dT%H:%M:%S%z",
         )
-        self.__cached_server_api_versions: dict[str, ApiVersion] = {}
         self.__session = requests.Session()
         self.__session.verify = tls_verify
         self.__session.headers.update(self.DEFAULT_HEADERS)
@@ -78,18 +49,25 @@ class BitbucketCommitCollector(AbstractCommitCollector):
             return None
 
         try:
-            # Get or figure out the BB API version
-            # check the cache
-            api_version = self.get_api_version(git_server)
-            if api_version is None:
+            git_server = metric.git_server
+
+            project_name = metric.repo_project
+            sha = cast(str, metric.commit_hash)
+            group = metric.repo_group
+
+            api_dict = self.get_commit_information(
+                git_server, group, project_name, sha, metric
+            )
+
+            if api_dict is None:
                 return metric
 
-            if api_version is ApiVersion.V_1_0:
-                metric = self.get_commit_time_v1(metric)
-            elif api_version is ApiVersion.V_2_0:
-                metric = self.get_commit_time_v2(metric)
-            else:
-                raise RuntimeError(f"unknown API Version {api_version}")
+            commit_time = api_dict["date"]
+            logging.debug("API v2 returned sha: %s, commit date: %s", sha, commit_time)
+            metric.commit_time = commit_time
+            metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
+                metric.commit_time, self._timedate_format
+            )
         except requests.exceptions.SSLError as e:
             logging.error(
                 "TLS error talking to %s for build %s: %s",
@@ -106,87 +84,9 @@ class BitbucketCommitCollector(AbstractCommitCollector):
             raise
         return metric
 
-    def get_commit_time_v1(self, metric: CommitMetric) -> CommitMetric:
-        """
-        Get commit time information from the V1 version of the API.
-        """
-        git_server = metric.git_server
-
-        project_name = metric.repo_project
-        sha = metric.commit_hash
-        group = metric.repo_group
-
-        # URL munging copied from original code.
-        # TODO: this is messy. We should investigate the parsing that CommitMetric is doing.
-
-        # Due to the BB V1 git pattern differences, need remove '/scm' and parse again.
-        old_url = metric.repo_url
-        # Parse out the V1 /scm, for whatever reason why it is present.
-        new_url = old_url.replace("/scm", "")
-        # set the new url, so the parsing will happen
-        metric.repo_url = new_url
-        # set the new project name
-        project_name = metric.repo_project
-        # set the new group
-        group = metric.repo_group
-        # set the URL back to the original
-        metric.repo_url = old_url
-
-        api_dict = self.get_commit_information(
-            git_server, ApiVersion.V_1_0, group, project_name, sha, metric
-        )
-
-        if api_dict is None:
-            return metric
-
-        # API V1 has the commit timestamp, which does not need to be converted
-        commit_timestamp = api_dict["committerTimestamp"]
-        logging.debug("API v1 returned sha: %s, timestamp: %s", sha, commit_timestamp)
-        # Convert timestamp from miliseconds to seconds
-        converted_timestamp = commit_timestamp / 1000
-        # set the timestamp in the metric
-        metric.commit_timestamp = converted_timestamp
-        # convert the time stamp to datetime and set in metric
-        metric.commit_time = pelorus.convert_timestamp_to_date_time_str(
-            converted_timestamp
-        )
-
-        return metric
-
-    def get_commit_time_v2(self, metric: CommitMetric) -> CommitMetric:
-        """
-        Get commit time information from the V2 version of the API.
-        """
-        git_server = metric.git_server
-
-        project_name = metric.repo_project
-        sha = metric.commit_hash
-        group = metric.repo_group
-
-        api_dict = self.get_commit_information(
-            git_server, ApiVersion.V_2_0, group, project_name, sha, metric
-        )
-
-        if api_dict is None:
-            return metric
-
-        # API V2 only has the commit time, which needs to be converted.
-        # get the commit date/time
-        commit_time = api_dict["date"]
-        logging.debug("API v2 returned sha: %s, commit date: %s", sha, commit_time)
-        # set the commit time from the API
-        metric.commit_time = commit_time
-        # set the timestamp after conversion
-        metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
-            metric.commit_time, self._timedate_format
-        )
-
-        return metric
-
     def get_commit_information(
         self,
         git_server: str,
-        api_version: ApiVersion,
         group: str,
         project_name: str,
         sha: str,
@@ -206,7 +106,7 @@ class BitbucketCommitCollector(AbstractCommitCollector):
         """
         api_response = None
         try:
-            url = api_version.commit_url(git_server, group, project_name, sha)
+            url = commit_url(git_server, group, project_name, sha)
 
             response = self.__session.get(url)
             response.encoding = "utf-8"
@@ -261,55 +161,3 @@ class BitbucketCommitCollector(AbstractCommitCollector):
                 ),
             )
         return api_response
-
-    def get_api_version(self, git_server: str) -> Optional[ApiVersion]:
-        """
-        Get the API version for the server from the cache.
-        If absent, test API urls to see which version is correct.
-        """
-        api_version = self.__cached_server_api_versions.get(git_server)
-
-        if api_version is not None:
-            return api_version
-
-        try:
-            for potential_api_version in ApiVersion:
-                if self.check_api_verison(git_server, potential_api_version):
-                    api_version = self.__cached_server_api_versions[
-                        git_server
-                    ] = potential_api_version
-                    break
-        except requests.HTTPError as e:
-            logging.error(
-                "While testing for API Version %s at server %s, got response: %s",
-                cast(ApiVersion, potential_api_version)._name_,
-                git_server,
-                e,
-            )
-
-        return api_version
-
-    def check_api_verison(self, git_server: str, api_version: ApiVersion) -> bool:
-        """
-        Check if the git_server supports a given ApiVersion.
-        Will return True if so, False if there's some non-successful response,
-        or re-raise the requests.HTTPError if the response was 401 UNAUTHORIZED
-        """
-        url = api_version.test_url(git_server)
-
-        response = self.__session.get(url)
-        try:
-            response.raise_for_status()
-            return True
-        except requests.HTTPError as e:
-            status = e.response.status_code
-
-            if status == requests.codes.unauthorized:
-                raise
-
-            logging.warning(
-                "While testing API version at URL %s got response: %s",
-                url,
-                status,
-            )
-            return False

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -33,7 +33,7 @@ PROVIDER_TYPES = ["jira", "github", "servicenow"]
 class TrackerFactory:
     @staticmethod
     def getCollector() -> AbstractFailureCollector:
-        username = pelorus.utils.get_env_var("USER")
+        username = pelorus.utils.get_env_var("API_USER")
         token = pelorus.utils.get_env_var("TOKEN")
         tracker_api = pelorus.utils.get_env_var("SERVER")
         tracker_provider = pelorus.utils.get_env_var(

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -43,7 +43,7 @@ class JiraFailureCollector(AbstractFailureCollector):
     Jira implementation of a FailureCollector
     """
 
-    REQUIRED_CONFIG = ["USER", "TOKEN", "SERVER"]
+    REQUIRED_CONFIG = ["API_USER", "TOKEN", "SERVER"]
 
     def __init__(self, user, apikey, server, projects):
         super().__init__(server, user, apikey)

--- a/exporters/failure/collector_servicenow.py
+++ b/exporters/failure/collector_servicenow.py
@@ -19,7 +19,7 @@ class ServiceNowFailureCollector(AbstractFailureCollector):
     Service Now implementation of a FailureCollector
     """
 
-    REQUIRED_CONFIG = ["USER", "TOKEN", "SERVER"]
+    REQUIRED_CONFIG = ["API_USER", "TOKEN", "SERVER"]
 
     def __init__(self, user, apikey, server):
         if not pelorus.utils.get_env_var("APP_FIELD"):

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -116,14 +116,19 @@ def missing_configs(vars):
 
 
 def upgrade_legacy_vars():
-    github_user = utils.get_env_var("GITHUB_USER")
     github_token = utils.get_env_var("GITHUB_TOKEN")
-    git_username = utils.get_env_var("GIT_USER")
     git_token = utils.get_env_var("GIT_TOKEN")
     api = utils.get_env_var("GITHUB_API", DEFAULT_GIT_API)
-    if not utils.get_env_var("USER"):
-        if git_username or github_user:
-            os.environ["USER"] = git_username or github_user
+
+    api_user = utils.get_env_var("API_USER")
+    github_user = utils.get_env_var("GITHUB_USER")
+    git_username = utils.get_env_var("GIT_USER")
+
+    assigned_user = api_user or git_username or github_user
+
+    if assigned_user:
+        os.environ["API_USER"] = assigned_user
+
     if not utils.get_env_var("TOKEN"):
         if git_token or github_token:
             os.environ["TOKEN"] = git_token or github_token

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -136,12 +136,12 @@ def upgrade_legacy_vars():
         os.environ["GIT_API"] = api
 
 
-def url_joiner(url, path, trailing=None):
-    """Join to sections for a URL and add proper forward slashes"""
-    url_link = "/".join(s.strip("/") for s in [url, path])
-    if trailing:
-        url_link += "/"
-    return url_link
+def url_joiner(base: str, *parts: str):
+    """
+    Joins each part together (including the base url) with a slash, stripping any leading or trailing slashes.
+    Used for "normalizing" URLs to handle most use cases.
+    """
+    return base.strip("/") + "/" + "/".join(s.strip("/") for s in parts)
 
 
 class AbstractPelorusExporter(ABC):

--- a/exporters/tests/test_pelorus.py
+++ b/exporters/tests/test_pelorus.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timezone
+from typing import NamedTuple, Optional
 
 import pytest
 
@@ -96,19 +97,103 @@ def unset_envs():
         print("%s: %s" % (var, pelorus.utils.get_env_var(var)))
 
 
+class LegacyVarsArgs(NamedTuple):
+    """
+    Arguments for upgrade_legacy_vars parametrized testing.
+    """
+
+    name: str
+    git_user: Optional[str] = None
+    git_token: Optional[str] = None
+    git_api: Optional[str] = None
+    github_user: Optional[str] = None
+    github_token: Optional[str] = None
+    github_api: Optional[str] = None
+    user: Optional[str] = None
+    token: Optional[str] = None
+
+
 @pytest.mark.parametrize(
-    "git_user,git_token,git_api,github_user,github_token,github_api,user,token",
+    "_test_name,git_user,git_token,git_api,github_user,github_token,github_api,user,token",
     [
-        (None, None, None, "goodU", "goodT", "goodA", None, None),
-        ("goodU", "goodT", "goodA", None, None, None, None, None),
-        ("goodU", "goodT", "goodA", "badU", "badT", "badA", None, None),
-        (None, None, "goodA", None, None, None, "goodU", "goodT"),
-        ("badU", "badT", "goodA", None, None, None, "goodU", "goodT"),
-        (None, None, "goodA", "badU", "badT", None, "goodU", "goodT"),
+        LegacyVarsArgs(
+            name="github_{user,token,api} work on their own",
+            git_user=None,
+            git_token=None,
+            git_api=None,
+            github_user="goodU",
+            github_token="goodT",
+            github_api="goodA",
+            user=None,
+            token=None,
+        ),
+        LegacyVarsArgs(
+            name="git_{user,token,api} work on their own",
+            git_user="goodU",
+            git_token="goodT",
+            git_api="goodA",
+            github_user=None,
+            github_token=None,
+            github_api=None,
+            user=None,
+            token=None,
+        ),
+        LegacyVarsArgs(
+            name="git_* takes precedence over github_*",
+            git_user="goodU",
+            git_token="goodT",
+            git_api="goodA",
+            github_user="badU",
+            github_token="badT",
+            github_api="badA",
+            user=None,
+            token=None,
+        ),
+        LegacyVarsArgs(
+            name="user, token work on their own",
+            git_user=None,
+            git_token=None,
+            git_api="goodA",
+            github_user=None,
+            github_token=None,
+            github_api=None,
+            user="goodU",
+            token="goodT",
+        ),
+        LegacyVarsArgs(
+            name="user, token have precedence over git_*",
+            git_user="badU",
+            git_token="badT",
+            git_api="goodA",
+            github_user=None,
+            github_token=None,
+            github_api=None,
+            user="goodU",
+            token="goodT",
+        ),
+        LegacyVarsArgs(
+            name="user, token have precedence over github_*",
+            git_user=None,
+            git_token=None,
+            git_api="goodA",
+            github_user="badU",
+            github_token="badT",
+            github_api=None,
+            user="goodU",
+            token="goodT",
+        ),
     ],
 )
 def test_ugprade_legacy_vars(
-    git_user, git_token, git_api, github_user, github_token, github_api, user, token
+    _test_name,
+    git_user,
+    git_token,
+    git_api,
+    github_user,
+    github_token,
+    github_api,
+    user,
+    token,
 ):
     unset_envs()
     if git_user:

--- a/exporters/tests/test_pelorus.py
+++ b/exporters/tests/test_pelorus.py
@@ -87,7 +87,7 @@ def unset_envs():
         "GITHUB_USER",
         "GITHUB_TOKEN",
         "GITHUB_API",
-        "USER",
+        "API_USER",
         "TOKEN",
     ]
 
@@ -109,12 +109,12 @@ class LegacyVarsArgs(NamedTuple):
     github_user: Optional[str] = None
     github_token: Optional[str] = None
     github_api: Optional[str] = None
-    user: Optional[str] = None
+    api_user: Optional[str] = None
     token: Optional[str] = None
 
 
 @pytest.mark.parametrize(
-    "_test_name,git_user,git_token,git_api,github_user,github_token,github_api,user,token",
+    "_test_name,git_user,git_token,git_api,github_user,github_token,github_api,api_user,token",
     [
         LegacyVarsArgs(
             name="github_{user,token,api} work on their own",
@@ -124,7 +124,7 @@ class LegacyVarsArgs(NamedTuple):
             github_user="goodU",
             github_token="goodT",
             github_api="goodA",
-            user=None,
+            api_user=None,
             token=None,
         ),
         LegacyVarsArgs(
@@ -135,7 +135,7 @@ class LegacyVarsArgs(NamedTuple):
             github_user=None,
             github_token=None,
             github_api=None,
-            user=None,
+            api_user=None,
             token=None,
         ),
         LegacyVarsArgs(
@@ -146,40 +146,40 @@ class LegacyVarsArgs(NamedTuple):
             github_user="badU",
             github_token="badT",
             github_api="badA",
-            user=None,
+            api_user=None,
             token=None,
         ),
         LegacyVarsArgs(
-            name="user, token work on their own",
+            name="api_user, token work on their own",
             git_user=None,
             git_token=None,
             git_api="goodA",
             github_user=None,
             github_token=None,
             github_api=None,
-            user="goodU",
+            api_user="goodU",
             token="goodT",
         ),
         LegacyVarsArgs(
-            name="user, token have precedence over git_*",
+            name="api_user, token have precedence over git_*",
             git_user="badU",
             git_token="badT",
             git_api="goodA",
             github_user=None,
             github_token=None,
             github_api=None,
-            user="goodU",
+            api_user="goodU",
             token="goodT",
         ),
         LegacyVarsArgs(
-            name="user, token have precedence over github_*",
+            name="api_user, token have precedence over github_*",
             git_user=None,
             git_token=None,
             git_api="goodA",
             github_user="badU",
             github_token="badT",
             github_api=None,
-            user="goodU",
+            api_user="goodU",
             token="goodT",
         ),
     ],
@@ -192,7 +192,7 @@ def test_ugprade_legacy_vars(
     github_user,
     github_token,
     github_api,
-    user,
+    api_user,
     token,
 ):
     unset_envs()
@@ -208,12 +208,12 @@ def test_ugprade_legacy_vars(
         os.environ["GITHUB_TOKEN"] = github_token
     if github_api:
         os.environ["GITHUB_API"] = github_api
-    if user:
-        os.environ["USER"] = user
+    if api_user:
+        os.environ["API_USER"] = api_user
     if token:
         os.environ["TOKEN"] = token
     pelorus.upgrade_legacy_vars()
-    assert os.environ["USER"] == "goodU"
+    assert os.environ["API_USER"] == "goodU"
     assert os.environ["TOKEN"] == "goodT"
     assert os.environ["GIT_API"] == "goodA"
     unset_envs()

--- a/labs/consultant/03-Exporters.md
+++ b/labs/consultant/03-Exporters.md
@@ -61,7 +61,7 @@ Confirm you have a [Github Personal Access Token](https://help.github.com/en/git
 Use the token information and the command below to generate a Github secret:
 
     oc create secret generic github-secret \
-      --from-literal=USER=<username> \
+      --from-literal=API_USER=<username> \
       --from-literal=TOKEN=<personal access token> -n pelorus
 
 Update the `values.yaml` and then upgrade our helm installation of Pelorus to add an additional exporter to the `instances` list:
@@ -98,7 +98,7 @@ Use the token information and the command below to generate a Jira secret:
 
        oc create secret generic jira-secret \
         --from-literal=SERVER=<Jira Server> \
-        --from-literal=USER=<email> \
+        --from-literal=API_USER=<email> \
         --from-literal=TOKEN=<personal access token> \
         --from-literal=PROJECT=<Jira Project> \
         -n pelorus

--- a/mocks/README.md
+++ b/mocks/README.md
@@ -27,7 +27,7 @@ Mock started at https://localhost:3000 (pid: 0, name: mockoon-openshift)
 Set up your envs in order to use the mock server.
 
 ```sh
-export USER=gituser
+export API_USER=gituser
 export TOKEN=gittoken
 export GIT_API=localhost:3000
 export LOG_LEVEL=DEBUG

--- a/samples/todolist_commit_deploy.md
+++ b/samples/todolist_commit_deploy.md
@@ -118,7 +118,7 @@ To develop a Pelorus exporter please fork the Pelorus git source and branch
 2. If you have forked Pelorus to a private git repository
 Create a GitHub Personal Access Token and store it as a secret in Openshift:
 ```
-oc create secret generic github-secret --from-literal=USER=<username> --from-literal=TOKEN=<personal access token> --namespace pelorus
+oc create secret generic github-secret --from-literal=API_USER=<username> --from-literal=TOKEN=<personal access token> --namespace pelorus
 ```
 
 Ensure you configure the exporters in /var/tmp/values.yml to use the github-secret:


### PR DESCRIPTION
resolves #464

## Testing Instructions

Positive test:

1. Make a pelorus repo on bitbucket
2. Make an app password in bitbucket
3. Deploy a bitbucket committime collector using that bitbucket repo and credentials
4. Confirm that the metrics are logged / collected correctly

SSL Error test:
1. Keep the existing repo and deployment
2. Set up mockoon, enable TLS
3. Locally change the code so `git_server` is always overwritten with the local mockoon url
4. Verify the TLS/SSL error in the logs

Now, the negative test:

0. Remove the hardcoded git_server from the above test
1. Delete that repo
2. Redeploy the pod (don't rebuild!)
3. Confirm that the logs report the error and are fully detailed.

