### PR TITLE
Ensure values from secrets has higher precedence than from configmap

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.5.4
+version: 1.5.5
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -29,15 +29,15 @@ spec:
       - name: {{ .app_name }}
         imagePullPolicy: Always
         envFrom:
-      {{- if .env_from_secrets }}
-        {{- range .env_from_secrets }}
-        - secretRef:
-            name: {{ . }}
-        {{- end}}
-      {{- end}}
       {{- if .env_from_configmaps }}
         {{- range .env_from_configmaps }}
         - configMapRef:
+            name: {{ . }}
+        {{- end}}
+      {{- end}}
+      {{- if .env_from_secrets }}
+        {{- range .env_from_secrets }}
+        - secretRef:
             name: {{ . }}
         {{- end}}
       {{- end}}


### PR DESCRIPTION
In case both values are present in ConfigMap and Secret, one from Secret is being used. This is already documented in the ConfigMap example files, however logic in the deploymentconfig was vice-versa.

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #<issue number> <-- Use this if merging should auto-close an issue

related to #<issue number> <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
