### PR TITLE
Report resource timestamp as metric timestamp

### DIFF
--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -92,6 +92,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
                     my_metric.image_hash,
                 ],
                 my_metric.commit_timestamp,
+                timestamp=my_metric.commit_timestamp,
             )
             yield commit_metric
 

--- a/exporters/failure/collector_base.py
+++ b/exporters/failure/collector_base.py
@@ -40,13 +40,17 @@ class AbstractFailureCollector(pelorus.AbstractPelorusExporter):
                         "Collected failure_creation_timestamp{ app=%s, issue_number=%s } %s"
                         % (m.labels[0], m.labels[1], m.time_stamp)
                     )
-                    creation_metric.add_metric(m.labels, m.get_value())
+                    creation_metric.add_metric(
+                        m.labels, m.get_value(), timestamp=m.time_stamp
+                    )
                 else:
                     logging.info(
                         "Collected failure_resolution_timestamp{ app=%s, issue_number=%s } %s"
                         % (m.labels[0], m.labels[1], m.time_stamp)
                     )
-                    failure_metric.add_metric(m.labels, m.get_value())
+                    failure_metric.add_metric(
+                        m.labels, m.get_value(), timestamp=m.time_stamp
+                    )
             yield (creation_metric)
             yield (failure_metric)
 


### PR DESCRIPTION
Wes fixed the deploytime issue with this in #497. This just does it for committime and failure.

~~Still need to double check what _type_ it is, as we can't guarantee that the prometheus library will handle non-floats correctly.~~ Wes tried it and said it was good. We can revisit this if there's some type weirdness somewhere.

resolves #532 
resolves #533 

## Testing Instructions

Set up committime and/or failure time exporters, and ensure that the values seen in grafana / prometheus are what you expect.