### PR TITLE
Rename GIT_USER and GIT_TOKEN to be consistent across exporters

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.4
+version: 1.6.5
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/configmaps/committime.yaml
+++ b/charts/pelorus/configmaps/committime.yaml
@@ -7,8 +7,8 @@ metadata:
   name: committime-config
   namespace: pelorus
 data:
-  GIT_USER: "default"        # ""  |  User's github username, can be overriden by env_from_secrets
-  GIT_TOKEN: "default"       # ""  |  User's Github API Token, can be overriden by env_from_secrets
+  USER: "default"            # ""  |  User's github username, can be overriden by env_from_secrets
+  TOKEN: "default"           # ""  |  User's Github API Token, can be overriden by env_from_secrets
   GIT_API: "default"         # api.github.com  |  Github Enterprise API FQDN, can be overriden by env_from_secrets
   GIT_PROVIDER: "default"    # github  |  github, gitlab, or bitbucket
   TLS_VERIFY: "default"      # True

--- a/charts/pelorus/secrets/github_example.yaml
+++ b/charts/pelorus/secrets/github_example.yaml
@@ -8,5 +8,5 @@ metadata:
   namespace: pelorus
 type: Opaque
 stringData:
-  GIT_USER: "pelorus@jira.username.io"             # Github Username
-  GIT_TOKEN: "secret_token"                        # Github Token
+  USER: "pelorus@jira.username.io"             # Github Username
+  TOKEN: "secret_token"                        # Github Token

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -116,13 +116,13 @@ Note: The requirement to label the build with `app.kubernetes.io/name=<app_name>
 Create a secret containing your Git username and token.
 
 ```shell
-oc create secret generic github-secret --from-literal=GIT_USER=<username> --from-literal=GIT_TOKEN=<personal access token> -n pelorus
+oc create secret generic github-secret --from-literal=USER=<username> --from-literal=TOKEN=<personal access token> -n pelorus
 ```
 
 Create a secret containing your Git username, token, and API.  An API example is `github.mycompany.com/api/v3`
 
 ```shell
-oc create secret generic github-secret --from-literal=GIT_USER=<username> --from-literal=GIT_TOKEN=<personal access token> --from-literal=GIT_API=<api> -n pelorus
+oc create secret generic github-secret --from-literal=USER=<username> --from-literal=TOKEN=<personal access token> --from-literal=GIT_API=<api> -n pelorus
 ```
 
 #### Instance Config
@@ -145,8 +145,8 @@ This exporter provides several configuration options, passed via `pelorus-config
 
 | Variable | Required | Explanation | Default Value |
 |---|---|---|---|
-| `GIT_USER` | yes | User's github username | unset |
-| `GIT_TOKEN` | yes | User's Github API Token | unset |
+| `USER` | yes | User's github username | unset |
+| `TOKEN` | yes | User's Github API Token | unset |
 | `GIT_API` | no | Github API FQDN.  This allows the override for Github Enterprise users.  Currently only applicable to `github` provider type. | `api.github.com` |
 | `GIT_PROVIDER` | no | Set Git provider type. Can be `github`, `gitlab`, or `bitbucket` | `github` |
 | `LOG_LEVEL` | no | Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR` | `INFO` |

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -221,8 +221,8 @@ Running an exporter on your local machine should follow this process:
 
 3. Set any environment variables required (or desired) for the given exporter (see [Configuring Exporters](Configuration.md#configuring-exporters) to see supported variables).
 
-        export GIT_TOKEN=xxxx
-        export GIT_USER=xxxx
+        export TOKEN=xxxx
+        export USER=xxxx
 
 4. Log in to your OpenShift cluster
 

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -44,11 +44,11 @@ if __name__ == "__main__":
 
     dyn_client = pelorus.utils.get_k8s_client()
 
-    username = pelorus.utils.get_env_var("GIT_USER", "")
-    token = pelorus.utils.get_env_var("GIT_TOKEN", "")
+    username = pelorus.utils.get_env_var("USER", "")
+    token = pelorus.utils.get_env_var("TOKEN", "")
     if not username and not token:
         logging.info(
-            "No GIT_USER and no GIT_TOKEN given. This is okay for public repositories only."
+            "No USER and no TOKEN given. This is okay for public repositories only."
         )
     git_api = pelorus.utils.get_env_var("GIT_API", pelorus.DEFAULT_GIT_API)
     git_provider = pelorus.utils.get_env_var("GIT_PROVIDER", pelorus.DEFAULT_GIT)

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -116,13 +116,17 @@ def missing_configs(vars):
 
 
 def upgrade_legacy_vars():
-    username = utils.get_env_var("GITHUB_USER")
-    token = utils.get_env_var("GITHUB_TOKEN")
+    github_user = utils.get_env_var("GITHUB_USER")
+    github_token = utils.get_env_var("GITHUB_TOKEN")
+    git_username = utils.get_env_var("GIT_USER")
+    git_token = utils.get_env_var("GIT_TOKEN")
     api = utils.get_env_var("GITHUB_API", DEFAULT_GIT_API)
-    if username and not utils.get_env_var("GIT_USER"):
-        os.environ["GIT_USER"] = username
-    if token and not utils.get_env_var("GIT_TOKEN"):
-        os.environ["GIT_TOKEN"] = token
+    if not utils.get_env_var("USER"):
+        if git_username or github_user:
+            os.environ["USER"] = git_username or github_user
+    if not utils.get_env_var("TOKEN"):
+        if git_token or github_token:
+            os.environ["TOKEN"] = git_token or github_token
     if api and not utils.get_env_var("GIT_API"):
         os.environ["GIT_API"] = api
 

--- a/exporters/tests/test_pelorus.py
+++ b/exporters/tests/test_pelorus.py
@@ -86,6 +86,8 @@ def unset_envs():
         "GITHUB_USER",
         "GITHUB_TOKEN",
         "GITHUB_API",
+        "USER",
+        "TOKEN",
     ]
 
     for var in vars:
@@ -95,15 +97,18 @@ def unset_envs():
 
 
 @pytest.mark.parametrize(
-    "git_user,git_token,git_api,github_user,github_token,github_api",
+    "git_user,git_token,git_api,github_user,github_token,github_api,user,token",
     [
-        (None, None, None, "goodU", "goodT", "goodA"),
-        ("goodU", "goodT", "goodA", None, None, None),
-        ("goodU", "goodT", "goodA", "badU", "badT", "badA"),
+        (None, None, None, "goodU", "goodT", "goodA", None, None),
+        ("goodU", "goodT", "goodA", None, None, None, None, None),
+        ("goodU", "goodT", "goodA", "badU", "badT", "badA", None, None),
+        (None, None, "goodA", None, None, None, "goodU", "goodT"),
+        ("badU", "badT", "goodA", None, None, None, "goodU", "goodT"),
+        (None, None, "goodA", "badU", "badT", None, "goodU", "goodT"),
     ],
 )
 def test_ugprade_legacy_vars(
-    git_user, git_token, git_api, github_user, github_token, github_api
+    git_user, git_token, git_api, github_user, github_token, github_api, user, token
 ):
     unset_envs()
     if git_user:
@@ -118,8 +123,12 @@ def test_ugprade_legacy_vars(
         os.environ["GITHUB_TOKEN"] = github_token
     if github_api:
         os.environ["GITHUB_API"] = github_api
+    if user:
+        os.environ["USER"] = user
+    if token:
+        os.environ["TOKEN"] = token
     pelorus.upgrade_legacy_vars()
-    assert os.environ["GIT_USER"] == "goodU"
-    assert os.environ["GIT_TOKEN"] == "goodT"
+    assert os.environ["USER"] == "goodU"
+    assert os.environ["TOKEN"] == "goodT"
     assert os.environ["GIT_API"] == "goodA"
     unset_envs()

--- a/labs/consultant/03-Exporters.md
+++ b/labs/consultant/03-Exporters.md
@@ -61,8 +61,8 @@ Confirm you have a [Github Personal Access Token](https://help.github.com/en/git
 Use the token information and the command below to generate a Github secret:
 
     oc create secret generic github-secret \
-      --from-literal=GIT_USER=<username> \
-      --from-literal=GIT_TOKEN=<personal access token> -n pelorus
+      --from-literal=USER=<username> \
+      --from-literal=TOKEN=<personal access token> -n pelorus
 
 Update the `values.yaml` and then upgrade our helm installation of Pelorus to add an additional exporter to the `instances` list:
 

--- a/mocks/README.md
+++ b/mocks/README.md
@@ -27,8 +27,8 @@ Mock started at https://localhost:3000 (pid: 0, name: mockoon-openshift)
 Set up your envs in order to use the mock server.
 
 ```sh
-export GIT_USER=gituser
-export GIT_TOKEN=gittoken
+export USER=gituser
+export TOKEN=gittoken
 export GIT_API=localhost:3000
 export LOG_LEVEL=DEBUG
 export NAMESPACES=basic-nginx-build,basic-nginx-dev,basic-nginx-stage,basic-nginx-prod

--- a/samples/todolist_commit_deploy.md
+++ b/samples/todolist_commit_deploy.md
@@ -118,7 +118,7 @@ To develop a Pelorus exporter please fork the Pelorus git source and branch
 2. If you have forked Pelorus to a private git repository
 Create a GitHub Personal Access Token and store it as a secret in Openshift:
 ```
-oc create secret generic github-secret --from-literal=GIT_USER=<username> --from-literal=GIT_TOKEN=<personal access token> --namespace pelorus
+oc create secret generic github-secret --from-literal=USER=<username> --from-literal=TOKEN=<personal access token> --namespace pelorus
 ```
 
 Ensure you configure the exporters in /var/tmp/values.yml to use the github-secret:

--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -179,11 +179,11 @@ if [ "${ENABLE_FAIL_EXP}" == true ]; then
     if [[ $secret_present = 0 ]]; then
         echo "The github-secret was found"
         GITHUB_SECRET_CONFIGURED=true
-    # if GIT_USER and GIT_TOKEN are set
-    elif [[ -z ${!GIT_USER} && -z ${!GIT_TOKEN} ]]; then
+    # if TOKEN are set
+    elif [[ -n ${TOKEN} ]]; then
         # turn off debug if enabled
         if [[ $- == *x* ]]; then set +x; export debug_set_off=true; fi
-        oc -n $PELORUS_NAMESPACE create secret generic github-secret --from-literal=GITHUB_USER="$GIT_USER" --from-literal=TOKEN="$GIT_TOKEN"
+        oc -n $PELORUS_NAMESPACE create secret generic github-secret --from-literal=TOKEN="$TOKEN"
         # if debug was turned off, turn it back on.
         if [[ $debug_set_off == true ]]; then set -x; fi
         GITHUB_SECRET_CONFIGURED=true


### PR DESCRIPTION
Change which renames GIT_USER to USER and GIT_TOKEN to TOKEN, however ensures backwards compatibility with the old value names.

This makes all the exporters use same USER and TOKEN value names rather than failure using USER and commit time using GIT_USER.

@redhat-cop/mdt
