### PR TITLE
Ensure git URI does not end with "/"

### DIFF
--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -63,6 +63,8 @@ class CommitMetric:
 
     @repo_url.setter
     def repo_url(self, value):
+        # Ensure git URI does not end with "/", issue #590
+        value = value.strip("/")
         self.__repo_url = value
         self.__parse_repourl()
 


### PR DESCRIPTION
Fixes #590 which causes giturlparse to improperly parse git URI when ending with "/" e.g. https://github.com/konveyor/pelorus/ instead of https://github.com/konveyor/pelorus or https://github.com/konveyor/pelorus.git

@redhat-cop/mdt
