### PR TITLE
Fix traceback for unsupported git providers

### DIFF
--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -35,6 +35,16 @@ COMMIT_HASH_ANNOTATION_ENV = "COMMIT_HASH_ANNOTATION"
 COMMIT_REPO_URL_ANNOTATION_ENV = "COMMIT_REPO_URL_ANNOTATION"
 
 
+class UnsupportedGITProvider(Exception):
+    """
+    Exception raised for unsupported GIT provider
+    """
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)
+
+
 class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
     """
     Base class for a CommitCollector.
@@ -345,7 +355,11 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
                 "sha: %s, commit_timestamp not found in cache, executing API call.",
                 metric.commit_hash,
             )
-            metric = self.get_commit_time(metric)
+            try:
+                metric = self.get_commit_time(metric)
+            except UnsupportedGITProvider as ex:
+                errors.append(ex.message)
+                return None
             # If commit time is None, then we could not get the value from the API
             if metric.commit_time is None:
                 errors.append("Couldn't get commit time")

--- a/exporters/committime/collector_bitbucket.py
+++ b/exporters/committime/collector_bitbucket.py
@@ -6,7 +6,7 @@ import requests.exceptions
 
 import pelorus
 from committime import CommitMetric
-from committime.collector_base import AbstractCommitCollector
+from committime.collector_base import AbstractCommitCollector, UnsupportedGITProvider
 
 
 def commit_url(server: str, group: str, project: str, commit: str) -> str:
@@ -44,9 +44,15 @@ class BitbucketCommitCollector(AbstractCommitCollector):
         git_server = metric.git_server
 
         # do a simple check for hosted Git services.
-        if "github" in git_server or "gitlab" in git_server:
-            logging.warn("Skipping non BitBucket server, found %s" % (git_server))
-            return None
+        if (
+            "github" in git_server
+            or "gitea" in git_server
+            or "gitlab" in git_server
+            or "azure" in git_server
+        ):
+            raise UnsupportedGITProvider(
+                "Skipping non BitBucket server, found %s" % (git_server)
+            )
 
         try:
             git_server = metric.git_server

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -1,7 +1,7 @@
 import logging
 
 import requests
-from collector_base import AbstractCommitCollector
+from collector_base import AbstractCommitCollector, UnsupportedGITProvider
 
 import pelorus
 
@@ -36,8 +36,6 @@ class GiteaCommitCollector(AbstractCommitCollector):
     # base class impl
     def get_commit_time(self, metric):
         """Method called to collect data and send to Prometheus"""
-        session = requests.Session()
-        session.verify = False
 
         git_server = metric.git_server
 
@@ -47,8 +45,12 @@ class GiteaCommitCollector(AbstractCommitCollector):
             or "gitlab" in git_server
             or "azure" in git_server
         ):
-            logging.warn("Skipping non Gitea server, found %s" % (git_server))
-            return None
+            raise UnsupportedGITProvider(
+                "Skipping non Gitea server, found %s" % (git_server)
+            )
+
+        session = requests.Session()
+        session.verify = False
 
         url = (
             self._prefix

--- a/exporters/committime/collector_github.py
+++ b/exporters/committime/collector_github.py
@@ -5,7 +5,7 @@ import requests
 
 import pelorus
 
-from .collector_base import AbstractCommitCollector
+from .collector_base import AbstractCommitCollector, UnsupportedGITProvider
 
 
 class GitHubCommitCollector(AbstractCommitCollector):
@@ -45,9 +45,15 @@ class GitHubCommitCollector(AbstractCommitCollector):
         """Method called to collect data and send to Prometheus"""
         git_server = metric.git_fqdn
         # check for gitlab or bitbucket
-        if "gitlab" in git_server or "bitbucket" in git_server:
-            logging.warn("Skipping non GitHub server, found %s" % (git_server))
-            return None
+        if (
+            "gitea" in git_server
+            or "gitlab" in git_server
+            or "bitbucket" in git_server
+            or "azure" in git_server
+        ):
+            raise UnsupportedGITProvider(
+                "Skipping non GitHub server, found %s" % (git_server)
+            )
 
         url = (
             self._prefix


### PR DESCRIPTION
Each committime exporter supports only one GIT provider.
Currently it's implemented in a way it tries to talk to all GIT URLs except well known other provires. This allows to collect data from self hosted GIT providers with custom fqdn.

Fix is to properly propagate error for unsupported by each individual class GIT providers.

resolves #577 

## Testing Instructions

Setup exporter as in the bug and check the logs.

With the current implementation we get:

```
08-02-2022 12:46:12 WARNING  Missing data for CommitTime metric from Build pelorus/failure-exporter-1 in app failure-exporter: Skipping non GitLab server, found https://github.com
```