### PR TITLE
Ensure thanos uses same version across all required containers

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.4
+version: 1.7.5
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/templates/prometheus-cr.yaml
+++ b/charts/pelorus/templates/prometheus-cr.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   {{- if .Values.bucket_access_point }}
   thanos:
-    baseImage: quay.io/thanos/thanos
-    version: v0.8.1
+    image: quay.io/thanos/thanos:{{ .Values.thanos_version | default "v0.28.0" }}
+    version: {{ .Values.thanos_version | default "v0.28.0" }}
     objectStorageConfig:
       key: thanos.yaml
       name: thanos-objstore-config

--- a/charts/pelorus/templates/thanos-query.yml
+++ b/charts/pelorus/templates/thanos-query.yml
@@ -35,7 +35,7 @@ spec:
   {{- end }}
       containers:
       - name: thanos-query
-        image: quay.io/thanos/thanos:v0.27.0
+        image: quay.io/thanos/thanos:{{ .Values.thanos_version | default "v0.28.0" }}
         args:
         - "query"
         - "--log.level=info"

--- a/charts/pelorus/templates/thanos-store.yml
+++ b/charts/pelorus/templates/thanos-store.yml
@@ -30,7 +30,7 @@ spec:
           name: trusted-certs
       containers:
       - name: thanos-store
-        image: quay.io/thanos/thanos:v0.27.0
+        image: quay.io/thanos/thanos:{{ .Values.thanos_version | default "v0.28.0" }}
         args:
         - "store"
         - "--log.level=info"

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -12,7 +12,7 @@ extra_prometheus_hosts:
 
 # Thanos / S3 Storage with noobaa
 # thanos_bucket_name: thanos
-# bucket_access_point: s3.noobaa.svc
+# bucket_access_point: s3.pelorus.svc:443
 # bucket_access_key:
 # bucket_secret_access_key:
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -55,7 +55,7 @@ See [Configuring the Pelorus Stack](Configuration.md) for a full readout of all 
 The Pelorus chart supports deploying a thanos instance for long term storage.  It can use any S3 bucket provider. The following is an example of configuring a values.yaml file for NooBaa with the local s3 service name:
 
 ```
-bucket_access_point: s3.noobaa.svc
+bucket_access_point: s3.pelorus.svc:443
 bucket_access_key: <your access key>
 bucket_secret_access_key: <your secret access key>
 ```
@@ -63,7 +63,7 @@ bucket_secret_access_key: <your secret access key>
 The default bucket name is thanos.  It can be overriden by specifying an additional value for the bucket name as in:
 
 ```
-bucket_access_point: s3.noobaa.svc
+bucket_access_point: s3.pelorus.svc:443
 bucket_access_key: <your access key>
 bucket_secret_access_key: <your secret access key>
 thanos_bucket_name: <bucket name here>

--- a/docs/Noobaa.md
+++ b/docs/Noobaa.md
@@ -107,13 +107,13 @@ noobaa bucket status thanos --namespace pelorus
 
 To update our Pelorus stack, follow the instructions provided in the [Long Term Storage](Install.md#configure-long-term-storage-recommended).
 
-Ensure that `<s3 access key>`, `<s3 secred access key>` and `<bucket name>` are used from the [Deploy NooBaa
-](#deploy-noobaa) step and `s3.noobaa.svc` as bucket access point as in example:
+Ensure that `<s3 access key>`, `<s3 secred access key>` and the `<bucket name>` are used from the [Deploy NooBaa
+](#deploy-noobaa) step and `s3.pelorus.svc:443`, which is an `S3 InternalDNS Address` from the `noobaa status --namespace pelorus` command, as bucket access point as in example:
 
 ```yaml
 # Thanos / S3 Storage with noobaa
 thanos_bucket_name: thanos
-bucket_access_point: s3.noobaa.svc
+bucket_access_point: s3.pelorus.svc:443
 bucket_access_key: <s3 access key>
 bucket_secret_access_key: <s3 secred access key>
 


### PR DESCRIPTION
This fixes issues with stanos-store side container not writing data to the s3 buckets.

Related issue #139 

## Testing Instructions
1. Create pelorus namespace
2. Ensure noobaa is configured/deployed and bucket thanos is created
3. Deploy Pelorus with Thanos pointing to the noobaa s3 storage created
4. Ensure s3 bucket is not empty - typically takes 2h from the time of deployment (s3cmd command can be used: s3cmd ls s3://thanos). 
Example s3cfg file vars from < > can be gathered from the noobaa status --namespace pelorus:
```
$ cat ~/.s3cfg
[default]
host_base = <ExternalDNS> # e.g. s3-pelorus.apps.cluster-mpryc1502ocp49n.mpryc1502ocp49n.mg.dog8code.com:443
host_bucket = <Backing Stores/TARGET-BUCKET> #e.g. nb.1661336201734.mpryc1502ocp49n.mg.dog8code.com
access_key = <AWS_ACCESS_KEY_ID>
secret_key = <AWS_SECRET_ACCESS_KEY>
use_https = True
check_ssl_certificate = False
check_ssl_hostname = False
signature_v2 = True
multipart_chunk_size_mb = 32
send_chunk = 1048576
```
5. Ensure pelorus gathers data, and grafana shows data
6. Uninstall pelorus and reinstall it
7. Ensure pelorus data has historical records and not only ones from the last installation 

@redhat-cop/mdt
