### PR TITLE
Add readiness and liveness probes, associate exporter type label

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.5.3
+version: 1.5.4
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -22,7 +22,8 @@ spec:
         app.kubernetes.io/name: {{ .app_name }}
         app: {{ .app_name }}
         deploymentconfig: {{ .app_name }}
-        application: {{ .app_name}}
+        application: {{ .app_name }}
+        pelorus.konveyor.io/exporter-type: {{ .exporter_type | default "generic-exporter" }}
     spec:
       containers:
       - name: {{ .app_name }}
@@ -51,6 +52,16 @@ spec:
         ports:
         - containerPort: 8080
           protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
       serviceAccount: pelorus-exporter
   triggers:
   - type: ConfigChange


### PR DESCRIPTION
This will allow to check exporter pod statuses in easy way.

@redhat-cop/mdt
