### PR TITLE
Add option to configure prometheus with PVC

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.4
+version: 1.7.5
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/templates/prometheus-cr.yaml
+++ b/charts/pelorus/templates/prometheus-cr.yaml
@@ -5,6 +5,18 @@ metadata:
   labels:
     prometheus: prometheus-pelorus
 spec:
+  {{- if eq (.Values.prometheus_storage | toString) "true" }}
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.prometheus_storage_pvc_storageclass }}
+        storageClassName: {{ .Values.prometheus_storage_pvc_storageclass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.prometheus_storage_pvc_capacity | default "2Gi" }}
+  {{- end }}
   {{- if .Values.bucket_access_point }}
   thanos:
     baseImage: quay.io/thanos/thanos
@@ -74,5 +86,4 @@ spec:
       readOnly: true
       mountPath: /etc/prometheus/configmaps/cluster-ca-bundle
 {{- end }}
-
 

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -16,6 +16,16 @@ extra_prometheus_hosts:
 # bucket_access_key:
 # bucket_secret_access_key:
 
+## Persistent storage for Prometheus Operator
+# https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/storage.md
+
+# Uncomment to use PVC for Prometheus
+# prometheus_storage: true
+
+# Additional configuration options for Prometheus PVC
+# prometheus_storage_pvc_capacity: 2Gi
+# prometheus_storage_pvc_storageclass: "gp2"
+
 exporters:
   instances:
   - app_name: deploytime-exporter


### PR DESCRIPTION
Thanos does persist Prometheus data, however the data is stored in buckets every 2h. Prometheus PVC allows to continuously store data and be resiliant to prometheus operator restarts and upgrades allowing to keep the data safe.

## Testing Instructions

Deploy pelorus with the following config options:
```
prometheus_storage: true # mandatory
prometheus_storage_pvc_capacity: 2Gi #optional
prometheus_storage_pvc_storageclass: "gp2" #optional
```

Check that the PVC were created:
```
oc get pvc -n pelorus
```

Fixes #622

@redhat-cop/mdt
