### PR TITLE
Improve gitlab performance by calling direct project

### DIFF
--- a/exporters/committime/collector_gitlab.py
+++ b/exporters/committime/collector_gitlab.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python3
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
 import logging
 
 import gitlab
@@ -5,9 +22,6 @@ import requests
 from collector_base import AbstractCommitCollector
 
 import pelorus
-
-# import urllib3
-# urllib3.disable_warnings()
 
 
 class GitLabCommitCollector(AbstractCommitCollector):
@@ -22,47 +36,60 @@ class GitLabCommitCollector(AbstractCommitCollector):
             "%Y-%m-%dT%H:%M:%S.%f%z",
         )
 
-    # base class impl
-    def get_commit_time(self, metric):
-        """Method called to collect data and send to Prometheus"""
-        session = requests.Session()
-        session.verify = False
-
-        project_name = metric.repo_project
+    def _connect_to_gitlab(self, metric) -> gitlab.Gitlab:
+        """Method to connect to Gitlab instance."""
         git_server = metric.git_server
 
         if "github" in git_server or "bitbucket" in git_server:
             logging.warn("Skipping non GitLab server, found %s" % (git_server))
             return None
 
-        # Private or personal token
-        gl = gitlab.Gitlab(
-            git_server, private_token=self._token, api_version=4, session=session
-        )
-        # oauth token authentication
-        # gl = gitlab.Gitlab(git_server, oauth_token='my_long_token_here', api_version=4, session=session)
+        gitlab_client = None
 
-        # get the project id from the map by search for the project_name
-        project = None
-        try:
-            logging.debug("Searching for project: %s" % project_name)
-            project = self._get_next_results(gl, project_name, metric.repo_url, 0)
-            logging.debug(
-                "Setting project to %s : %s" % (project.name, str(project.id))
+        session = requests.Session()
+        session.verify = False
+
+        if self._token:
+            # Private or personal token
+            logging.debug("Connecting to GitLab server using token: %s" % (git_server))
+            gitlab_client = gitlab.Gitlab(
+                git_server, private_token=self._token, api_version=4, session=session
             )
+        else:
+            # Public repo without token
+            logging.debug(
+                "Connecting to GitLab server without token: %s" % (git_server)
+            )
+            gitlab_client = gitlab.Gitlab(git_server, api_version=4, session=session)
+
+        return gitlab_client
+
+    # base class impl
+    def get_commit_time(self, metric):
+        """Method called to collect data and send to Prometheus"""
+
+        gl = self._connect_to_gitlab(metric)
+        if not gl:
+            return None
+
+        project_namespace = metric.repo_group
+        project_name = metric.repo_project
+
+        # namespaced project allows to get it by it's name
+        project_namespaced = "%s/%s" % (project_namespace, project_name)
+
+        project = None
+
+        try:
+            logging.debug("Getting project: %s" % (project_namespaced))
+            project = gl.projects.get(project_namespaced)
         except Exception:
             logging.error(
-                "Failed to find project: %s, repo: %s for build %s"
+                "Failed to get project: %s, repo: %s for build %s"
                 % (metric.repo_url, project_name, metric.build_name),
                 exc_info=True,
             )
             raise
-        # Using the project id, get the project
-        if project is None:
-            raise TypeError(
-                "Failed to find repo project: %s, for build %s"
-                % (metric.repo_url, metric.build_name)
-            )
         try:
             # get the commit from the project using the hash
             short_hash = metric.commit_hash[:8]
@@ -80,43 +107,3 @@ class GitLabCommitCollector(AbstractCommitCollector):
             )
             raise
         return metric
-
-    @staticmethod
-    def _get_next_results(gl, project_name, git_url, page):
-        """
-        Returns a list of projects according to the search term project_name.
-        :param gl: Gitlab library
-        :param project_name: search term in the form of a string
-        :param git_url: Repository url stored in the metric
-        :param page: int represents the next page to retrieve
-        :return: matching project or None if no match is found
-        """
-        if page == 0:
-            project_list = gl.search("projects", project_name)
-        else:
-            project_list = gl.search("projects", project_name, page=page)
-        if project_list:
-            project = GitLabCommitCollector.get_matched_project(project_list, git_url)
-            if project:
-                return gl.projects.get(project["id"])
-            else:
-                GitLabCommitCollector._get_next_results(
-                    gl, project_name, git_url, page + 1
-                )
-        return None
-
-    @staticmethod
-    def get_matched_project(project_list, git_url):
-        """
-        Returns the project in the project list that matches the git url
-        :param project_list: list of projects returned by the search by name API call
-        :param git_url: Repository url stored in the metric
-        :return: Matching project or None if there is no match
-        """
-        for p in project_list:
-            if (
-                p.get("http_url_to_repo") == git_url
-                or p.get("ssh_url_to_repo") == git_url
-            ):
-                return p
-        return None


### PR DESCRIPTION
This change improves gitlab performance by allowing to call direct project by it's name within namespace. Previous implementation was searching for the project name, which was not effective and prone to errors if the project name was matching regex from all other gitlab projects.

Fixes #244 

@redhat-cop/mdt
