### PR TITLE
Make default values.yaml use default configmaps

### DIFF
--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -29,17 +29,13 @@ spec:
       - name: {{ .app_name }}
         imagePullPolicy: Always
         envFrom:
-      {{- if .env_from_configmaps }}
-        {{- range .env_from_configmaps }}
+      {{- range .env_from_configmaps | default (list "default-pelorus-config" "default-deploytime-config") }}
         - configMapRef:
             name: {{ . }}
-        {{- end}}
       {{- end}}
-      {{- if .env_from_secrets }}
-        {{- range .env_from_secrets }}
+      {{- range .env_from_secrets }}
         - secretRef:
             name: {{ . }}
-        {{- end}}
       {{- end}}
         env:
 {{- if .exporter_type }}

--- a/charts/pelorus/charts/exporters/templates/default_configmaps.yaml
+++ b/charts/pelorus/charts/exporters/templates/default_configmaps.yaml
@@ -1,0 +1,21 @@
+# These configmaps are not meant to be edited directly.
+# To configure pelorus, you can create your own copies of these.
+# See the documentation for details:
+# https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-pelorus-config
+data:
+  PELORUS_DEFAULT_KEYWORD: "default"   # default  |  Other ConfigMap values "default" keyword
+  APP_LABEL: "default"                 # app.kubernetes.io/name  |  Deploy and Commit time exporters - label key used to identify applications
+  LOG_LEVEL: "default"                 # INFO  |  Log level, DEBUG, INFO, WARNING or ERROR
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-deploytime-config
+data:
+  PROD_LABEL: "default"    # "" | PROD_LABEL is ignored if NAMESPACES are provided
+  NAMESPACES: "default"    # "" | Restricts the set of namespaces,  comma separated value "myapp-ns-dev,otherapp-ci"

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -20,9 +20,9 @@ exporters:
   instances:
   - app_name: deploytime-exporter
     exporter_type: deploytime
-    env_from_configmaps:
-    - pelorus-config
-    - deploytime-config
+    # env_from_configmaps:
+    # - pelorus-config
+    # - deploytime-config
 
 #  - app_name: failuretime-exporter
 #    exporter_type: failure

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -30,8 +30,6 @@ cd pelorus
 oc create namespace pelorus
 helm install operators charts/operators --namespace pelorus
 # Verify the operators are completely installed before installing the pelorus helm chart
-oc apply -f charts/pelorus/configmaps/pelorus.yaml
-oc apply -f charts/pelorus/configmaps/deploytime.yaml
 helm install pelorus charts/pelorus --namespace pelorus
 ```
 


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Lets a default install work without setting up configmaps first.

## Testing Instructions

1. Uninstall pelorus and any configmaps referenced by it.
2. Install pelorus using the default values.yml in this branch.
3. See if the deploytime exporter deploys correctly.