### PR TITLE
Use quay.io images in the deployment of pelorus exporters

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.0
+version: 1.6.1
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -67,6 +67,10 @@ spec:
       - {{ .app_name }}
       from:
         kind: ImageStreamTag
+{{- if or .source_ref .source_url }}
         name: {{ .app_name }}:latest
+{{- else }}
+        name: {{ .app_name }}:{{ .image_tag | default "stable" }}
+{{- end }}
     type: ImageChange
 {{- end }}

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -1,0 +1,33 @@
+{{- define "exporters.imagestream_from_image" }}
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .app_name }}
+    app: {{ .app_name }}
+  name: {{ .app_name }}
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - from:
+      kind: DockerImage
+{{- if .image_name }}
+    # .image_name is provided with :tag, .image_tag is ignored here
+    # .image_tag can be specified to tag internal to registry image
+    {{- if contains ":" .image_name }}
+      name: {{ .image_name }}
+    # .image_name is provided without tag
+    {{- else }}
+      name: {{ .image_name }}:{{ .image_tag | default "stable" }}
+    {{- end }}
+{{- else }}
+      name: quay.io/pelorus/{{ .exporter_type }}-exporter:{{ .image_tag | default "stable" }}
+# .image_name
+{{- end }}
+    name: {{ .image_tag | default "stable" }}
+    referencePolicy:
+      type: Local
+# define
+{{- end }}

--- a/charts/pelorus/charts/exporters/templates/exporters.yaml
+++ b/charts/pelorus/charts/exporters/templates/exporters.yaml
@@ -1,7 +1,28 @@
 {{- range $index, $exporter := .Values.instances }}
-  {{ include "exporters.buildconfig" $exporter }}
-  {{ include "exporters.deploymentconfig" $exporter }}
-  {{ include "exporters.imagestream" $exporter }}
-  {{ include "exporters.route" $exporter }}
-  {{ include "exporters.service" $exporter }}
+  # https://hackmd.io/@openshift-mig-eng/rkNC3W8dq
+  {{- if and ($exporter.image_name) (or $exporter.source_ref $exporter.source_url) }}
+    {{- fail "ERROR: image_name configuration can't be used with source_ref or source_url" }}
+  {{- end }}
+  {{- if and ($exporter.image_tag) (or $exporter.source_ref $exporter.source_url) }}
+    {{- fail "ERROR: image_tag configuration can't be used with source_ref or source_url" }}
+  {{- end }}
+  {{- if and $exporter.image_name $exporter.image_tag }}
+    {{- if contains ":" $exporter.image_name }}
+      {{- fail "ERROR: image_tag configuration can't be used with image_name that includes tag e.g. generic-exporter:tag-name" }}
+    {{- end }}
+  {{- end }}
+  {{- if or $exporter.source_ref $exporter.source_url }}
+    {{ include "exporters.buildconfig" $exporter }}
+  {{- end }}
+    {{ include "exporters.deploymentconfig" $exporter }}
+  {{- if or $exporter.source_ref $exporter.source_url }}
+    {{ include "exporters.imagestream" $exporter }}
+  {{- else }}
+    {{- if not $exporter.exporter_type }}
+      {{- fail "ERROR: exporter_type must be provided when using podman image installation method" }}
+    {{- end}}
+    {{ include "exporters.imagestream_from_image" $exporter }}
+  {{- end }}
+    {{ include "exporters.route" $exporter }}
+    {{ include "exporters.service" $exporter }}
 {{- end }}


### PR DESCRIPTION
Fixes #373 , which by default uses "stable" images from quay.io to deploy exporter images.

The below options are per exporter instance, so each exporter may be deployed with different tag/image or method.

User have option to still use git based deployment when:
```
  source_url OR source_ref is specified
```

User also have option to provide image tag different then stable by:
```
  image_tag: <tag name>
```

Or fully qualified image url with or without image_tag, examples:
```
  image_name: quay.io/pelorus/committime-exporter
  image_name: quay.io/pelorus/committime-exporter:latest
```

There are also some pre-conditions to ensure user specified proper values, e.g. using GIT and image deployment at the same time or specifying image tag when the image tag is already part of image_name.

Matrix of possible errors and results:
https://hackmd.io/@openshift-mig-eng/rkNC3W8dq

Depends on #483

@redhat-cop/mdt
