### PR TITLE
Fix pylava traceback by pinning dependent pyflakes pip package

### DIFF
--- a/exporters/requirements-dev.txt
+++ b/exporters/requirements-dev.txt
@@ -19,6 +19,9 @@ black
 isort
 pylava
 
+# Issue #584
+pyflakes <= 2.4.0
+
 # Required by `ct lint` command
 yamale
 yamllint


### PR DESCRIPTION
pylava 0.3.0 is incompatible with new pyflakes (2.5.0). Pin pyflakes to the version which is working with pylava.

Resolves #584 

Upstream bug: https://github.com/pylava/pylava/issues/13

@redhat-cop/mdt
