### PR TITLE
minor release for new quay.io migtool image location.

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.0
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.7.6
+version: 1.8.0
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v1.7.1" }}
+      ref: {{ .source_ref | default "v1.8.0" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -20,7 +20,7 @@ Pelorus gets installed via helm charts. The first deploys the operators on which
 
 ```shell
 # clone the repo (you can use a different release or clone from master if you wish)
-git clone --depth 1 --branch v1.7.1 https://github.com/konveyor/pelorus
+git clone --depth 1 --branch v1.8.0 https://github.com/konveyor/pelorus
 cd pelorus
 oc create namespace pelorus
 helm install operators charts/operators --namespace pelorus


### PR DESCRIPTION
minor release (1.8.0) with modified location of the Pelorus Quay images.

Current location for the four exporters:

https://quay.io/repository/migtools/pelorus-committime-exporter
https://quay.io/repository/migtools/pelorus-deploytime-exporter
https://quay.io/repository/migtools/pelorus-failure-exporter

Experimental exporter:
https://quay.io/repository/migtools/pelorus-releasetime-exporter

Signed-off-by: Michal Pryc <mpryc@redhat.com>

@redhat-cop/mdt
