### PR TITLE
Requests custom certs docs and charts

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.2
+version: 1.7.3
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -25,44 +25,60 @@ spec:
         application: {{ .app_name }}
         pelorus.konveyor.io/exporter-type: {{ .exporter_type | default "generic-exporter" }}
     spec:
-      containers:
-      - name: {{ .app_name }}
-        imagePullPolicy: Always
-        envFrom:
-      {{- range .env_from_configmaps | default (list "default-pelorus-config" "default-deploytime-config") }}
-        - configMapRef:
-            name: {{ . }}
-      {{- end}}
-      {{- range .env_from_secrets }}
-        - secretRef:
-            name: {{ . }}
-      {{- end}}
-        env:
-{{- if .exporter_type }}
-        - name: APP_FILE
-          value: {{ .exporter_type }}/app.py
-{{- end }}
-{{- if and (not .source_ref) (not .source_url) }}
-        - name: PELORUS_IMAGE_TAG
-          value: {{ .app_name }}:{{ .image_tag | default "stable" }}
-{{- end }}
-{{- if .extraEnv }}
-{{ toYaml .extraEnv | indent 8 }}
-{{- end }}
-        ports:
-        - containerPort: 8080
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 8080
-          initialDelaySeconds: 15
-          periodSeconds: 20
       serviceAccount: pelorus-exporter
+      volumes:
+        {{- range $config := .custom_certs }}
+        - name: custom-cert-volume-{{$config.map_name}}
+          configMap:
+            name: {{ $config.map_name }}
+        {{- end }}
+      containers:
+        - name: {{ .app_name }}
+          imagePullPolicy: Always
+
+          volumeMounts:
+            {{- range $config := .custom_certs }}
+            - name: custom-cert-volume-{{$config.map_name}}
+              mountPath: /etc/pelorus/custom_certs/{{$config.map_name}}
+            {{- end }}
+
+          envFrom:
+            {{- range .env_from_configmaps | default (list "default-pelorus-config" "default-deploytime-config") }}
+            - configMapRef:
+                name: {{ . }}
+            {{- end }}
+
+            {{- range .env_from_secrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end}}
+          env:
+            {{- if .exporter_type }}
+            - name: APP_FILE
+              value: {{ .exporter_type }}/app.py
+            {{- end }}
+
+            {{- if and (not .source_ref) (not .source_url) }}
+            - name: PELORUS_IMAGE_TAG
+              value: {{ .app_name }}:{{ .image_tag | default "stable" }}
+            {{- end }}
+
+            {{- if .extraEnv }}
+            {{- toYaml .extraEnv | nindent 12}}
+            {{- end }}
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
   triggers:
   - type: ConfigChange
   - imageChangeParams:
@@ -71,10 +87,10 @@ spec:
       - {{ .app_name }}
       from:
         kind: ImageStreamTag
-{{- if or .source_ref .source_url }}
+        {{- if or .source_ref .source_url }}
         name: {{ .app_name }}:latest
-{{- else }}
+        {{- else }}
         name: {{ .app_name }}:{{ .image_tag | default "stable" }}
-{{- end }}
+        {{- end }}
     type: ImageChange
 {{- end }}

--- a/exporters/committime/collector_gitlab.py
+++ b/exporters/committime/collector_gitlab.py
@@ -27,6 +27,8 @@ from .collector_base import AbstractCommitCollector, UnsupportedGITProvider
 
 
 class GitLabCommitCollector(AbstractCommitCollector):
+    session: requests.Session
+
     def __init__(self, kube_client, username, token, namespaces, apps):
         super().__init__(
             kube_client,
@@ -37,9 +39,8 @@ class GitLabCommitCollector(AbstractCommitCollector):
             "GitLab",
             "%Y-%m-%dT%H:%M:%S.%f%z",
         )
-        set_up_requests_certs()
         self.session = requests.Session()
-        self.session = set_up_requests_certs()
+        self.session.verify = set_up_requests_certs()
 
     def _connect_to_gitlab(self, metric) -> gitlab.Gitlab:
         """Method to connect to Gitlab instance."""

--- a/exporters/extra/releasetime/collector_github.py
+++ b/exporters/extra/releasetime/collector_github.py
@@ -14,6 +14,7 @@ from prometheus_client.core import GaugeMetricFamily
 from requests import Session
 
 from pelorus import AbstractPelorusExporter
+from pelorus.certificates import set_up_requests_certs
 from pelorus.config import REDACT, env_vars, load_and_log, log
 from pelorus.config.converters import comma_or_whitespace_separated
 from pelorus.utils import TokenAuth, join_url_path_components
@@ -103,6 +104,8 @@ class GitHubReleaseCollector(AbstractPelorusExporter):
     def __attrs_post_init__(self):
         if not self.projects:
             raise ValueError("No projects specified for GitHub deploytime collector")
+
+        self._session.verify = set_up_requests_certs()
 
         if self.token:
             self._session.auth = TokenAuth(self.token)

--- a/exporters/tests/certs/conftest.py
+++ b/exporters/tests/certs/conftest.py
@@ -1,9 +1,10 @@
 import os
+import shutil
 from contextlib import suppress
-from pathlib import Path
 from threading import Thread
 
 import pytest
+from pytest import TempPathFactory
 
 import tests.certs.utils.https as https
 from pelorus.certificates import _combine_certificates
@@ -11,21 +12,29 @@ from tests.certs.utils.certs import CustomCerts, context_for_certs_dir, create_c
 
 
 @pytest.fixture
-def custom_certs(tmp_path: Path) -> CustomCerts:
+def custom_certs(tmp_path_factory: TempPathFactory) -> CustomCerts:
     """
     Get a bundle of custom certs.
     """
-    return create_certs(tmp_path)
+    return create_certs(tmp_path_factory.mktemp("custom-cert-workdir"))
 
 
 @pytest.fixture
 def combined_certificates(
+    tmp_path_factory: TempPathFactory,
     custom_certs: CustomCerts,
 ):
     """
     Get the path to an alread-combined certificate bundle.
     """
-    combined_bundle = _combine_certificates([custom_certs.bundle])
+    lookup_dir = tmp_path_factory.mktemp("custom_certs")
+
+    cert_containing_dir = lookup_dir / "0"
+    cert_containing_dir.mkdir()
+
+    shutil.copy(custom_certs.bundle, cert_containing_dir)
+
+    combined_bundle = _combine_certificates(lookup_dir)
 
     yield combined_bundle
 

--- a/exporters/tests/certs/test_custom_certs.py
+++ b/exporters/tests/certs/test_custom_certs.py
@@ -1,15 +1,16 @@
 from http.server import HTTPServer
+from pathlib import Path
 
 import pytest
 import requests
 
 
 def test_custom_requests_certs(
-    combined_certificates: str,
+    combined_certificates: Path,
     https_server: HTTPServer,
 ):
     session = requests.Session()
-    session.verify = combined_certificates
+    session.verify = str(combined_certificates)
 
     session.get(f"https://127.0.0.1:{https_server.server_port}")
 

--- a/exporters/tests/certs/utils/certs.py
+++ b/exporters/tests/certs/utils/certs.py
@@ -1,3 +1,6 @@
+"""
+Custom cert generation.
+"""
 import shutil
 import ssl
 import subprocess
@@ -10,6 +13,10 @@ CERT_X509_SAN_EXT_CONFIG = "subjectAltName=IP:127.0.0.1"
 
 
 class CustomCerts(NamedTuple):
+    """
+    A cert chain bundle and a private key file.
+    """
+
     bundle: Path
     keyfile: Path
 
@@ -23,23 +30,23 @@ def context_for_certs_dir(custom: CustomCerts) -> SSLContext:
     return ctx
 
 
-def create_certs(tmp_path: Path) -> CustomCerts:
+def create_certs(working_dir: Path) -> CustomCerts:
     """
     NOTE: no security guarantees here-- this is just for testing.
 
     Create a CA certificate, leaf certificate,
     and an unencrypted private key for the leaf cert.
     """
-    run = partial(subprocess.run, cwd=tmp_path, check=True)
+    run = partial(subprocess.run, cwd=working_dir, check=True)
 
     # although we use absolute paths as args,
     # openssl produces some other files as side effects.
-    priv_key_path = tmp_path / "priv.key"
-    ca_cert_path = tmp_path / "ca.pem"
-    csr_path = tmp_path / "req.csr"
-    csr_ext_path = tmp_path / "req.csr.ext"
-    leaf_cert_path = tmp_path / "leaf.pem"
-    bundle_path = tmp_path / "bundle.pem"
+    priv_key_path = working_dir / "priv.key"
+    ca_cert_path = working_dir / "ca.pem"
+    csr_path = working_dir / "req.csr"
+    csr_ext_path = working_dir / "req.csr.ext"
+    leaf_cert_path = working_dir / "leaf.pem"
+    bundle_path = working_dir / "bundle.pem"
 
     # create private key
     run(["openssl", "genpkey", "-algorithm", "rsa", "-out", priv_key_path])

--- a/exporters/tests/certs/utils/https.py
+++ b/exporters/tests/certs/utils/https.py
@@ -2,7 +2,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from ssl import SSLContext
 
 
-class ResponseHandler(BaseHTTPRequestHandler):
+class _ResponseHandler(BaseHTTPRequestHandler):
     """
     Returns a 204 for every GET.
     """
@@ -16,6 +16,6 @@ def make_server(ssl_context: SSLContext):
     """
     Make an HTTPS server serving on localhost on an ephemeral port.
     """
-    server = HTTPServer(("127.0.0.1", 0), ResponseHandler)
+    server = HTTPServer(("127.0.0.1", 0), _ResponseHandler)
     server.socket = ssl_context.wrap_socket(server.socket, server_side=True)
     return server


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Document how to use custom certificates, update charts with this functionality, and make the implementation simpler (dir based instead of env var based).

# ~~TODO~~ Done

- [x] add configmap volume support to exporter deploymentconfigs
- [x] ~~add `REQUESTS_CA_etc` env var building for deploymentconfig~~ using directories instead
- [x] let certificate setup function handle directories
- [x] document example(s)

## Linked Issues?

resolves #463

## Testing Instructions

While the unit tests should be sufficient for request testing, you can verify that loading the certs in the cluster works as follows.

1. Create a certificate and put it in a configmap:
```shell
openssl genpkey -algorithm rsa -out privkey.pem
openssl req -new -key privkey.pem -x509 -days 1 -subj '/CN=the coolest project ever AKA pelorus' -out cert.pem
oc create configmap my-certs --from-file=cert.pem
```
2. Deploy a requests-based exporter (listed in the docs-- committime_github is an easy one). Make sure it has the certificate map referenced as in [the docs](https://pelorus--612.org.readthedocs.build/en/612/Configuration/index.html#custom-certificates), and set the `LOG_LEVEL` to `DEBUG`.
3. Look in the logs for that deployed pod and look for the log line showing it was loaded, as indicated in [the docs](https://pelorus--612.org.readthedocs.build/en/612/Configuration/index.html#custom-certificates-example).