### PR TITLE
Ensure curl backwards compatibility in e2e tests

### DIFF
--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -35,7 +35,13 @@ function download_file_from_url() {
     pushd "${dest_folder}" || exit
       echo "Downloading file: ${url}"
       echo "To: ${dest_folder}/${file_name}"
-      curl --fail-with-body -Lo "${file_name}" "${url}" || exit
+      if curl --fail-with-body --help >/dev/null 2>&1; then
+          curl --fail-with-body -Lo "${file_name}" "${url}" || exit
+      elif type curl; then
+          curl -Lo "${file_name}" "${url}" || exit
+      else
+          wget -O "${file_name}" "${url}" || exit
+      fi
     popd || exit
 }
 


### PR DESCRIPTION
curl prior to v7.76.0 had no --fail-with-body option, this change uses curl without such option. On top of that uses wget in situations where curl is not found.


@redhat-cop/mdt
