### PR TITLE
Move default labels from helm pelorus example values.yaml

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.3
+version: 1.6.4
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/templates/thanos-rbac.yaml
+++ b/charts/pelorus/templates/thanos-rbac.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
   {{- with .Values.deployment.labels }}
 {{ toYaml . | indent 4 }}
-  {{- end }}  
+  {{- end }}
+  {{- if not .Values.deployment.labels }}
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: pelorus
+    app.kubernetes.io/version: v0.33.0
+  {{- end }}
   name: {{ .Release.Namespace }}-pelorus-thanos
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -10,12 +10,6 @@ extra_prometheus_hosts:
 # Uncomment this if your cluster serves privately signed certificates
 # custom_ca: true
 
-deployment:
-  labels:
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/name: pelorus
-    app.kubernetes.io/version: v0.33.0
-
 exporters:
   instances:
   - app_name: deploytime-exporter


### PR DESCRIPTION
Change that moves the default labels that are being used in the thanos-rbac.yaml inside that Thanos ClusterRoleBinding yaml file.

This is nothing more then a bit of cleanup for the values.yaml.

@redhat-cop/mdt
