### PR TITLE
remove oc apply configmaps from ci

### DIFF
--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -167,7 +167,8 @@ fi
 pushd "${SCRIPT_DIR}/../"
 
 # Apply config maps for the exporters
-oc apply -f "charts/pelorus/configmaps"
+# disable for now, as it's divergent from the install instructions.
+# oc apply -f "charts/pelorus/configmaps"
 
 helm install operators charts/operators --namespace pelorus --debug --wait --wait-for-jobs
 


### PR DESCRIPTION
* remove oc apply configmaps from ci because the
documented install does not apply configmaps in a seperate step yet.

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #<issue number> <-- Use this if merging should auto-close an issue

related to #<issue number> <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
