### PR TITLE
Use PULL_NUMBER in e2e tests scripts

### DIFF
--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -151,6 +151,12 @@ fi
 # From now on, exit if something goes wrong
 set -e
 
+# Check if PULL_NUMBER exists and it's actual number
+if [ ${PULL_NUMBER+x} ] && [[ $PULL_NUMBER =~ ^[0-9]+$ ]]; then
+    echo "Provided PULL_NUMBER: '$PULL_NUMBER'"
+    sed -i "s/source_ref:.*/source_ref: refs\/pull\/${PULL_NUMBER}\/head/" "${DWN_DIR}/ci_values.yaml"
+fi
+
 # Ensure we are in the top-level directory of pelorus project
 pushd "${SCRIPT_DIR}/../"
 


### PR DESCRIPTION
CI has one shell env variable PULL_NUMBER which should be used while running e2e tests.

This change adds such check and ensures the PULL_NUMBER Is actual number before modyfing values.yaml file.

@redhat-cop/mdt
