### PR TITLE
Nit change to inform that exporter is ran from image.

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.1
+version: 1.6.2
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -42,6 +42,10 @@ spec:
         - name: APP_FILE
           value: {{ .exporter_type }}/app.py
 {{- end }}
+{{- if and (not .source_ref) (not .source_url) }}
+        - name: PELORUS_IMAGE_TAG
+          value: {{ .app_name }}:{{ .image_tag | default "stable" }}
+{{- end }}
 {{- if .extraEnv }}
 {{ toYaml .extraEnv | indent 8 }}
 {{- end }}

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -40,7 +40,11 @@ def _print_version():
             f"Running {exporter_name} exporter from {repo}, ref {ref} (commit {commit})"
         )
     else:
-        print(f"Running {exporter_name} exporter. No version information found.")
+        image_tag = utils.get_env_var("PELORUS_IMAGE_TAG")
+        if image_tag:
+            print(f"Running {exporter_name} exporter from the image: {image_tag}.")
+        else:
+            print(f"Running {exporter_name} exporter. No version information found.")
 
 
 # region: logging setup


### PR DESCRIPTION
When the exporter is ran from the pre-built image, no OPENSHIFT_BUILT_* env variables are available.
There is also no information accessible from the image itself about the source code from which the image was built.

This change allows to include image name and tag, so we can print this information within exporter.

We also have knowledge about the image sha that we can easily identify the source code for it using standard oc describe commands:

To obtain information about the image, simple use:
```
oc describe pod -n pelorus <exporter_name>

oc describe pod -n pelorus deploytime-exporter
[...]
>     Image:          image-registry.openshift-image-registry.svc:5000/pelorus/deploytime-exporter@sha256:2574fb8ea74e7ceca6033a0bac75b3ca1581c34fc06c6b79bc755cbd9a6e6d15

```

@redhat-cop/mdt
