### PR TITLE
Allow user to override github bug label

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.3
+version: 1.7.4
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/configmaps/failuretime.yaml
+++ b/charts/pelorus/configmaps/failuretime.yaml
@@ -7,10 +7,11 @@ metadata:
   name: failuretime-config
   namespace: pelorus
 data:
-  PROVIDER: "default"    # jira  |  jira, github, servicenow
-  SERVER:                #       |  URL to the Jira or ServiceNowServer, can be overriden by env_from_secrets
-  API_USER:                  #       |  Tracker Username, can be overriden by env_from_secrets
-  TOKEN:                 #       |  User's API Token, can be overriden by env_from_secrets
+  PROVIDER: "default"             # jira  |  jira, github, servicenow
+  SERVER:                         #       |  URL to the Jira or ServiceNowServer, can be overriden by env_from_secrets
+  API_USER:                       #       |  Tracker Username, can be overriden by env_from_secrets
+  TOKEN:                          #       |  User's API Token, can be overriden by env_from_secrets
+  GITHUB_ISSUE_LABEL: "default"   # bug   |  bug  |  github default label for an issue marked as a bug.
   APP_FIELD: "default"   # u_application  | Required for ServiceNow,  used for the Application label. ex: "u_appName"
   PROJECTS:
 

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
 
     logging.info("Server: " + collector.server)
     logging.info(f"User: {collector.user}")
+    logging.info("APP_LABEL: " + pelorus.get_app_label())
     start_http_server(8080)
 
     REGISTRY.register(collector)

--- a/exporters/failure/collector_github.py
+++ b/exporters/failure/collector_github.py
@@ -75,6 +75,7 @@ class GithubFailureCollector(AbstractFailureCollector):
         except Exception:
             logging.warning("github username not found")
             raise
+        logging.info(f"Bug Label: " + pelorus.get_github_issue_label())
 
     def _get_github_user(self) -> str:
         # login and get username
@@ -124,7 +125,7 @@ class GithubFailureCollector(AbstractFailureCollector):
             for issue in all_issues:
                 is_bug = False
                 labels = issue["labels"]
-                is_bug = any(label for label in labels if "bug" in label["name"])
+                is_bug = any(label for label in labels if pelorus.get_github_issue_label() in label["name"])
                 logging.debug(
                     "Found issue opened: {}, {}: {}".format(
                         issue["created_at"], issue["number"], issue["title"]

--- a/exporters/failure/collector_github.py
+++ b/exporters/failure/collector_github.py
@@ -75,7 +75,7 @@ class GithubFailureCollector(AbstractFailureCollector):
         except Exception:
             logging.warning("github username not found")
             raise
-        logging.info(f"Bug Label: " + pelorus.get_github_issue_label())
+        logging.info("Bug Label: " + pelorus.get_github_issue_label())
 
     def _get_github_user(self) -> str:
         # login and get username
@@ -125,7 +125,11 @@ class GithubFailureCollector(AbstractFailureCollector):
             for issue in all_issues:
                 is_bug = False
                 labels = issue["labels"]
-                is_bug = any(label for label in labels if pelorus.get_github_issue_label() in label["name"])
+                is_bug = any(
+                    label
+                    for label in labels
+                    if pelorus.get_github_issue_label() in label["name"]
+                )
                 logging.debug(
                     "Found issue opened: {}, {}: {}".format(
                         issue["created_at"], issue["number"], issue["title"]

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -111,8 +111,10 @@ def get_app_label():
 def get_prod_label():
     return utils.get_env_var("PROD_LABEL", DEFAULT_PROD_LABEL)
 
+
 def get_github_issue_label():
     return utils.get_env_var("GITHUB_ISSUE_LABEL", DEFAULT_GITHUB_ISSUE_LABEL)
+
 
 def missing_configs(vars):
     missing_configs = False
@@ -132,9 +134,6 @@ def upgrade_legacy_vars():
     api_user = utils.get_env_var("API_USER")
     github_user = utils.get_env_var("GITHUB_USER")
     git_username = utils.get_env_var("GIT_USER")
-
-    github_issue_label = utils.get_env_var("GITHUB_ISSUE_LABEL", 
-        DEFAULT_GITHUB_ISSUE_LABEL)
 
     assigned_user = api_user or git_username or github_user
 

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -20,6 +20,7 @@ DEFAULT_TLS_VERIFY = True
 DEFAULT_TRACKER = "jira"
 DEFAULT_TRACKER_APP_LABEL = "unknown"
 DEFAULT_TRACKER_APP_FIELD = "u_application"
+DEFAULT_GITHUB_ISSUE_LABEL = "bug"
 
 
 def _print_version():
@@ -110,6 +111,8 @@ def get_app_label():
 def get_prod_label():
     return utils.get_env_var("PROD_LABEL", DEFAULT_PROD_LABEL)
 
+def get_github_issue_label():
+    return utils.get_env_var("GITHUB_ISSUE_LABEL", DEFAULT_GITHUB_ISSUE_LABEL)
 
 def missing_configs(vars):
     missing_configs = False
@@ -129,6 +132,9 @@ def upgrade_legacy_vars():
     api_user = utils.get_env_var("API_USER")
     github_user = utils.get_env_var("GITHUB_USER")
     git_username = utils.get_env_var("GIT_USER")
+
+    github_issue_label = utils.get_env_var("GITHUB_ISSUE_LABEL", 
+        DEFAULT_GITHUB_ISSUE_LABEL)
 
     assigned_user = api_user or git_username or github_user
 


### PR DESCRIPTION
Issues in github for personal repos by default have the label "bug".
It is possible for an org or user to use any label to indicate a bug.
For example OpenShift changed the label "bug" to "kind/bug"

This change is meant to make the label used for issues only in Github.
Allow the user to override the label.

* log the bug label
* also added, log the app_label

A customer can set two labels on the github issue, the bug label and the app_label

## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #547

Example of how I tested:
```
(.venv) [whayutin@thinkdoe pelorus]$ export PROVIDER=github
(.venv) [whayutin@thinkdoe pelorus]$ export TOKEN=ghp_<snip>
(.venv) [whayutin@thinkdoe pelorus]$  hstr -- 
export PROJECTS=weshayutin/mig-demo-apps,konveyor/pelorus
(.venv) [whayutin@thinkdoe pelorus]$ export PROJECTS=weshayutin/mig-demo-apps,konveyor/pelorus
(.venv) [whayutin@thinkdoe pelorus]$ python exporters/failure/app.py 
Running failure exporter. No version information found.
Initializing Logger with LogLevel: INFO
08-29-2022 12:10:37 INFO     ===== Starting Failure Collector =====
08-29-2022 12:10:37 INFO     Querying issues from 'weshayutin/mig-demo-apps,konveyor/pelorus' projects.
08-29-2022 12:10:37 INFO     Bug Label: bug
08-29-2022 12:10:37 INFO     Server: api.github.com
08-29-2022 12:10:37 INFO     User: weshayutin
08-29-2022 12:10:37 INFO     APP_LABEL: app.kubernetes.io/name
08-29-2022 12:10:37 INFO     Getting issues from: weshayutin/mig-demo-apps
08-29-2022 12:10:37 INFO     Getting issues from: konveyor/pelorus
^CTraceback (most recent call last):
  File "/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/failure/app.py", line 85, in <module>
    time.sleep(1)
KeyboardInterrupt

(.venv) [whayutin@thinkdoe pelorus]$  hstr -- 
export APP_LABEL=production_issue/name
(.venv) [whayutin@thinkdoe pelorus]$ export APP_LABEL=production_issue/name
(.venv) [whayutin@thinkdoe pelorus]$ python exporters/failure/app.py 
Running failure exporter. No version information found.
Initializing Logger with LogLevel: INFO
08-29-2022 12:10:55 INFO     ===== Starting Failure Collector =====
08-29-2022 12:10:55 INFO     Querying issues from 'weshayutin/mig-demo-apps,konveyor/pelorus' projects.
08-29-2022 12:10:55 INFO     Bug Label: bug
08-29-2022 12:10:55 INFO     Server: api.github.com
08-29-2022 12:10:55 INFO     User: weshayutin
08-29-2022 12:10:55 INFO     APP_LABEL: production_issue/name
08-29-2022 12:10:55 INFO     Getting issues from: weshayutin/mig-demo-apps
08-29-2022 12:10:55 INFO     Getting issues from: konveyor/pelorus
08-29-2022 12:10:56 INFO     Collected failure_creation_timestamp{ app=pelorus, issue_number=613 } 1661359277.0
^CTraceback (most recent call last):
  File "/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/failure/app.py", line 85, in <module>
    time.sleep(1)
KeyboardInterrupt

(.venv) [whayutin@thinkdoe pelorus]$  hstr -- 
export GITHUB_ISSUE_LABEL=bug
(.venv) [whayutin@thinkdoe pelorus]$ export GITHUB_ISSUE_LABEL=foo
(.venv) [whayutin@thinkdoe pelorus]$ python exporters/failure/app.py 
Running failure exporter. No version information found.
Initializing Logger with LogLevel: INFO
08-29-2022 12:11:29 INFO     ===== Starting Failure Collector =====
08-29-2022 12:11:29 INFO     Querying issues from 'weshayutin/mig-demo-apps,konveyor/pelorus' projects.
08-29-2022 12:11:30 INFO     Bug Label: foo
08-29-2022 12:11:30 INFO     Server: api.github.com
08-29-2022 12:11:30 INFO     User: weshayutin
08-29-2022 12:11:30 INFO     APP_LABEL: production_issue/name
08-29-2022 12:11:30 INFO     Getting issues from: weshayutin/mig-demo-apps
08-29-2022 12:11:30 INFO     Getting issues from: konveyor/pelorus
^CTraceback (most recent call last):
  File "/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/failure/app.py", line 85, in <module>
    time.sleep(1)
KeyboardInterrupt

(.venv) [whayutin@thinkdoe pelorus]$ export GITHUB_ISSUE_LABEL=kind/bug
(.venv) [whayutin@thinkdoe pelorus]$ python exporters/failure/app.py 
Running failure exporter. No version information found.
Initializing Logger with LogLevel: INFO
08-29-2022 12:11:40 INFO     ===== Starting Failure Collector =====
08-29-2022 12:11:40 INFO     Querying issues from 'weshayutin/mig-demo-apps,konveyor/pelorus' projects.
08-29-2022 12:11:40 INFO     Bug Label: kind/bug
08-29-2022 12:11:40 INFO     Server: api.github.com
08-29-2022 12:11:40 INFO     User: weshayutin
08-29-2022 12:11:40 INFO     APP_LABEL: production_issue/name
08-29-2022 12:11:40 INFO     Getting issues from: weshayutin/mig-demo-apps
08-29-2022 12:11:40 INFO     Getting issues from: konveyor/pelorus
08-29-2022 12:11:40 INFO     Collected failure_creation_timestamp{ app=pelorus, issue_number=613 } 1661359277.0
^CTraceback (most recent call last):
  File "/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/failure/app.py", line 85, in <module>
    time.sleep(1)
KeyboardInterrupt
```