### PR TITLE
Collect commit time based on the Image Label or annotation

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.1
+version: 1.7.2
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/rbac.yaml
+++ b/charts/pelorus/charts/exporters/templates/rbac.yaml
@@ -41,6 +41,12 @@ rules:
   verbs:
   - list
   - get
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - images
+  verbs:
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/pelorus/configmaps/committime.yaml
+++ b/charts/pelorus/configmaps/committime.yaml
@@ -7,7 +7,8 @@ metadata:
   name: committime-config
   namespace: pelorus
 data:
-  API_USER: "default"            # ""  |  User's github username, can be overriden by env_from_secrets
+  PROVIDER: "default"        # "git" | Provider from which commit date is taken. "git" or "image"
+  API_USER: "default"        # ""  |  User's github username, can be overriden by env_from_secrets
   TOKEN: "default"           # ""  |  User's Github API Token, can be overriden by env_from_secrets
   GIT_API: "default"         # api.github.com  |  Github Enterprise API FQDN, can be overriden by env_from_secrets
   GIT_PROVIDER: "default"    # github  |  github, gitlab, or bitbucket

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -239,7 +239,7 @@ or `https://gitea.mycompany.com`.
 
 The cli commands can also be substituted with Secret templates. Example files can be found [here](https://github.com/konveyor/pelorus/tree/master/charts/pelorus/secrets)
 
-Create a secret containing your Git username, token, and API example:  
+Create a secret containing your Git username, token, and API example:
 
 ```shell
 oc create secret generic github-secret --from-literal=API_USER=<username> --from-literal=TOKEN=<personal access token> --from-literal=GIT_API=<api> -n pelorus
@@ -298,7 +298,7 @@ Example Failure exporter config:
 ```
 
 > **Warning** 
-> If the application label is not properly configured, Pelorus will not collect data for that object.  
+> If the application label is not properly configured, Pelorus will not collect data for that object.
 
 In the following examples an application named [todolist](https://github.com/konveyor/mig-demo-apps/blob/master/apps/todolist-mongo-go/mongo-persistent.yaml) is being monitored.
 
@@ -369,11 +369,11 @@ oc annotate build <build-name> -n <namespace> --overwrite io.openshift.build.com
 oc annotate build <build-name> -n <namespace> --overwrite io.openshift.build.source-location=<repo_uri>
 ```
 
-Custom Annotation names may also be configured using ConfigMap Data Values.
+Custom Annotation names may also be configured using Commit Time Exporter [ConfigMap Data Values](#configmap-data-values).
 
 Note: The requirement to label the build with `app.kubernetes.io/name=<app_name>` for the annotated Builds applies.
 
-#### An example workflow for an OpenShift binary build:
+#### Example workflow for an OpenShift binary build
 
 * Sample Application
 
@@ -402,10 +402,69 @@ io.openshift.build.source-location=http://github.com/konveyor/pelorus
 oc -n "${NS}" new-app "${NAME}" -l "app.kubernetes.io/name=${NAME}"
 ```
 
-
 #### Additional Examples
 
 There are many ways to build and deploy applications in OpenShift.  Additional examples of how to annotate builds such that Pelorus will properly discover the commit metadata can be found in the  [Pelorus tekton demo](https://github.com/konveyor/pelorus/tree/master/demo)
+
+### Annotations, Docker Labels and Image support
+
+Image object annotations similarly to [Annotations and local build support](#annotations-and-local-build-support) may be used for the Commit Time Exporter **where values from the Build objects required to gather commit time from the source repository are missing**.
+
+Note: The requirement to label the image SHA with `app.kubernetes.io/name=<app_name>` for the annotated or Labeled Image objects applies.
+
+Custom Annotation names may also be configured using Commit Time Exporter [ConfigMap Data Values](#configmap-data-values).
+
+An Image object which is a result of Docker or Source-to-Image (S2I) builds set includes Docker Label `io.openshift.build.commit.date` metadata from which Commit Time Exporter gets the commit date. In such case Image object do not need to be annotated.
+
+Example image metadata with `io.openshift.build.commit.date` Docker Labels and `app.kubernetes.io/name=<app_name>` Label required for the Commit Time Exporter:
+
+```
+IMAGE_SHA=588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
+
+$ oc describe "sha256:${IMAGE_SHA}"
+
+Docker Image:	image-registry.openshift-image-registry.svc:5000/mongo-persistent/todolist-mongo-go@sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
+Name:		    sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
+[...]
+Labels:		    app.kubernetes.io/name=my-demo-application
+[...]
+Docker Labels:	io.buildah.version=1.22.4
+		        io.openshift.build.commit.author=Wesley Hayutin <weshayutin@gmail.com>
+		        io.openshift.build.commit.date=Mon Aug 8 13:13:58 2022 -0600
+		        io.openshift.build.commit.id=b6abfb214557289bdaa9bed3dcc570ffd5b9ad4f
+		        io.openshift.build.commit.message=Merge pull request #90 from mpryc/master
+		        io.openshift.build.commit.ref=master
+		        io.openshift.build.name=todolist-1
+		        io.openshift.build.namespace=mongo-persistent
+		        io.openshift.build.source-location=https://github.com/konveyor/mig-demo-apps.git
+```
+
+To annotate Image and ensure Commit Time Exporter can gather relevant values, use `oc annotate` CLI as in the following example:
+
+```
+$ NAME=my-application
+$ IMAGE_SHA=588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
+$ oc label image "sha256:${IMAGE_SHA}" "app.kubernetes.io/name=${NAME}"
+
+# In case image already has the `app.kubernetes.io/name` label, use --overwrite CLI option
+$ oc label image "sha256:${IMAGE_SHA}" --overwrite "app.kubernetes.io/name=${NAME}"
+
+> image.image.openshift.io/sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e labeled
+
+$ oc annotate image "sha256:${IMAGE_SHA}" --overwrite \
+     io.openshift.build.commit.date="Mon Aug 8 13:13:58 2022 -0600"
+
+> image.image.openshift.io/sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e annotated
+
+# It's not necessary for the Pelorus metric, but for completeness of the data, you may also annotate Git commit corresponding
+# with the Image build:
+
+$ oc annotate image "sha256:${IMAGE_SHA}" --overwrite \
+    io.openshift.build.commit.id=b6abfb214557289bdaa9bed3dcc570ffd5b9ad4f \
+    io.openshift.build.commit.date="Mon Aug 8 13:13:58 2022 -0600"
+
+> image.image.openshift.io/sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e annotated
+```
 
 ### Configuring JIRA workflow(s)
 
@@ -494,14 +553,24 @@ exporters:
 
 ### Commit Time Exporter
 
-The job of the commit time exporter is to find relevant builds in OpenShift and associate a commit from the build's source code repository with a container image built from that commit. We capture a timestamp for the commit, and the resulting image hash, so that the Deploy Time Exporter can later associate that image with a production deployment.
+The job of the commit time exporter is to find and associate time of the relevant source code commit with a container image SHA built from that source code.
+Later the Deploy Time Exporter can associate that image SHA with a production deployment and allow to calculate [Lead Time for Change](../dashboards/SoftwareDeliveryPerformance/#lead-time-for-change) metrics.
 
-We require that all builds associated with a particular application be labeled with the same `app.kubernetes.io/name=<app_name>` label.
+Commit Time Exporter may be used with an Build or Image cluster objects.
 
-Currently we support GitHub and GitLab, with BitBucket coming soon. Open an issue or a pull request to add support for additional Git providers!
+#### Using Commit Time with Git APIs
 
+This is the default method of gathering commit time from the source code that triggered container build. Git commit hash and FQDN from the Build metadata are used to perform a query to a relevant Git API and collect commit time.
 
-#### Instance Config
+Currently we support GitHub, GitLab, BitBucket, Gitea and Azure DevOps Git services.
+
+Open an [issue](https://github.com/konveyor/pelorus/issues/new) or a pull request to add support for additional Git providers!
+
+We require that all builds associated with a particular application be labeled with the same `app.kubernetes.io/name=<app_name>` label. Different label name may be used with provided exporter instance configuration option `APP_LABEL`.
+
+In some cases, such as binary build the `Build` object may be missing information required to gather Git commit time. Refer to the [Annotations and local build support](#annotations-and-local-build-support) for information how to enable Commit Time Exporter for such builds.
+
+##### Instance Config
 
 ```yaml
 exporters:
@@ -515,23 +584,55 @@ exporters:
     - committime-config
 ```
 
+#### Using Commit Time with Images
+
+This is the method of gathering source commit time associated directly with an `Image` object, where `Build` object may be missing.
+
+To configure Commit Time Exporter with an `image` provider type, ensure ConfigMap has such option and it's used in the committime instance config, similarly to the example:
+
+ConfigMap file:
+
+```
+kind: ConfigMap
+metadata:
+  name: image-committime-config
+  namespace: pelorus
+data:
+  PROVIDER: "image"
+```
+
+Instance Config:
+
+```yaml
+exporters:
+  instances:
+  - app_name: image-committime-exporter
+    exporter_type: committime
+    env_from_configmaps:
+    - pelorus-config
+    - image-committime-config
+```
+Refer to the [Annotations, Docker Labels and Image support](#annotations-docker-labels-and-mage-support) for information how to enable Commit Time Exporter for the Image use case.
+
 #### ConfigMap Data Values
 
 This exporter provides several configuration options, passed via `pelorus-config` and `committime-config` variables. User may define own ConfigMaps and pass to the committime exporter in a similar way.
 
-| Variable | Required | Explanation | Default Value |
-|---|---|---|---|
-| `API_USER` | yes | User's github username | unset |
-| `TOKEN` | yes | User's Github API Token | unset |
-| `GIT_API` | no | GitHub, Gitea or Azure DevOps API FQDN. This allows the override for Enterprise users. Currently only applicable to `github`, `gitea` and `azure-devops` provider types. | `api.github.com`, or `https://try.gitea.io`. No default for Azure DevOps. |
-| `GIT_PROVIDER` | no | Set Git provider type. Can be `github`, `gitlab`, or `bitbucket` | `github` |
-| `LOG_LEVEL` | no | Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR` | `INFO` |
-| `APP_LABEL` | no | Changes the label key used to identify applications  | `app.kubernetes.io/name`  |
-| `NAMESPACES` | no | Restricts the set of namespaces from which metrics will be collected. ex: `myapp-ns-dev,otherapp-ci` | unset; scans all namespaces |
-| `PELORUS_DEFAULT_KEYWORD` | no | ConfigMap default keyword. If specified it's used in other data values to indicate "Default Value" should be used | `default` |
-| `COMMIT_HASH_ANNOTATION` | no | Annotation name associated with the Build from which hash is used to calculate commit time | `io.openshift.build.commit.id` |
-| `COMMIT_REPO_URL_ANNOTATION` | no | Annotation name associated with the Build from which GIT repository URL is used to calculate commit time | `io.openshift.build.source-location` |
-  
+| Variable | Required | Supported provider | Explanation | Default Value |
+|---|---|---|---|---|
+| `PROVIDER` | no | | Provider from which commit date is taken. `git` or `image` |
+| `API_USER` | yes | `git` | User's github username | unset |
+| `TOKEN` | yes | `git` | User's Github API Token | unset |
+| `GIT_API` | no | `git` | GitHub, Gitea or Azure DevOps API FQDN. This allows the override for Enterprise users. Currently only applicable to `github`, `gitea` and `azure-devops` provider types. | `api.github.com`, or `https://try.gitea.io`. No default for Azure DevOps. |
+| `GIT_PROVIDER` | no | `git` | Set Git provider type. Can be `github`, `bitbucket`, `gitea`, `azure-devops` or `gitlab` | `github` |
+| `LOG_LEVEL` | no | `git`, `image` | Set the log level. One of `DEBUG`, `INFO`, `WARNING`, `ERROR` | `INFO` |
+| `APP_LABEL` | no | `git`, `image` | Changes the label key used to identify applications  | `app.kubernetes.io/name`  |
+| `NAMESPACES` | no | `git` | Restricts the set of namespaces from which metrics will be collected. ex: `myapp-ns-dev,otherapp-ci` | unset; scans all namespaces |
+| `PELORUS_DEFAULT_KEYWORD` | no | `git`, `image` | ConfigMap default keyword. If specified it's used in other data values to indicate "Default Value" should be used | `default` |
+| `COMMIT_HASH_ANNOTATION` | no | `git`, `image` | Annotation name associated with the Build from which hash is used to calculate commit time | `io.openshift.build.commit.id` |
+| `COMMIT_REPO_URL_ANNOTATION` | no | `git`, `image` | Annotation name associated with the Build from which GIT repository URL is used to calculate commit time | `io.openshift.build.source-location` |
+| `COMMIT_DATE_ANNOTATION` | no | `image` | Annotation name associated with the Image from which commit time is taken. | `io.openshift.build.commit.date` |
+| `COMMIT_DATE_FORMAT` | no | `image` | Format in `1989 C standard` to convert time and date found in the Docker Label `io.openshift.build.commit.date` or annotation for the Image | `%a %b %d %H:%M:%S %Y %z` |
 
 ### Deploy Time Exporter
 

--- a/exporters/committime/README.md
+++ b/exporters/committime/README.md
@@ -5,8 +5,7 @@ The Commit Time exporter is responsible for collecting the following metric:
 ```
 commit_timestamp{app, commit_hash, image_sha, namespace} timestamp
 ```
-
-The job of the commit time exporter is to find relevant build data in OpenShift and associate a commit from the build's source code repository with a container image built from that commit. We capture a timestamp for the commit, and the resulting image hash, so that the Deploy Time Exporter can later associate that image with a production deployment.
+The job of the commit time exporter is to find and associate time of the relevant source code commit with a container image SHA built from that source code. Later the Deploy Time Exporter can associate that image SHA with a production deployment and allow to calculate Lead Time for Change metrics.
 
 In order for proper collection, we require that all builds associated with a particular application be labelled with a common label (`app.kubernetes.io/name` by default).
 
@@ -14,7 +13,7 @@ Configuration options can be found in the [config guide](/docs/Configuration.md)
 
 ## Supported Integrations
 
-This exporter currently pulls build data from the following systems:
+This exporter currently pulls commit data from the `Build` or an `Image` objects:
 
 * OpenShift - We look for `Build` resources where `.spec.source.git.uri` and `.spec.revision.git.commit` are set. This includes:
   * Source to Image builds
@@ -25,12 +24,21 @@ This exporter currently pulls build data from the following systems:
   * Binary (local) source build
   * Any build type
 
-Then we get commit data from the following systems through their respective APIs:
+* OpenShift - We look for `Image` resources with `Docker Labels` or `Annotations`.
 
+For the `Build` resources we get commit data from the following systems through their respective APIs:
+
+* Azure DevOps
+* Bitbucket
+* Gitea
 * GitHub
 * GitHub Enterprise (including private endpoints)
-* Bitbucket _(coming soon)_
-* Gitlab _(coming soon)_
+* Gitlab
+
+For the `Image` resources we get commit time from the:
+
+* Value of an `io.openshift.build.commit.date` within the the `Docker Labels`
+* Value of an `io.openshift.build.commit.date` within specified `COMMIT_DATE_ANNOTATION` env. variable, that defaults to `io.openshift.build.commit.date`
 
 ## Annotated Binary (local) source build support
 

--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -142,6 +142,7 @@ class CommitMetric:
     _ANNOTATION_MAPPIG = dict(
         repo_url="io.openshift.build.source-location",
         commit_hash="io.openshift.build.commit.id",
+        commit_time="io.openshift.build.commit.date",
     )
 
 

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -8,7 +8,7 @@ from kubernetes.client import ApiClient, Configuration
 from openshift.dynamic import DynamicClient
 
 from committime import CommitMetric
-from committime.app import CommittimeConfig
+from committime.app import GitCommittimeConfig
 from committime.collector_github import GitHubCommitCollector
 from pelorus.config import load_and_log
 
@@ -47,7 +47,7 @@ def setup_collector_from_env_loading():
     )
 
     config = load_and_log(
-        CommittimeConfig,
+        GitCommittimeConfig,
         other=dict(
             kube_client=_make_dyn_client(),
             tls_verify=False,
@@ -113,7 +113,7 @@ def test_github_provider(setup):
 
     actual = [
         CommitMetricEssentials.from_commit_metric(cm)
-        for cm in collector.generate_metrics(collector._namespaces)
+        for cm in collector.generate_metrics()
     ]
 
     actual.sort(key=lambda commit: commit.commit_timestamp)


### PR DESCRIPTION
Resolves #371.

An Image from "image.openshift.io/v1" is a non namespaced object which can be used to gather commit time data where such is missing from the Build.

During build process Labels may be available that includes information about commit time which was used to builds such image:

https://docs.openshift.com/online/pro/dev_guide/builds/build_output.html#output-image-labels

If such information is missing we still allow to annotate Image to include required data for the Pelorus metrics.

## Testing Instructions

1. Create Image in the OCP cluster (even demo or e2e tests may be used)
2. For the mongo-persistent image the Labels should be there and collection should happen, only label the image so pelorus knows it's within interest:
```
oc label image sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e app.kubernetes.io/name=myapp
```
4. For other type of image, we need to annotate it (e.g. for the binary build). Note only io.openshift.build.commit.date is really required.
```
oc get images | grep  image-registry

oc label image sha256:31f2f6187b1ce171983faebb8815ce996e79cf07f214114ea0c69b8c2e7b3ac4 app.kubernetes.io/name=secondapp

oc annotate image sha256:31f2f6187b1ce171983faebb8815ce996e79cf07f214114ea0c69b8c2e7b3ac4 --overwrite io.openshift.build.commit.id=e2c4ef00468dfc10aad1bd2d4c9d470160a7f471 io.openshift.build.source-location=https://bitbucket.org/michalpryc/pelorus-bitbucket io.openshift.build.commit.date="Mon Aug 8 13:13:58 2022 -0600"
```

5. Start the exporter:
```
export PROVIDER=image
export LOG_LEVEL=debug
python exporters/committime/app.py
```


@redhat-cop/mdt
