### PR TITLE
Allow JIRA to define custom resolution field and search query

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -241,8 +241,10 @@ This exporter provides several configuration options, passed via `pelorus-config
 | `USER` | yes | Tracker Username | unset |
 | `TOKEN` | yes | User's API Token | unset |
 | `APP_FIELD` | no | Required for ServiceNow, field used for the Application label. ex: "u_appName" | 'u_application' |
-| `PROJECTS` | no | Used for Jira Exporter to query issues from a list of project keys. Comma separated string. ex: `PROJECTKEY1,PROJECTKEY2` | unset |
+| `PROJECTS` | no | Used for Jira Exporter to query issues from a list of project keys. Comma separated string. ex: `PROJECTKEY1,PROJECTKEY2`. Value is ignored if `JIRA_JQL_SEARCH_QUERY` is defined. | unset |
 | `PELORUS_DEFAULT_KEYWORD` | no | ConfigMap default keyword. If specified it's used in other data values to indicate "Default Value" should be used | `default` |
+| `JIRA_JQL_SEARCH_QUERY` | no | Used for Jira Exporter to define custom JQL query to gather list issues. Ex: `type in ("Bug") AND priority in ("Highest","Medium") AND project in ("Project_1","Project_2")` | unset |
+| `JIRA_RESOLVED_STATUS` | no | Used for Jira Exporter to define list Issue states that indicates whether issue is considered resolved. Comma separated string. ex: `Done,Closed,Resolved,Fixed` | unset |
 
 ### Github failure exporter details
 

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -54,7 +54,6 @@ class TrackerFactory:
                 user=username,
                 apikey=token,
                 projects=projects,
-                jql_query_string=None,
             )
         elif tracker_provider == "servicenow":
             pelorus.utils.check_required_config(


### PR DESCRIPTION
Fixes #440 and #439 to allow specify custom JQL issues search query via environment variable or Custom Resource and also allow to define custom resolution state to calculate JIRA failure metric.

resolves #440 #439

## Testing Instructions
Unit tests and you can run the failure exporter with additional env. (example oun our pelorustest account):

```
export SERVER=https://pelorustest.atlassian.net/
export TOKEN=YOUR_TOKEN_TO_ACCESS_PELORUSTEST
export USER=your@username.com
export LOG_LEVEL=debug
export JIRA_JQL_SEARCH_QUERY='type in ("Bug") AND priority in ("highest","medium")'
export JIRA_RESOLVED_STATUS="done,to do"
python exporters/failure/app.py
```

@redhat-cop/mdt
