### PR TITLE
Unified config management and parameter logging: implementation before integration

### DIFF
--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -28,8 +28,12 @@ def _print_version():
     """
     import __main__
 
-    # name of dir above app.py
-    exporter_name = pathlib.PurePath(__main__.__file__).parent.name
+    file = getattr(__main__, "__file__", None)
+    if file:
+        # name of dir above app.py
+        exporter_name = pathlib.PurePath(file).parent.name
+    else:
+        exporter_name = "INTERPRETER"
 
     repo, ref, commit = (
         utils.get_env_var(f"OPENSHIFT_BUILD_{var.upper()}")

--- a/exporters/pelorus/config/DEVELOPING.md
+++ b/exporters/pelorus/config/DEVELOPING.md
@@ -1,0 +1,77 @@
+# What is `pelorus.config`?
+
+A declarative way to load configuration from environment variables, and log that configuration properly.
+
+See [the README](./README.md) for more details.
+
+# How does it work?
+
+`attrs` lets you declaratively create python classes with minimal boilerplate.
+This concept was so popular a similar tool was added to python in the `dataclasses` module.
+
+It also lets you easily do some metaprogramming: you can inspect each field of the class,
+what type it was declared as, its name, and any optional metadata attached to it.
+
+These factors combined make it easy to look for environment variables of the same name,
+and know how to convert the type in a consistent way.
+
+Knowing the name also makes it possible to guess what should be logged and what shouldn't be (credentials, etc).
+
+Since you can pass metadata per field, you can configure the above behaviors.
+
+# Why attrs instead of dataclasses?
+
+attrs has some very attractive additional features over dataclasses.
+
+Converters allow devs to customize how we convert configuration,
+in case there's something more complex that needs to be handled,
+or they need to deviate from the standard way of doing things.
+
+Validators let devs... validate.
+
+# Why load env vars yourself instead of using attrs's default factories?
+
+Suppose the first required env var is missing.
+The user makes a change, re-deploys the configuration,
+waits for the pods to re-deploy...
+only to find that they missed the second required env var.
+
+Errors that can be reported in parallel absolutely should be reported in parallel.
+
+This idea (in the abstract) is even acknowledged by python itself
+in the upcoming "exception groups" feature.
+
+# What is `NOTHING`?
+
+In python, it's common to set a parameter's default to `None` to see if it wasn't passed anything.
+
+However, there are cases where `None` is a perfectly valid value to pass,
+so you can't rely on it meaning "no parameter was passed".
+
+There is a common python idiom of using a "sentinel value",
+usually made with something like `SENTINEL = object()`.
+
+As for why it's re-exported in its own file, that's so typing tools such as mypy and pyright
+can use it in a type signature, making sure the NOTHING case is handled.
+
+This will be unnecessary if [the PR changing the typing](https://github.com/python-attrs/attrs/pull/983) is merged.
+
+# Why are there so many type annotations? What are `.pyi` files?
+
+mypy and pyright tools will type check python code.
+They can catch _so many_ errors that would otherwise happen at runtime,
+and provide even more helpful code completion / inline documentation support.
+There's a reason why Guido Van Rossum is working so heavily on mypy!
+
+`.pyi` files are "type stubs": they are checked for type information by typing tools,
+but ignored at runtime.
+
+We only use them for two things.
+
+First, to use `NOTHING` as its own type (see above).
+
+Secondly, for `attrs.Factory`.
+Because a class's fields are marked as their runtime type (e.g. `str`, `bool`),
+but `field` returns an `attrs.Attribute`, their type stubs have to lie about the
+return value of both `field` and `attrs.Factory` to keep the type checker happy.
+We undo that.

--- a/exporters/pelorus/config/README.md
+++ b/exporters/pelorus/config/README.md
@@ -1,0 +1,231 @@
+# pelorus.config
+
+A declarative way to load configuration from environment variables, and log that configuration properly.
+
+Configuration needs to be consistent, and easy to get right.
+Configuration should be logged in order to make debugging easier.
+However, accidentally logging sensitive information (API credentials, etc.) must be hard.
+
+This module handles the above goals by using `attrs`.
+
+# Background
+
+When it comes to exporter configuration and startup, we've experienced the following issues:
+- It's always been ad-hoc and repetitious.
+- As env vars evolve, we had to keep reassigning old ones for backwards compatibility.
+- Configuration was not abstracted away from its source--
+  changing to a config file instead of env vars would take a lot of work.
+- Converting from strings to things such as lists was error-prone.
+- Logging wasn't always done, leading to tons of time lost debugging.
+
+# Tutorial: Basic Usage
+
+```python
+from pelorus.config import load_and_log
+
+config = load_and_log(ConfigClass)
+```
+
+`load_and_log` inspects a class set up by `attrs`,
+loading values from the environment, and logging what was found.
+
+It uses some common-sense defaults:
+- an attribute's name in uppercase is the environment variable's name.
+- attributes whose name contains something implying sensitive information
+  (e.g. credentials end up in a variable called `token`) have their values redacted.
+- private fields (starting with any number of underscores) are not logged at all.
+
+What does `ConfigClass` look like?
+
+```python
+from attrs import define
+
+@define(kw_only=True)
+class ConfigClass:
+    username: str = "GVR"
+    password: str
+```
+
+`load_and_log` will do the following:
+
+1. Look for the environment variable `USERNAME`. If missing, it will be set to `GVR`.
+2. Look for the environment variable `PASSWORD`.
+3. Log the config class's name, the values obtained, and where the values came from:
+  1. `username=GVR, default value; USERNAME was not set`
+  2. `password=REDACTED, from env var PASSWORD`
+4. Call `MyConfiguration(...)`:
+  If `USERNAME` is missing, it will default to `GVR`.
+  If `PASSWORD` is missing, a MissingConfigDataError will be thrown.
+
+`kw_only=True` is requires so we can have a mandatory field after one with a default.
+We recommend its use even if that doesn't apply to you.
+
+
+# Tutorial: Advanced Usage
+
+What if you need to:
+- [Use a different environment variable name? Or check multiple env vars, for backwards compatibility?](#environment-variables)
+- [Skip or recact a field that wouldn't normally be? Or the opposite?](#logging)
+- [Use a datatype that isn't a string? Have a default for that when it's mutable?](#converters)
+- [Use a value that isn't easily loaded from the environment?](#the-other-dict)
+
+## Metadata
+
+`attrs` lets you attach metadata to any field with just a simple dictionary.
+
+We expose helpers for customizing log and environent variable lookup .
+
+### Environment Variables
+
+```python
+from attrs import define, field
+from pelorus.config import env_vars
+
+@define(kw_only=True)
+class EnvVarExample:
+    different_variable_name: str = field(default="foo", metadata=env_vars("DIFF_VAR"))
+    fallback_var_names: str = field(metadata=env_vars("NEW_VAR", "LEGACY_VAR"))
+```
+
+Loading this will check `DIFF_VAR` for the first field, instead of `DIFFERENT_VARIABLE_NAME`. It still has a default.
+
+`fallback_var_names` will be set to whatever the earliest set env var is from the listed ones. e.g. if both are set, the value from `NEW_VAR` will be used.
+If neither are set, an error will be logged and thrown.
+
+### Logging
+
+```python
+from attrs import define, field
+from pelorus.config import log, LOG, SKIP, REDACT
+
+@define(kw_only=True)
+class LogExample:
+    test_to_pass: str = field(metadata=log(LOG))
+    _dont_skip_me: str = field(metadata=log(LOG))
+    i_am_sensitive: str = field(metadata=log(REDACT))
+    do_skip_me: str = field(metadata=log(SKIP))
+```
+
+The value of `test_to_pass` would normally be redacted, because `pass` is in the field name. With the log metadata, that behavior is overridden.
+`_dont_skip_me` would normally not appear in the logs at all because it is "private", but that is overridden.
+`i_am_sensitive` _would_ normally appear in the logs, because there's no member of `REDACT_WORDS` in it. We have forced it to be redacted.
+`do_skip_me` has been manually set to not appear in the logs at all.
+
+
+### Combining metadata
+
+What if you need to customize logging and env var metadata?
+The metadata helpers expose metadata as a dict for convenience--
+this means you can combine them with the dict union operator `|`.
+
+```python
+from attrs import define, field
+from pelorus.config import log, REDACT, env_vars
+@define
+class CombinedClass:
+    foo: str = field(metadata=log(REDACT) | env_vars("BAR"))
+```
+
+## Converters
+
+`attrs` lets incoming values be automatically converted.
+Since we load from environment variables, conversion is
+necessary if the desired value's type is not a string!
+
+We offer a helper for the common case, where a collection
+takes a comma separated list of (whitespace-stripped) strings:
+
+```python
+from attrs import define, field
+from attrs.converters import to_bool
+from pelorus.config.converters import comma_separated
+
+@define
+class GiveMeCollections:
+    namespaces: set[str] = field(factory=set, converter=comma_separated(set))
+    foo: list[str] = field(factory=list, converter=comma_separated(list))
+    tls_verify: bool = field(default="yes", converter=to_bool)
+```
+
+Note that we use `factory` instead of `default` for the collections.
+This is because of python's "mutable defaults" gotcha:
+if we set `default` to `[]`, _every instance of the class would use the same list!_
+
+Also note how `tls_verify` uses a string default.
+Even defaults go through converters.
+Well-behaved converters will handle when their inputs are the same desired type,
+and pass them through as-is. This is true for both to_bool and comma_separated,
+so we could have written `default=True` if we wanted to.
+
+`attrs` has some more converters defined, and even ways to compose them.
+See their docs for details.
+
+## The `other` dict
+
+What if you have some data type that couldn't be loaded from the environment
+(in our most common case, an openshift client)?
+
+That can be passed in with `load_and_log`'s `other` dict.
+
+```python
+from attrs import define, field
+from pelorus.config import no_env_vars
+
+@define
+class UsesOpenshift:
+    client: object = field(metadata=no_env_vars())
+
+_ = load_and_log(UsesOpenshift, other=dict(client=SOME_CLIENT_HERE))
+```
+
+Fields meant to be provided through `other` are not logged.
+You can override this behavior.
+
+## Customizing Init
+
+Although `attrs` will generate an `__init__` for the class,
+sometimes you need to deviate from this behavior.
+Maybe you have a field that you need to create based on two other fields?
+Or something to log after being set up?
+Or need to validate the whole thing, not just a field or two?
+
+See [attrs's docs on hooking into init](https://www.attrs.org/en/stable/init.html#hooking-yourself-into-initialization)
+to learn how.
+
+As a simple example:
+
+```python
+from attrs import define, field
+from requests import Session
+
+@define
+class RequestsUser:
+    api_user: str
+    token: str
+
+    _session: Session = field(factory=Session, init=False)
+
+    def __attrs_post_init__(self):
+        self._session.auth = (self.api_user, self.api_token)
+```
+
+Note that we still declare the field. This is nice for type checking tools,
+but is also necessary because attrs uses `__slots__` unless told not to
+in `define`'s arguments.
+
+## Other attrs features
+
+See the [`attrs` docs](https://www.attrs.org/en/stable/overview.html) to learn more
+about its other features, including:
+- validators
+- frozen instances (a good idea!)
+
+# Reference
+
+See the pydoc for each item for more details.
+
+You can also see the [unit test](../../tests/test_config.py) for more examples.
+
+# Development
+
+See [DEVELOPING.md](./DEVELOPING.md) for details.

--- a/exporters/pelorus/config/__init__.py
+++ b/exporters/pelorus/config/__init__.py
@@ -1,0 +1,165 @@
+"""
+A declarative way to load configuration from environment variables, and log that configuration properly.
+
+See the [README](./README.md) file for documentation.
+See [DEVELOPING](./DEVELOPING.md) for implementation details / dev docs.
+"""
+
+import logging
+import os
+from typing import Any, Generic, Mapping, Optional, Type, TypeVar
+
+import attrs
+
+from pelorus.config.loading import (
+    MissingConfigDataError,
+    MissingDataError,
+    ValueWithSource,
+    _EnvFinder,
+    env_vars,
+    no_env_vars,
+)
+from pelorus.config.log import LOG, REDACT, SKIP, Log, log
+from pelorus.utils import DEFAULT_VAR_KEYWORD
+
+
+def _prepare_kwargs(results: dict[str, Any]):
+    """
+    Handle the following cases:
+
+    Attrs removes underscores from field names for the init param names,
+    so we need to change the field names for the kwargs.
+
+    We wrap values in classes describing where they came from, so we need to unpack those.
+    """
+    for k, v in results.items():
+        if isinstance(v, ValueWithSource):
+            value = v.value
+        else:
+            value = v
+
+        yield k.lstrip("_"), value
+
+
+ConfigClass = TypeVar("ConfigClass")
+
+
+@attrs.frozen
+class _LoggingLoader(Generic[ConfigClass]):
+    """
+    Load values for the given class from the environment (overridden by `other`),
+    logging their values and reporting errors, before instantiating the class.
+    """
+
+    cls: Type[ConfigClass]
+    other: dict[str, Any]
+    env: Mapping[str, str]
+    default_keyword: str
+    logger: logging.Logger
+
+    results: dict[str, Any] = attrs.field(factory=dict, init=False)
+    errors: list[MissingDataError] = attrs.field(factory=list, init=False)
+
+    def _load(self):
+        for field in attrs.fields(self.cls):
+            if not field.init:
+                # field does not get set during instance creation,
+                # so don't load it.
+                continue
+
+            name = field.name
+
+            value = _EnvFinder.get_value(
+                field, self.env, self.other, self.default_keyword
+            )
+
+            if isinstance(value, MissingDataError):
+                self.results[name] = value
+                self.errors.append(value)
+            else:
+                self.results[name] = value
+
+    def _log(self):
+        if self.errors:
+            log_with_level = self.logger.error
+            log_with_level(
+                "While loading config %s, errors were encountered. All values:",
+                self.cls.__name__,
+            )
+        else:
+            log_with_level = self.logger.info
+            log_with_level("Loading %s, inputs below:", self.cls.__name__)
+
+        for field, value in self.results.items():
+            if isinstance(value, ValueWithSource):
+                if value.log is SKIP:
+                    continue
+
+                source = value.source()
+
+                if value.log is REDACT:
+                    value = "REDACTED"
+                else:
+                    value = repr(value.value)
+
+                log_with_level("%s=%s, %s", field, value, source)
+            elif isinstance(value, MissingDataError):
+                log_with_level("%s=ERROR: %s", field, value)
+
+    def load_and_log(self) -> ConfigClass:
+        self._load()
+        self._log()
+
+        if self.errors:
+            raise MissingConfigDataError(self.cls.__name__, self.errors)
+
+        kwargs = dict(_prepare_kwargs(self.results))
+
+        return self.cls(**kwargs)
+
+
+def load_and_log(
+    cls: Type[ConfigClass],
+    other: dict[str, Any] = {},
+    *,
+    env: Mapping[str, str] = os.environ,
+    default_keyword: Optional[str] = None,
+    logger: logging.Logger = logging.getLogger(__name__),
+) -> ConfigClass:
+    """
+    Load values for the given class from the environment,
+    logging their values and reporting errors, before instantiating the class.
+
+    `other` is used for variables that can't be loaded from the environment,
+    or to override the environment and skip checking it for their values.
+    The names in `other` are the _field name_, not the env var name.
+
+    env defaults to os.environ, and can be overridden for testing.
+
+    default_keyword may be overridden. If the default of `None`,
+    the env var of `PELORUS_DEFAULT_KEYWORD` is used, falling back to "default".
+    This is looked up from `env`, not necessarily os.environ.
+
+    logger defaults to the logger for `pelorus.config`, but may be overridden.
+    """
+    if default_keyword is None:
+        default = env.get("PELORUS_DEFAULT_KEYWORD", DEFAULT_VAR_KEYWORD)
+    else:
+        default = default_keyword
+
+    loader = _LoggingLoader(
+        cls, other=other, env=env, default_keyword=default, logger=logger
+    )
+    return loader.load_and_log()
+
+
+__all__ = [
+    "load_and_log",
+    "log",
+    "LOG",
+    "Log",
+    "SKIP",
+    "REDACT",
+    "env_vars",
+    "no_env_vars",
+]

--- a/exporters/pelorus/config/_attrs_compat.py
+++ b/exporters/pelorus/config/_attrs_compat.py
@@ -1,0 +1,9 @@
+"""
+Re-exports attrs.NOTHING with fixed typing,
+at least until [PR 983](https://github.com/python-attrs/attrs/pull/983) lands.
+"""
+import attrs
+
+NOTHING = attrs.NOTHING
+
+Factory = attrs.Factory

--- a/exporters/pelorus/config/_attrs_compat.pyi
+++ b/exporters/pelorus/config/_attrs_compat.pyi
@@ -1,0 +1,19 @@
+# override's attrs.NOTHING's type in a way that's nicer for type checking.
+import enum
+from typing import Callable, Generic, TypeVar, Union
+
+class _NothingType(enum.Enum):
+    NOTHING = enum.auto()
+
+NOTHING = _NothingType.NOTHING
+
+DefaultType = TypeVar("DefaultType")
+
+class Factory(Generic[DefaultType]):
+    def __init__(
+        self,
+        factory: Callable[[], DefaultType],
+        takes_self=False,
+    ): ...
+    factory: Callable[[], DefaultType]
+    takes_self: bool

--- a/exporters/pelorus/config/common.py
+++ b/exporters/pelorus/config/common.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+Metadata = dict[str, Any]
+"""
+A bit of metadata is a dict.
+In pelorus.config, we combine them with the union operator:
+metadata1() | metadata2()
+"""

--- a/exporters/pelorus/config/converters.py
+++ b/exporters/pelorus/config/converters.py
@@ -1,0 +1,34 @@
+"""
+Converters to augment `attrs.converters`,
+and tools to integrate them with our config system.
+"""
+from functools import partial
+from typing import Callable, Collection, Iterator, TypeVar, Union
+
+CollectionType = TypeVar("CollectionType", bound=Collection[str])
+
+
+def comma_separated(
+    collection: Callable[[Iterator[str]], CollectionType]
+) -> Callable[[Union[str, CollectionType]], CollectionType]:
+    """
+    Returns a converter for the collection that will
+    split a comma-separated string, stripping whitespace from each element.
+
+    If a string is not given, it is assumed to be the target
+    collection type and is returned as-is. (Useful for testing.)
+    """
+    return partial(_comma_separated_collection, collection)
+
+
+def _comma_separated_collection(
+    collection: Callable[[Iterator[str]], CollectionType],
+    val: Union[str, CollectionType],
+) -> CollectionType:
+    if isinstance(val, str):
+        return collection(part.strip() for part in val.split(","))
+    else:
+        return val
+
+
+__all__ = ["comma_separated"]

--- a/exporters/pelorus/config/loading.py
+++ b/exporters/pelorus/config/loading.py
@@ -1,0 +1,258 @@
+from typing import Any, Collection, Literal, Mapping, Optional, Sequence, Union
+
+import attrs
+from attrs import Attribute, frozen
+
+from pelorus.config._attrs_compat import NOTHING, Factory
+from pelorus.config.common import Metadata
+from pelorus.config.log import SKIP, Log, _get_log_meta, _should_log
+
+_ENV_LOOKUPS_KEY = "__pelorus_config_env_vars"
+
+
+def env_vars(*lookups: str) -> Metadata:
+    """
+    Each environment variable listed will be queried until a value is found.
+    """
+    return {_ENV_LOOKUPS_KEY: lookups}
+
+
+def no_env_vars() -> Metadata:
+    """
+    This field should not be loaded from the environment.
+    It will have to be passed through `other`.
+    """
+    return {_ENV_LOOKUPS_KEY: tuple()}
+
+
+# region: errors
+class MissingDataError(Exception):
+    """
+    Parent error for any data missing during loading.
+    """
+
+    pass
+
+
+@frozen
+class MissingVariable(MissingDataError):
+    """
+    A required variable was missing.
+    """
+
+    name: str
+    env_lookups: Sequence[str]
+
+    def __str__(self):
+        if len(self.env_lookups) == 1:
+            env_lookup_str = f"env var {self.env_lookups[0]}"
+        else:
+            env_lookup_str = "any of " + ",".join(self.env_lookups)
+
+        return f"{self.name} was not found in {env_lookup_str}"
+
+
+@frozen
+class MissingDefault(MissingDataError):
+    """
+    A variable was set to "default" but there was no default set.
+    """
+
+    name: str
+    var_containing_default: str
+    default_keyword: str
+
+    def __str__(self):
+        return (
+            f"{self.name} was set to {self.default_keyword} "
+            f"in env var {self.var_containing_default} but there was no default set"
+        )
+
+
+@frozen
+class MissingOther(MissingDataError):
+    """
+    A variable had environment lookups disabled, but was not passed in `other`.
+    """
+
+    name: str
+
+    def __str__(self):
+        return f"{self.name} had environment lookups disabled, but was not passed in to `load`'s `other` dict."
+
+
+class MissingConfigDataError(Exception):
+    """
+    Collects all missing env var issues into one error.
+    """
+
+    def __init__(self, config_class: str, missing: Collection[MissingDataError]):
+        super().__init__()
+        self.config_class = config_class
+        self.missing = missing
+
+    def __str__(self):
+        return f"Config for {self.config_class} is missing data: " + "\n".join(
+            str(x) for x in self.missing
+        )
+
+
+# endregion
+
+# region: successes
+
+
+@frozen
+class ValueWithSource:
+    """
+    The result of a variable / value lookup, with information about how the value was obtained.
+    Also notes the field's log status.
+    """
+
+    value: Any
+    log: Log = attrs.field(kw_only=True)
+
+    def source(self) -> str:
+        ...
+
+
+@frozen
+class FoundEnvVar(ValueWithSource):
+    "Found it in an env var"
+    env_name: str
+
+    def source(self):
+        return f"from env var {self.env_name}"
+
+
+@frozen
+class UnsetEnvVar(ValueWithSource):
+    "No env var, came from attrs"
+    env_lookups: tuple[str]
+
+    def source(self):
+        if len(self.env_lookups) == 1:
+            return f"default value; {self.env_lookups[0]} was not set"
+        else:
+            return "default value; none of " + ", ".join(self.env_lookups) + " were set"
+
+
+@frozen
+class DefaultSetEnvVar(ValueWithSource):
+    "Env var was set to default keyword"
+    env_name: str
+    default_keyword: str
+
+    def source(self):
+        return f"default value ({self.env_name} set to {self.default_keyword})"
+
+
+@frozen
+class OtherVar(ValueWithSource):
+    "Value came from `other` dict"
+
+    def source(self):
+        return "passed in from `other` dict"
+
+
+# endregion
+
+
+@frozen
+class _EnvFinder:
+    "Load from environment or get default"
+    field: Attribute
+    env: Mapping[str, str]
+    env_lookups: tuple[str]
+    default_keyword: str
+    other: Mapping[str, Any]
+
+    @property
+    def name(self):
+        """
+        Field name.
+        """
+        return self.field.name
+
+    def _first_env_match(self) -> Optional[str]:
+        """
+        Return the _name_ of the first present env var.
+        Returns `None` if none were present.
+        """
+        for name in self.env_lookups:
+            if name in self.env:
+                return name
+        return None
+
+    def _get_default(self) -> Union[Any, Literal[NOTHING]]:
+        """
+        Get the default value for this field, invoking the attrs.Factory if necessary.
+        Returns `NOTHING` if there was no default defined.
+
+        """
+        default = self.field.default
+        if isinstance(default, Factory):
+            if default.takes_self:
+                raise ValueError(
+                    "Factories used for config loading cannot use takes_self"
+                )
+            return default.factory()
+        else:
+            return default
+
+    def _value_or_default(self) -> Union[ValueWithSource, MissingDataError]:
+        """
+        Get the value wrapped with information about where it came from,
+        or return the descriptive error for its absence.
+        """
+        if self.name in self.other:
+            return OtherVar(
+                self.other[self.name], log=_get_log_meta(self.field.metadata) or SKIP
+            )
+        elif not self.env_lookups:
+            # should have been in other but was not.
+            return MissingOther(self.name)
+
+        env_name = self._first_env_match()
+
+        if env_name is None:
+            value = self._get_default()
+            if value is NOTHING:
+                return MissingVariable(self.name, self.env_lookups)
+            else:
+                return UnsetEnvVar(
+                    value, env_lookups=self.env_lookups, log=_should_log(self.field)
+                )
+
+        value = self.env[env_name]
+        if value == self.default_keyword:
+            value = self._get_default()
+            if value is NOTHING:
+                return MissingDefault(self.name, env_name, self.default_keyword)
+            else:
+                return DefaultSetEnvVar(
+                    env_name=env_name,
+                    value=value,
+                    default_keyword=self.default_keyword,
+                    log=_should_log(self.field),
+                )
+
+        return FoundEnvVar(env_name=env_name, value=value, log=_should_log(self.field))
+
+    @classmethod
+    def get_value(
+        cls,
+        field: Attribute,
+        env: Mapping[str, str],
+        other: Mapping[str, Any],
+        default_keyword: str,
+    ) -> Union[ValueWithSource, MissingDataError]:
+        """
+        Loads the value from the environment, handling various default-fallback scenarios.
+        """
+        if _ENV_LOOKUPS_KEY in field.metadata:
+            env_lookups = field.metadata[_ENV_LOOKUPS_KEY]
+        else:
+            env_lookups = (field.name.upper(),)
+
+        return cls(field, env, env_lookups, default_keyword, other)._value_or_default()

--- a/exporters/pelorus/config/log.py
+++ b/exporters/pelorus/config/log.py
@@ -1,0 +1,67 @@
+import enum
+from typing import Any, Mapping, Optional
+
+from attrs import Attribute
+
+from pelorus.config.common import Metadata
+
+REDACT_WORDS = {"pass", "token", "key", "cred", "secret", "auth"}
+"""
+Variables containing these words are not logged by default, nor are attributes starting with an underscore.
+"""
+
+_SHOULD_LOG = "__pelorus_config_log"
+
+
+class Log(enum.Enum):
+    LOG = enum.auto()
+    """
+    The field's key and value should be logged.
+    """
+    REDACT = enum.auto()
+    """
+    The field's key should be logged, and the value replaced by `REDACTED`.
+    """
+    SKIP = enum.auto()
+    """
+    The field will be skipped from logging entirely.
+    """
+
+
+LOG = Log.LOG
+REDACT = Log.REDACT
+SKIP = Log.SKIP
+
+
+def log(should: Log) -> Metadata:
+    """
+    Configure a field to be explicitly logged, redacted, or skipped.
+    """
+    return {_SHOULD_LOG: should}
+
+
+def _get_log_meta(meta: Mapping[str, Any]) -> Optional[Log]:
+    return meta.get(_SHOULD_LOG)
+
+
+def _should_log(field: Attribute) -> Log:
+    """
+    A field should NOT be logged if it explicitly marked as such,
+    or contains a word that implies it is sensitive (members of REDACT_WORDS).
+    """
+    should_log = _get_log_meta(field.metadata)
+    if should_log is not None:
+        return should_log
+
+    is_private = field.name.startswith("_")
+    if is_private:
+        return Log.SKIP
+
+    should_be_redacted = any(word in field.name.lower() for word in REDACT_WORDS)
+    if should_be_redacted:
+        return Log.REDACT
+
+    return Log.LOG
+
+
+__all__ = ["Log", "REDACT_WORDS", "log", "LOG", "REDACT", "SKIP"]

--- a/exporters/tests/test_config.py
+++ b/exporters/tests/test_config.py
@@ -1,0 +1,133 @@
+from typing import Optional
+
+import pytest
+from attrs import define, field
+
+from pelorus.config import load_and_log
+from pelorus.config.converters import comma_separated
+from pelorus.config.loading import env_vars, no_env_vars
+from pelorus.config.log import LOG, Log, log
+
+
+def test_loading_simple_string():
+    @define
+    class SimpleCase:
+        unannotated: str
+        with_var: str = field()
+
+    env = dict(UNANNOTATED="unannotated", WITH_VAR="with_var", FIELD_WORKS="field")
+
+    loaded = load_and_log(SimpleCase, env=env)
+
+    assert loaded.unannotated == env["UNANNOTATED"]
+    assert loaded.with_var == env["WITH_VAR"]
+
+
+def test_default():
+    @define
+    class Default:
+        foo: str = field(default="foo")
+        bar: str = "default from literal"
+        baz: Optional[str] = None
+
+    loaded = load_and_log(Default, env=dict())
+
+    assert loaded.foo == "foo"
+    assert loaded.bar == "default from literal"
+    assert loaded.baz is None
+
+
+def test_fallback_lookups():
+    @define
+    class Fallback:
+        foo: str = field(metadata=env_vars("FOO", "BAR", "BAZ"))
+
+    env = dict(BAR="bar", BAZ="baz")
+
+    loaded = load_and_log(Fallback, env=env)
+
+    assert loaded.foo == env["BAR"]
+
+
+def test_load_collections():
+    @define
+    class Collections:
+        a_set: set[str] = field(converter=comma_separated(set))
+        a_tuple: tuple[str] = field(converter=comma_separated(tuple))
+        a_list: list[str] = field(converter=comma_separated(list))
+        default_list: list[str] = field(factory=list, converter=comma_separated(list))
+
+    expected_list = ["one", "two", "three"]
+    expected_tuple = ("one", "two", "three")
+    expected_set = {"one", "two", "three"}
+
+    env = dict(
+        A_SET="one,two,three,one", A_LIST="one,two,three", A_TUPLE="one,two,three"
+    )
+
+    loaded = load_and_log(Collections, env=env)
+
+    assert loaded.a_set == expected_set
+    assert loaded.a_tuple == expected_tuple
+    assert loaded.a_list == expected_list
+    assert loaded.default_list == []
+
+
+def test_loading_from_other():
+    @define
+    class OtherConfig:
+        foo: object = field(metadata=no_env_vars())
+
+    foo = object()
+
+    loaded = load_and_log(OtherConfig, other=dict(foo=foo))
+
+    assert loaded.foo is foo
+
+
+def test_logging(caplog: pytest.LogCaptureFixture):
+    @define(kw_only=True)
+    class Loggable:
+        regular_field: str = field(default="LOG ME 1")
+
+        sensitive_credential: str = field(default="REDACT ME 1")
+        log_this_credential_anyway: str = field(
+            default="LOG ME 2", metadata=log(Log.LOG)
+        )
+        explicitly_sensitive: str = field(
+            default="REDACT ME 2", metadata=log(Log.REDACT)
+        )
+
+        _private_field: str = field(default="SHOULD BE ABSENT 1")
+        _private_but_log_me_anyway: str = field(
+            default="LOG ME 3", metadata=log(Log.LOG)
+        )
+        _private_but_redact_me: str = field(
+            default="REDACT ME 3", metadata=log(Log.REDACT)
+        )
+        not_private_but_skip_logging: str = field(
+            default="SHOULD BE ABSENT 2", metadata=log(Log.SKIP)
+        )
+
+        from_multi_env: str = field(
+            default="", metadata=env_vars("MULTI_ENV", "FROM_MULTI_ENV")
+        )
+        default_name: str = field(default="LOG ME 4")
+
+        other_not_logged: str = field(metadata=no_env_vars())
+        other_explicitly_logged: str = field(metadata=no_env_vars() | log(LOG))
+
+    load_and_log(
+        Loggable,
+        env=dict(DEFAULT_NAME="default"),
+        other=dict(
+            other_not_logged="SHOULD BE ABSENT 3", other_explicitly_logged="LOG ME 5"
+        ),
+    )
+
+    logged = caplog.text
+
+    assert "REDACT ME" not in logged
+    assert "SHOULD BE ABSENT" not in logged
+    for i in range(1, 6):
+        assert f"LOG ME {i}" in logged

--- a/exporters/tests/test_utils.py
+++ b/exporters/tests/test_utils.py
@@ -43,6 +43,9 @@ def test_nested_lookup_collect():
 
 
 def test_env_var_default():
+    if "PELORUS_DEFAULT_KEYWORD" in os.environ:
+        del os.environ["PELORUS_DEFAULT_KEYWORD"]
+
     # Empty string should give us empty string
     os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = ""
     assert get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT") == ""
@@ -53,8 +56,6 @@ def test_env_var_default():
         get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT")
 
     # Use env variable instead of default value
-    if "PELORUS_DEFAULT_KEYWORD" in os.environ:
-        del os.environ["PELORUS_DEFAULT_KEYWORD"]
     os.environ["PELORUS_TEST_ENV_VAR_DEFAULT"] = pelorus.utils.DEFAULT_VAR_KEYWORD
     assert (
         get_env_var("PELORUS_TEST_ENV_VAR_DEFAULT", "default_value") == "default_value"


### PR DESCRIPTION
Relates to #554.

This adds the module responsible for the approach, with docs and tests. Integrating it with each exporter will come in a separate PR if we think this is a good approach.