### PR TITLE
Enable gitlab, gitea and bitbucket commit time exporter in periodic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ e2e-tests: e2e-tests-dev-env
 
 e2e-tests-scenario-1: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \
-	./scripts/run-pelorus-e2e-tests -f "periodic/quay_images_latest.yaml"
+	./scripts/run-pelorus-e2e-tests -f "periodic/quay_images_latest.yaml" -o konveyor -e failure,gitlab_committime,gitea_committime,bitbucket_committime
 
 e2e-tests-scenario-2: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \


### PR DESCRIPTION
Prow periodic CI job which runs out of quay images should include multiple git backends. This is done via annotation as github commit time exporter does build and deploy application, so we don't have to do it for every other supporter git APIs.

Depends On: https://github.com/konveyor/pelorus/pull/599

@redhat-cop/mdt
