### PR TITLE
Disable helm checksum checking as it's flake in CI

### DIFF
--- a/scripts/install_dev_tools
+++ b/scripts/install_dev_tools
@@ -142,7 +142,7 @@ function install_helm() {
     fi
 
     chmod +x "${helm_install_script}" 
-    HELM_INSTALL_DIR="${dest_dir}" USE_SUDO=false "${helm_install_script}"
+    HELM_INSTALL_DIR="${dest_dir}" USE_SUDO=false VERIFY_CHECKSUM=false "${helm_install_script}"
 }
 
 # Function to check if particular cli binary should be installed


### PR DESCRIPTION
Disabling helm checksum checking may improve pass ratio in the CI.


@redhat-cop/mdt
