### PR TITLE
Small release bump - 1.7.1

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.0
+version: 1.7.1
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v1.7.0" }}
+      ref: {{ .source_ref | default "v1.7.1" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:


### PR DESCRIPTION
We need to bump to 1.7.1 from just released 1.7.0. This is because the Draft release was not published after that minor bump and followed by other PRs that did not create new quay images #600.

Note that exporter quay images are being built not on every PR merge, just the one which is touching exporter files or _buildconfig.

This is corner case where 1.7.0 tag was trying to find latest hash from the github, however quay was missing that hash due to image not being built.

In the first place the publish release was supposed to be created after minor release PR was merged #599.

@redhat-cop/mdt
