### PR TITLE
Ensure mongo-persistent-scc is deleted in e2e tests

### DIFF
--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -372,6 +372,12 @@ if oc get namespace mongo-persistent 2>/dev/null; then
     oc delete -f "${DWN_DIR}/mongo-persistent.yaml"
 fi
 
+# Delete mongo-persistent-scc (securitycontextconstraints.security.openshift.io)
+# which may be left from previous runs.
+if oc get scc mongo-persistent-scc 2>/dev/null; then
+    oc delete scc mongo-persistent-scc
+fi
+
 # From now on, exit if something goes wrong
 set -e
 


### PR DESCRIPTION
Sometimes e2e tests are leaving mongo-persistent-scc behind remove this SCC if exists before running e2e tests.

@redhat-cop/mdt
