### PR TITLE
Update grafana to the newest available version from v4 channel

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.0
+version: 1.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/operators/templates/grafana-subscription.yaml
+++ b/charts/operators/templates/grafana-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v4.2.0
+  startingCSV: grafana-operator.v4.4.1


### PR DESCRIPTION
Grafana operator is installed from the community-operators that is available at:

https://operatorhub.io/operator/grafana-operator

Change to bump the version to the newest available version from the v4 channel which we are using.

@redhat-cop/mdt
