### PR TITLE
minor release - 1.7.0

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.1
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.7
+version: 1.7.0
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v1.6.0" }}
+      ref: {{ .source_ref | default "v1.7.0" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:


### PR DESCRIPTION
minor release required by the #598. Enabling other exporters does need new quay images which are tagged as released ones.


@redhat-cop/mdt
