### PR TITLE
Allow to test gitlab,gitea and bitbucket committime exporters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ mockoon-tests: $(PELORUS_VENV)
 .PHONY: e2e-tests e2e-tests-scenario-1 e2e-tests-scenario-1
 e2e-tests: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \
-	./scripts/run-pelorus-e2e-tests -o konveyor -e failure
+	./scripts/run-pelorus-e2e-tests -o konveyor -e failure,gitlab_committime,bitbucket_committime
 
 e2e-tests-scenario-1: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \

--- a/scripts/e2e-tests-templates/app.py
+++ b/scripts/e2e-tests-templates/app.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+# Sample Hello World application used with binary builds for e2e tests
+
+print("Hello World")

--- a/scripts/e2e-tests-templates/build_binary_app
+++ b/scripts/e2e-tests-templates/build_binary_app
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+
+# Function to safely remove temporary files and temporary download dir
+# Argument is optional exit value to propagate it after cleanup
+function cleanup_and_exit() {
+    oc get namespace "${s_build_namespace}"
+    namespace_exit=$?
+    if [[ $namespace_exit != 0 ]]; then
+        echo "Problem getting namespace ${s_build_namespace}"
+        exit 1
+    fi
+
+    oc delete namespace "${s_build_namespace}"
+    namespace_delete=$?
+    if [[ $namespace_delete != 0 ]]; then
+        echo "Could not delete namespace ${s_build_namespace}"
+        exit 1
+    fi
+
+    exit 0
+}
+
+function print_help() {
+    printf "\nUsage: %s [OPTION]... -n [NAMESPACE] -b [APP_NAME]\n\n" % "$0"
+    printf "\tStartup:\n"
+    printf "\t  -h\tprint this help\n"
+    printf "\n\tOptions:\n"
+    printf "\t  -c\tclean up binary build (by removing provided namespace)\n"
+    printf "\t  -n\tnamespace\n"
+    printf "\t  -b\tbinary build app name\n"
+    printf "\t  -u\tgit uri to be used for annotation\n"
+    printf "\t  -s\tgit commit hash to be used for annotation\n"
+  
+    exit 0
+}
+
+s_cleanup=false
+
+while getopts "h?cb:n:u:s:" option; do
+    case "$option" in
+    h|\?) print_help;;
+    c)    s_cleanup=true;;
+    n)    s_build_namespace=$OPTARG;;
+    b)    s_build_app_name=$OPTARG;;
+    u)    s_git_uri=$OPTARG;;
+    s)    s_git_hash=$OPTARG;;
+    
+    esac
+done
+
+if [ -z "${s_build_namespace}" ]; then
+    print_help
+fi
+
+if [ "${s_cleanup}" == true ]; then
+    cleanup_and_exit
+    exit 0
+fi
+
+# build_app_name is not required for cleanup, however we do need
+# app name, git hash and git uri
+if [ -z "${s_build_app_name}" ] || [ -z "${s_git_hash}" ] || [ -z "${s_git_uri}" ]; then
+    print_help
+fi
+
+# We do not want to manually remove the built namespace.
+# The calling script for the e2e tests makes use of builds
+# trap 'cleanup_and_exit $?' INT TERM EXIT
+
+# Create namespace in which build will happen
+oc create namespace "${s_build_namespace}"
+
+oc new-build --namespace="${s_build_namespace}" python --name="${s_build_app_name}" --binary=true
+oc label --namespace="${s_build_namespace}" bc "${s_build_app_name}" app.kubernetes.io/name="${s_build_app_name}"
+
+# To ensure ./app.py is found
+pushd "$(dirname "$0")"
+oc start-build --namespace="${s_build_namespace}" bc/"${s_build_app_name}" --from-file=./app.py --follow
+popd
+
+set -x
+oc annotate build --namespace="${s_build_namespace}" "${s_build_app_name}"-1 --overwrite \
+io.openshift.build.commit.id="${s_git_hash}" \
+io.openshift.build.source-location="${s_git_uri}"
+
+echo "SUCCESS"

--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -20,6 +20,11 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DEFAULT_VENV="${SCRIPT_DIR}/../.venv"
 TMP_DIR_PREFIX="pelorus_tmp_"
 PELORUS_NAMESPACE="pelorus"
+# Used in CI
+PROW_SECRETS_DIR="/var/run/konveyor/pelorus/pelorus-github/"
+
+# Binary build script
+BINARY_BUILD_SCRIPT="${SCRIPT_DIR}/e2e-tests-templates/build_binary_app"
 
 
 # Used to download required files prior to running the job
@@ -69,6 +74,11 @@ function cleanup_and_exit() {
         oc logs -n "${PELORUS_NAMESPACE}" "${failing_pod}"
     done
 
+    # Cleanup binary builds
+    for binary_build_ns in "${BINARY_BUILDS_NAMESPACES[@]}"; do
+        "${BINARY_BUILD_SCRIPT}" -c -n "${binary_build_ns}"
+    done
+
     # Propagate exit value if was provided
     [ -n "${exit_val}" ] && echo "Exit code: ${exit_val}" && exit "$exit_val"
     exit 0
@@ -93,7 +103,8 @@ function print_help() {
     printf "\t  -f\tvalues filename passed to the Pelorus deployment from the todolist-mongo-go project\n"
     printf "\t  -o\tgithub organization of the mig-demo-apps\n"
     printf "\t  -d\tpath to virtualenv DIR\n"
-    printf "\t  -e\tenable exporter <comma_list>. e.g. failure\n"
+    printf "\t  -s\tpath to DIR with secrets files (used in prow CI)\n"
+    printf "\t  -e\tenable exporter <comma_list>. e.g. failure\n"    
 
     exit 0
 }
@@ -112,13 +123,21 @@ set +a
 ### Options
 OPTIND=1
 ENABLE_FAIL_EXP=false
-while getopts "h?b:d:o:f:e:" option; do
+ENABLE_GITLAB_COM_EXP=false
+ENABLE_GITEA_COM_EXP=false
+ENABLE_BITBUCKET_COM_EXP=false
+
+# Used for cleanup to ensure created binary builds can be safely deleted
+BINARY_BUILDS_NAMESPACES=()
+
+while getopts "h?b:d:s:o:f:e:" option; do
     case "$option" in
     h|\?) print_help;;
     b)    demo_branch=$OPTARG;;
     f)    ci_filename=$OPTARG;;
     o)    demo_org=$OPTARG;;
     d)    venv_dir=$OPTARG;;
+    s)    secrets_dir=$OPTARG;;
     e)    enable_exporters=$OPTARG;;
     esac
 done
@@ -129,10 +148,17 @@ else
     VENV="${venv_dir}"
 fi
 
+if [ -z "${secrets_dir}" ]; then
+    SECRETS_DIR="${PROW_SECRETS_DIR}"
+else
+    SECRETS_DIR="${secrets_dir}"
+fi
+
 if [ -n "${enable_exporters}" ]; then
-    if echo ",$enable_exporters," | grep -q ",failure,"; then
-        ENABLE_FAIL_EXP=true
-    fi
+    echo ",$enable_exporters," | grep -q ",failure," && ENABLE_FAIL_EXP=true && echo "Enabling Failure exporter"
+    echo ",$enable_exporters," | grep -q ",gitlab_committime," && ENABLE_GITLAB_COM_EXP=true && echo "Enabling Gitlab committime exporter"
+    echo ",$enable_exporters," | grep -q ",gitea_committime," && ENABLE_GITEA_COM_EXP=true && echo "Enabling Gitea committime exporter"
+    echo ",$enable_exporters," | grep -q ",bitbucket_committime," && ENABLE_BITBUCKET_COM_EXP=true && echo "Enabling Bitbucket committime exporter"
 fi
 
 if [ -z "${demo_branch}" ]; then
@@ -169,39 +195,175 @@ sed -i.bak "s/your_org/$demo_org/g" "${DWN_DIR}/mongo-persistent.yaml"
 # Show what has been modified:
 diff -uNr "${DWN_DIR}/mongo-persistent.yaml" "${DWN_DIR}/mongo-persistent.yaml.bak"
 
+# Used to create secret temporary file that is used with oc apply
+# command. This is to ensure API Tokens are hidden from the terminal
+# output.
+#
+# Arguments:
+#    $1 - namespace for which secret will be applied, e.g. pelorus
+#    $2 - secret name, e.g. github-secret
+#    $3 - api token value
+#    $4 - (Optional) - api user name. Not all API tokens require corresponding user.
+#
+# Return:
+#    path to the temporary secret file
+#
+function mksecret_temp() {
+    TMP_FILE=$(TMPDIR="${DWN_DIR}" mktemp -t "XXXXX.pelorus.yaml")
+    local secret_namespace=$1
+    local secret_name=$2
+    local api_token=$3
+    local api_user=$4
+
+cat <<EOF >> "${TMP_FILE}"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $secret_name
+  namespace: $secret_namespace
+type: Opaque
+stringData:
+  API_TOKEN: $api_token
+  TOKEN: $api_token
+EOF
+
+    if [[ -n ${api_user} ]]; then
+        echo "  USER: $api_user" >> "${TMP_FILE}"
+    fi
+
+    echo "${TMP_FILE}"
+}
+
+function create_k8s_secret() {
+    local secret_name=$1
+    local env_token_name=$2
+    local env_user_name="${3:-NO_USERNAME_DEFINED_VAR}"
+
+    SECRET_CONFIGURED=false
+    oc -n $PELORUS_NAMESPACE get secret "${secret_name}"
+    secret_present=$?
+    if [[ $secret_present = 0 ]]; then
+        echo "Secret $secret_name was found"
+        SECRET_CONFIGURED=true
+    else
+      echo "Secret $secret_name was not found, checking env variables to create one"
+      secret_filepath=""
+      # TOKEN must always be set, USER may be required depending on the backend type
+      if [[ -n ${!env_token_name} ]] && [[ -n ${!env_user_name} ]]; then
+          echo "API Token and user passed from env var"
+          secret_filepath=$( mksecret_temp "$PELORUS_NAMESPACE" "$secret_name" "${!env_token_name}" "${!env_user_name}" )
+      elif [[ -n ${!env_token_name} ]]; then
+          echo "API Token passed from env var"
+          secret_filepath=$( mksecret_temp "$PELORUS_NAMESPACE" "$secret_name" "${!env_token_name}" )
+      elif [ -r "${SECRETS_DIR}/${env_token_name}" ] && [ -r "${SECRETS_DIR}/${env_user_name}" ]; then
+          echo "Getting API TOKEN and API USER from secrets mounted directory"
+          secret_filepath=$( mksecret_temp "$PELORUS_NAMESPACE" "$secret_name" "$( cat "${SECRETS_DIR}/${env_token_name}" )" "$( cat "${SECRETS_DIR}/${env_user_name}" )" )
+      elif [ -r "${SECRETS_DIR}/${env_token_name}" ]; then
+          echo "Getting API TOKEN from secrets mounted directory"
+          secret_filepath=$( mksecret_temp "$PELORUS_NAMESPACE" "$secret_name" "$( cat "${SECRETS_DIR}/${env_token_name}" )" )
+      else
+          echo "ERROR: API Token for ${secret_name} not provided, exiting..."
+          exit 1
+      fi
+      # Ensure path is set and file is readable
+      if [[ -n "${secret_filepath}" ]] && [ -r "${secret_filepath}" ]; then
+          oc apply -f "${secret_filepath}"
+          oc_apply=$?
+          if [[ $oc_apply = 0 ]]; then
+              echo "Secret $secret_name was added"
+              SECRET_CONFIGURED=true
+          fi
+          rm "${secret_filepath}"
+      fi
+    fi
+    echo "${SECRET_CONFIGURED}"
+}
+
 # enable the pelorus failure exporter for github
 if [ "${ENABLE_FAIL_EXP}" == true ]; then
-    GITHUB_SECRET_CONFIGURED=false
-    # if github-secret is created in ci
-    oc -n $PELORUS_NAMESPACE get secret github-secret
-    secret_present=$?
-
-    if [[ $secret_present = 0 ]]; then
-        echo "The github-secret was found"
-        GITHUB_SECRET_CONFIGURED=true
-    # if TOKEN are set
-    elif [[ -n ${TOKEN} ]]; then
-        # turn off debug if enabled
-        if [[ $- == *x* ]]; then set +x; export debug_set_off=true; fi
-        oc -n $PELORUS_NAMESPACE create secret generic github-secret --from-literal=TOKEN="$TOKEN"
-        # if debug was turned off, turn it back on.
-        if [[ $debug_set_off == true ]]; then set -x; fi
-        GITHUB_SECRET_CONFIGURED=true
-    else
-        echo "The pelorus github failure exporter was enabled, but the TOKEN was not configured properly"
+    secret_configured=$(create_k8s_secret github-secret TOKEN)
+    secret_exit=$?
+    echo "${secret_configured}"
+    if [[ $secret_exit != 0 ]]; then
         exit 1
     fi
 
     # uncomment the failure exporter in ci_values.yaml
-    if [ $GITHUB_SECRET_CONFIGURED == true ]; then
+    if [[ "$secret_configured" == *true ]]; then
         sed -i.bak "s/#@//g" "${DWN_DIR}/ci_values.yaml"
         echo "The pelorus failure exporter has been enabled"
     fi
 
     # if required update the failure issue github organization
-    if [ $demo_org != "konveyor" ]; then
+    if [ "$demo_org" != "konveyor" ]; then
         sed -i.bak "s/konveyor\/mig-demo-apps/$demo_org\/mig-demo-apps/g" "${DWN_DIR}/ci_values.yaml"
     fi
+fi
+
+# enable gitlab committime exporter
+if [ "${ENABLE_GITLAB_COM_EXP}" == true ]; then
+    secret_configured=$(create_k8s_secret gitlab-secret GITLAB_API_TOKEN)
+    secret_exit=$?
+    echo "${secret_configured}"
+    if [[ $secret_exit != 0 ]]; then
+        exit 1
+    fi
+    # uncomment the gitlab committime exporter in ci_values.yaml
+    if [[ "$secret_configured" == *true ]]; then
+        sed -i.bak "s/#gitlab-committime@//g" "${DWN_DIR}/ci_values.yaml"
+        echo "The pelorus gitlab committime exporter has been enabled"
+    fi
+
+    # namespace must much one from ci_values.yaml
+    build_ns="gitlab-binary"
+    BINARY_BUILDS_NAMESPACES+=("${build_ns}")
+    build_uri="https://gitlab.com/mpryc/pelorus-gitlab"
+    build_hash="b807fd8e1b2bd1755eca14960e5352fe89ff466e"
+    "${BINARY_BUILD_SCRIPT}" -n "${build_ns}" -b "${build_ns}-todolist" -u "${build_uri}" -s "${build_hash}"
+fi
+
+# enable gitea committime exporter
+if [ "${ENABLE_GITEA_COM_EXP}" == true ]; then
+    secret_configured=$(create_k8s_secret gitea-secret GITEA_API_TOKEN)
+    secret_exit=$?
+    echo "${secret_configured}"
+    if [[ $secret_exit != 0 ]]; then
+        exit 1
+    fi
+    # uncomment the gitea committime exporter in ci_values.yaml
+    if [[ "$secret_configured" == *true ]]; then
+        sed -i.bak "s/#gitea-committime@//g" "${DWN_DIR}/ci_values.yaml"
+        echo "The pelorus gitea committime exporter has been enabled"
+    fi
+
+    # namespace must much one from ci_values.yaml
+    build_ns="gitea-binary"
+    BINARY_BUILDS_NAMESPACES+=("${build_ns}")
+    build_uri="https://try.gitea.io/mpryc/pelorus-gitea"
+    build_hash="897f5c490442e88cc609c241da880128ad02e42b"
+    "${BINARY_BUILD_SCRIPT}" -n "${build_ns}" -b "${build_ns}-todolist" -u "${build_uri}" -s "${build_hash}"
+fi
+
+# enable bitbucket committime exporter
+if [ "${ENABLE_BITBUCKET_COM_EXP}" == true ]; then
+    secret_configured=$(create_k8s_secret bitbucket-secret BITBUCKET_API_TOKEN BITBUCKET_API_USER)
+    secret_exit=$?
+    echo "${secret_configured}"    
+    if [[ $secret_exit != 0 ]]; then
+        exit 1
+    fi
+    # uncomment the bitbucket committime exporter in ci_values.yaml
+    if [[ "$secret_configured" == *true ]]; then
+        sed -i.bak "s/#bitbucket-committime@//g" "${DWN_DIR}/ci_values.yaml"
+        echo "The pelorus bitbucket committime exporter has been enabled"
+    fi
+
+    # namespace must much one from ci_values.yaml
+    build_ns="bitbucket-binary"
+    BINARY_BUILDS_NAMESPACES+=("${build_ns}")
+    build_uri="https://bitbucket.org/michalpryc/pelorus-bitbucket"
+    build_hash="e2c4ef00468dfc10aad1bd2d4c9d470160a7f471"
+    "${BINARY_BUILD_SCRIPT}" -n "${build_ns}" -b "${build_ns}-todolist" -u "${build_uri}" -s "${build_hash}"
 fi
 
 # We do check for the exit status, as we are not really interested in the
@@ -242,6 +404,9 @@ retry 5m 5s ogns grafana-service
 retry 5m 5s ogns prometheus-operated
 retry 5m 5s ogns prometheus-pelorus
 
+# Print ci_values.yaml for easy debug
+cat "${DWN_DIR}/ci_values.yaml"
+
 # update exporter values and helm upgrade
 helm upgrade pelorus charts/pelorus --namespace pelorus --values "${DWN_DIR}/ci_values.yaml"
 
@@ -258,6 +423,8 @@ exporters=$(oc get route -n "${PELORUS_NAMESPACE}"|grep "-exporter")
 echo "$exporters"
 for exporter_route in $(echo "$exporters" | awk '{print $2}');
 do
+    echo "$exporter_route"
+    curl "$exporter_route"
     curl "$exporter_route" 2>&1 | grep todolist || exit 2
 done
 


### PR DESCRIPTION
Enabling the gitlab,gitea and bitbucket committime exporters.

The way it works it creates binary build and annotate it with the corresponding git URL and hash. Based on that specific commit time exporter back-end is collecting timestamp of the commit from the provider PI.

Fixes #582 
