### PR TITLE
Fix id of the action used to build pelorus-releasetime-exporter

### DIFF
--- a/.github/workflows/build-pelorus.yaml
+++ b/.github/workflows/build-pelorus.yaml
@@ -112,7 +112,7 @@ jobs:
 
       # Setup S2i and Build container image
       - name: Setup and Build
-        id: releasetime-exporter
+        id: build-exporter
         uses: redhat-actions/s2i-build@v2
         with:
           image: 'pelorus-releasetime-exporter'


### PR DESCRIPTION
Small nit which fixes build of the pelorus-releasetime-exporter.

@redhat-cop/mdt
