### PR TITLE
Use quay.io images from migtools namespace

### DIFF
--- a/.github/workflows/build-pelorus.yaml
+++ b/.github/workflows/build-pelorus.yaml
@@ -29,7 +29,7 @@ jobs:
         id: build-exporter
         uses: redhat-actions/s2i-build@v2
         with:
-          image: 'committime-exporter'
+          image: 'pelorus-committime-exporter'
           path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
           tags: ${{ env.latesttag }} ${{ github.sha }}
@@ -57,7 +57,7 @@ jobs:
         id: build-exporter
         uses: redhat-actions/s2i-build@v2
         with:
-          image: 'deploytime-exporter'
+          image: 'pelorus-deploytime-exporter'
           path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
           tags: ${{ env.latesttag }} ${{ github.sha }}
@@ -86,7 +86,36 @@ jobs:
         id: build-exporter
         uses: redhat-actions/s2i-build@v2
         with:
-          image: 'failure-exporter'
+          image: 'pelorus-failure-exporter'
+          path_context: 'exporters'
+          builder_image: ${{ env.builder_image }}
+          tags: ${{ env.latesttag }} ${{ github.sha }}
+          log_level: ${{ env.s2i_log_level }}
+
+
+      # Push Image to Quay registry
+      - name: Push To Quay Action
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-exporter.outputs.image }}
+          tags: ${{ steps.build-exporter.outputs.tags }}
+          registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+
+  build-releasetime:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Setup S2i and Build container image
+      - name: Setup and Build
+        id: releasetime-exporter
+        uses: redhat-actions/s2i-build@v2
+        with:
+          image: 'pelorus-releasetime-exporter'
           path_context: 'exporters'
           builder_image: ${{ env.builder_image }}
           tags: ${{ env.latesttag }} ${{ github.sha }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Tag committime with (pre)release version
         uses: tinact/docker.image-retag@1.0.2
         with:
-          image_name: ${{ env.imagenamespace }}/committime-exporter
+          image_name: ${{ env.imagenamespace }}/pelorus-committime-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ github.event.release.tag_name }}
           registry: ${{ env.imageregistry }}
@@ -31,7 +31,7 @@ jobs:
       - name: Tag deploytime with (pre)released version
         uses: tinact/docker.image-retag@1.0.2
         with:
-          image_name: ${{ env.imagenamespace }}/deploytime-exporter
+          image_name: ${{ env.imagenamespace }}/pelorus-deploytime-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ github.event.release.tag_name }}
           registry: ${{ env.imageregistry }}
@@ -41,7 +41,17 @@ jobs:
       - name: Tag failure with (pre)released version
         uses: tinact/docker.image-retag@1.0.2
         with:
-          image_name: ${{ env.imagenamespace }}/failure-exporter
+          image_name: ${{ env.imagenamespace }}/pelorus-failure-exporter
+          image_old_tag: ${{ github.sha }}
+          image_new_tag: ${{ github.event.release.tag_name }}
+          registry: ${{ env.imageregistry }}
+          registry_username: ${{ secrets.QUAY_USERNAME }}
+          registry_password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Tag failure with (pre)released version
+        uses: tinact/docker.image-retag@1.0.2
+        with:
+          image_name: ${{ env.imagenamespace }}/pelorus-releasetime-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ github.event.release.tag_name }}
           registry: ${{ env.imageregistry }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Tag committime with release version
         uses: tinact/docker.image-retag@1.0.2
         with:
-          image_name: ${{ env.imagenamespace }}/committime-exporter
+          image_name: ${{ env.imagenamespace }}/pelorus-committime-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ env.releasetag }}
           registry: ${{ env.imageregistry }}
@@ -31,7 +31,7 @@ jobs:
       - name: Tag deploytime with released version
         uses: tinact/docker.image-retag@1.0.2
         with:
-          image_name: ${{ env.imagenamespace }}/deploytime-exporter
+          image_name: ${{ env.imagenamespace }}/pelorus-deploytime-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ env.releasetag }}
           registry: ${{ env.imageregistry }}
@@ -41,7 +41,17 @@ jobs:
       - name: Tag failure with released version
         uses: tinact/docker.image-retag@1.0.2
         with:
-          image_name: ${{ env.imagenamespace }}/failure-exporter
+          image_name: ${{ env.imagenamespace }}/pelorus-failure-exporter
+          image_old_tag: ${{ github.sha }}
+          image_new_tag: ${{ env.releasetag }}
+          registry: ${{ env.imageregistry }}
+          registry_username: ${{ secrets.QUAY_USERNAME }}
+          registry_password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Tag failure with released version
+        uses: tinact/docker.image-retag@1.0.2
+        with:
+          image_name: ${{ env.imagenamespace }}/pelorus-releasetime-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ env.releasetag }}
           registry: ${{ env.imageregistry }}

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.5
+version: 1.7.6
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/charts/exporters/templates/_imagestream_from_image.yaml
@@ -23,7 +23,7 @@ spec:
       name: {{ .image_name }}:{{ .image_tag | default "stable" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/{{ .exporter_type }}-exporter:{{ .image_tag | default "stable" }}
+      name: quay.io/migtools/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "stable" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -50,4 +50,15 @@ exporters:
 #    env_from_secrets:
 #    - github-secret
 
+# Experimental GitHub releasetime exporter
+#  - app_name: releasetime-exporter
+#    env_from_configmaps:
+#    - pelorus-config
+#    - releasetime-config
+#    env_from_secrets:
+#    - github-secret
+#    extraEnv:
+#    - name: APP_FILE
+#      value: extra/releasetime/app.py
+
 snapshot_schedule: "@monthly"

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -93,9 +93,9 @@ Each exporter can be deployed from the pre-built images or from the source code 
 
 If not defined specifically, exporters are using pre-built container images with the `stable` tag from the following sources:
 
-  * Quay repository for the [committime-exporter](https://quay.io/repository/pelorus/committime-exporter)
-  * Quay repository for the [failure-exporter](https://quay.io/repository/pelorus/failure-exporter)
-  * Quay repository for the [deploytime-exporter](https://quay.io/repository/pelorus/deploytime-exporter)
+  * Quay repository for the [committime-exporter](https://quay.io/repository/migtools/pelorus-committime-exporter)
+  * Quay repository for the [failure-exporter](https://quay.io/repository/migtools/pelorus-failure-exporter)
+  * Quay repository for the [deploytime-exporter](https://quay.io/repository/migtools/pelorus-deploytime-exporter)
 
 #### Pre-built Quay images
 


### PR DESCRIPTION
Moves building, tagging and using images from new migtools namespace.

Adds experimental releasetime GitHub exporter images and example use in values.yaml.

Please review. Once everyone is happy we will need to update in this repository the following secrets and create release so images are built:
 * QUAY_USERNAME
 * QUAY_PASSWORD
 * QUAY_IMAGE_NAMESPACE


Signed-off-by: Michal Pryc <mpryc@redhat.com>

@redhat-cop/mdt
