### PR TITLE
Update tekton to label committime on image for s2itekton

### DIFF
--- a/demo/tekton-demo-setup/03-build-and-deploy.yaml
+++ b/demo/tekton-demo-setup/03-build-and-deploy.yaml
@@ -63,16 +63,22 @@ objects:
           storage: 500Mi
 
   - kind: Task
-    apiVersion: tekton.dev/v1alpha1
+    apiVersion: tekton.dev/v1beta1
     metadata:
       name: debug
       namespace: ${NAMESPACE}
+      description: collect git repo debug information 
     spec:
       # notes: each task specifies the workspace name
       # the same pvc is used, only the mounted directory changes based on the name
       # in this case "debug"
       workspaces:
         - name: debug
+      results: 
+        - name: list-files
+          description: lists the repos files
+        - name: commit-time
+          description: get the time of the last commit
       steps:
         - name: list-workspace-files
           image: ubi9/toolbox
@@ -82,6 +88,17 @@ objects:
             cd /workspace/debug 
             git remote -vv 
             git log -n 1
+        - name: time-last-commit
+          image: ubi9/toolbox
+          script: |
+            set -ex
+            find /workspace
+            cd /workspace/debug 
+            git log -1 --format=%cd > "$(results.commit-time.path)"
+        - name: debug-time-last-commit
+          image: ubi9/toolbox
+          script: |
+            cat "$(results.commit-time.path)"
 
   - kind: Pipeline
     apiVersion: tekton.dev/v1beta1
@@ -179,6 +196,7 @@ objects:
                 oc label image "$(tasks.builds2i.results.IMAGE_DIGEST)" app.kubernetes.io/name=basic-python-tekton
                 oc annotate image "$(tasks.builds2i.results.IMAGE_DIGEST)" io.openshift.build.commit.id="$(tasks.checkout.results.commit)"
                 oc annotate image "$(tasks.builds2i.results.IMAGE_DIGEST)" io.openshift.build.source-location="$(tasks.checkout.results.url)"
+                oc annotate image "$(tasks.builds2i.results.IMAGE_DIGEST)" io.openshift.build.commit.date="$(tasks.listfiles.results.commit-time)" 
           runAfter: [builds2i]
           taskRef:
             kind: ClusterTask

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -137,7 +137,7 @@ class ImageCommitCollector(AbstractCommitCollector):
                 COMMIT_DATE_ANNOTATION_ENV,
                 CommitMetric._ANNOTATION_MAPPIG.get("commit_time"),
             )
-            commit_time = metric.annotations.get(commit_time_annotation)
+            commit_time = metric.annotations.get(commit_time_annotation).strip()
             if commit_time:
                 metric.commit_time = commit_time
                 logging.debug(

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -137,9 +137,9 @@ class ImageCommitCollector(AbstractCommitCollector):
                 COMMIT_DATE_ANNOTATION_ENV,
                 CommitMetric._ANNOTATION_MAPPIG.get("commit_time"),
             )
-            commit_time = metric.annotations.get(commit_time_annotation).strip()
+            commit_time = metric.annotations.get(commit_time_annotation)
             if commit_time:
-                metric.commit_time = commit_time
+                metric.commit_time = commit_time.strip()
                 logging.debug(
                     "Commit time for image %s provided by '%s' annotation: %s",
                     metric.image_hash,


### PR DESCRIPTION
tekton s2i task provides no builds, buildConfig etc. The
only artifact is an image.  Enhance the labels2i tekton task
to also annotate w/ the commit time.

When creating a result in tekton for the commit time the result
has a new line.  Use strip() on the annotation label.

## Testing Instructions

Use the image provider for the committime exporter, and execute 
```
./demo-tekton.sh -g https://github.com/konveyor/pelorus -b s2i -r master
```
results:

```
warnings.warn(
08-31-2022 11:54:05 INFO     Loading ImageCommittimeConfig, inputs below:
08-31-2022 11:54:05 INFO     date_format='%a %b %d %H:%M:%S %Y %z', default value; COMMIT_DATE_FORMAT was not set
08-31-2022 11:54:05 INFO     =====Using Image Collector=====
08-31-2022 11:54:05 DEBUG    /home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/committime/collector_image.py:162 generate_metrics() Searching for images with label: app.kubernetes.io/name
/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/.venv/lib64/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-wdh07052022a.wdh07052022a.mg.dog8code.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/.venv/lib64/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-wdh07052022a.wdh07052022a.mg.dog8code.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
08-31-2022 11:54:05 DEBUG    /home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/committime/collector_image.py:143 _set_commit_time_from_annotations() Commit time for image sha256:9e69d20ceeab791da3781abf263c3a2c18e850f23d5b4f9fbf964a1ec9469fb1 provided by 'io.openshift.build.commit.date' annotation: Tue Aug 30 14:13:13 2022 -0400
08-31-2022 11:54:05 DEBUG    /home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/committime/collector_base.py:277 _set_commit_hash_from_annotations() Commit hash for build None provided by 'io.openshift.build.commit.id' annotation: f0be306b70e9156a0a5a7f9270a8060a82e039c1
08-31-2022 11:54:05 DEBUG    /home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/committime/collector_image.py:202 _get_metrics_by_apps_from_images() Adding metric for app basic-python-tekton
08-31-2022 11:54:05 DEBUG    /home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/committime/collector_image.py:143 _set_commit_time_from_annotations() Commit time for image sha256:eabb013b89e66a8b7e717c831841ec39cafe4bfe7f5e0d678b17ad9e59141465 provided by 'io.openshift.build.commit.date' annotation: Tue Aug 30 14:13:13 2022 -0400
08-31-2022 11:54:05 DEBUG    /home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/committime/collector_base.py:277 _set_commit_hash_from_annotations() Commit hash for build None provided by 'io.openshift.build.commit.id' annotation: f0be306b70e9156a0a5a7f9270a8060a82e039c1
08-31-2022 11:54:05 DEBUG    /home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/exporters/committime/collector_image.py:202 _get_metrics_by_apps_from_images() Adding metric for app basic-python-tekton
08-31-2022 11:54:05 INFO     Collected commit_timestamp{ namespace=None, app=basic-python-tekton, commit=f0be306b70e9156a0a5a7f9270a8060a82e039c1, image_sha=sha256:9e69d20ceeab791da3781abf263c3a2c18e850f23d5b4f9fbf964a1ec9469fb1 } 1661868793.0
08-31-2022 11:54:05 INFO     Collected commit_timestamp{ namespace=None, app=basic-python-tekton, commit=f0be306b70e9156a0a5a7f9270a8060a82e039c1, image_sha=sha256:eabb013b89e66a8b7e717c831841ec39cafe4bfe7f5e0d678b17ad9e59141465 } 1661868793.0

```
