### PR TITLE
only change values.yml ref: master to PR if repo is pelorus

### DIFF
--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -213,10 +213,13 @@ fi
 # From now on, exit if something goes wrong
 set -e
 
-# Check if PULL_NUMBER exists and it's actual number
-if [ ${PULL_NUMBER+x} ] && [[ $PULL_NUMBER =~ ^[0-9]+$ ]]; then
-    echo "Provided PULL_NUMBER: '$PULL_NUMBER'"
-    sed -i "s/source_ref:.*/source_ref: refs\/pull\/${PULL_NUMBER}\/head/" "${DWN_DIR}/ci_values.yaml"
+# If this is a pull request from pelorus
+if [ ${REPO_NAME} == "pelorus" ]; then
+    # Check if PULL_NUMBER exists and it's actual number
+    if [ ${PULL_NUMBER+x} ] && [[ $PULL_NUMBER =~ ^[0-9]+$ ]]; then
+        echo "Provided PULL_NUMBER: '$PULL_NUMBER'"
+        sed -i "s/source_ref:.*/source_ref: refs\/pull\/${PULL_NUMBER}\/head/" "${DWN_DIR}/ci_values.yaml"
+    fi
 fi
 
 # Ensure we are in the top-level directory of pelorus project


### PR DESCRIPTION
when testing w/ openshift/release things were failing because the
change ref was from release and not pelorus.  Causing:
Cloning "https://github.com/konveyor/pelorus.git" ...
error: fatal: couldn't find remote ref refs/pull/29693/head

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #<issue number> <-- Use this if merging should auto-close an issue

related to #<issue number> <-- Use this if it shouldn't

## Testing Instructions

Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
