### PR TITLE
Fix to ensure scenario-2 are running different deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ e2e-tests-scenario-1: e2e-tests-dev-env
 
 e2e-tests-scenario-2: e2e-tests-dev-env
 	. ${PELORUS_VENV}/bin/activate && \
-	./scripts/run-pelorus-e2e-tests "periodic/different_deployment_methods.yaml"
+	./scripts/run-pelorus-e2e-tests -f "periodic/different_deployment_methods.yaml"
 
 # Integration tests
 ## integration-tests: pytest -rap -m integration


### PR DESCRIPTION
Small nit which caused scenario-2 jobs running PR type of tests instead of real different deployment methods.

## Testing Instructions

# Ensure cluster has nothing in pelorus namespace
$ make e2e-tests-scenario-2

# Check if proper deployments were made:
```
$ oc get pods -n pelorus
NAME                                                   READY   STATUS      RESTARTS      AGE
committime-exporter-1-deploy                           0/1     Completed   0             27m
committime-exporter-1-j2mvb                            1/1     Running     0             27m
deploytime-exporter-2-956x6                            1/1     Running     0             27m
deploytime-exporter-2-deploy                           0/1     Completed   0             27m
git-custom-source-ref-committime-exporter-1-build      0/1     Completed   0             27m
git-custom-source-ref-committime-exporter-1-deploy     0/1     Completed   0             25m
git-custom-source-ref-committime-exporter-1-qvp64      1/1     Running     0             25m
git-custom-source-ref-deploytime-exporter-1-build      0/1     Completed   0             27m
git-custom-source-ref-deploytime-exporter-1-deploy     0/1     Completed   0             25m
git-custom-source-ref-deploytime-exporter-1-kpsss      1/1     Running     0             25m
git-custom-url-committime-exporter-1-build             0/1     Completed   0             27m
git-custom-url-committime-exporter-1-deploy            0/1     Completed   0             25m
git-custom-url-committime-exporter-1-jjsd6             1/1     Running     0             25m
git-custom-url-deploytime-exporter-1-build             0/1     Completed   0             27m
git-custom-url-deploytime-exporter-1-c2n5s             1/1     Running     0             25m
git-custom-url-deploytime-exporter-1-deploy            0/1     Completed   0             25m
grafana-deployment-55f77ccc8f-fz7w8                    2/2     Running     0             28m
grafana-operator-controller-manager-7678cc5c7c-b8j2d   2/2     Running     0             29m
latest-custom-imagetag-committime-exporter-1-deploy    0/1     Completed   0             27m
latest-custom-imagetag-committime-exporter-1-sktmz     1/1     Running     0             27m
latest-custom-imagetag-deploytime-exporter-1-deploy    0/1     Completed   0             27m
latest-custom-imagetag-deploytime-exporter-1-hbbm2     1/1     Running     0             27m
prometheus-operator-559d659944-ksd6f                   1/1     Running     0             28m
prometheus-prometheus-pelorus-0                        3/3     Running     1 (28m ago)   28m
prometheus-prometheus-pelorus-1                        3/3     Running     1 (28m ago)   28m

```


@redhat-cop/mdt
