### PR TITLE
Tag latest released version with 'stable' tag.

### DIFF
--- a/.github/workflows/build-pelorus.yaml
+++ b/.github/workflows/build-pelorus.yaml
@@ -83,10 +83,10 @@ jobs:
 
       # Setup S2i and Build container image
       - name: Setup and Build
-        id: failure-exporter
+        id: build-exporter
         uses: redhat-actions/s2i-build@v2
         with:
-          image: 'committime-exporter'
+          image: 'failure-exporter'
           path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
           tags: ${{ env.latesttag }} ${{ github.sha }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,12 +1,12 @@
-name: Pelorus Release
+name: Pelorus Pre-Release
 
 on:
   release:
     types:
       - released
+      - prereleased
 
 env:
-  releasetag: 'stable'
   imageregistry: 'quay.io'
   imagenamespace: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
 
@@ -18,32 +18,32 @@ jobs:
       - name: Checkout opl-content-api
         uses: actions/checkout@v2
 
-      - name: Tag committime with release version
+      - name: Tag committime with (pre)release version
         uses: tinact/docker.image-retag@1.0.2
         with:
           image_name: ${{ env.imagenamespace }}/committime-exporter
           image_old_tag: ${{ github.sha }}
-          image_new_tag: ${{ env.releasetag }}
+          image_new_tag: ${{ github.event.release.tag_name }}
           registry: ${{ env.imageregistry }}
           registry_username: ${{ secrets.QUAY_USERNAME }}
           registry_password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Tag deploytime with released version
+      - name: Tag deploytime with (pre)released version
         uses: tinact/docker.image-retag@1.0.2
         with:
           image_name: ${{ env.imagenamespace }}/deploytime-exporter
           image_old_tag: ${{ github.sha }}
-          image_new_tag: ${{ env.releasetag }}
+          image_new_tag: ${{ github.event.release.tag_name }}
           registry: ${{ env.imageregistry }}
           registry_username: ${{ secrets.QUAY_USERNAME }}
           registry_password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Tag failure with released version
+      - name: Tag failure with (pre)released version
         uses: tinact/docker.image-retag@1.0.2
         with:
           image_name: ${{ env.imagenamespace }}/failure-exporter
           image_old_tag: ${{ github.sha }}
-          image_new_tag: ${{ env.releasetag }}
+          image_new_tag: ${{ github.event.release.tag_name }}
           registry: ${{ env.imageregistry }}
           registry_username: ${{ secrets.QUAY_USERNAME }}
           registry_password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Re-tag latest released version with the 'stable' tag.

It also fixes failure exporter image.

resolves: #480

## Testing Instructions
Testing was performed on a forked pelorus repository in the separate quay.io namespace, where all the images were correctly tagged during pre-release and release actions. Mixture of pre-release and release combinations on separate PRs and the same PR were performed to check possible use-cases. In all situations expected images were correctly tagged.

@redhat-cop/mdt
