### PR TITLE
Make logging set up part of exporter startup, not import side effect

### DIFF
--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -156,6 +156,7 @@ class GitCommittimeConfig:
 
 
 if __name__ == "__main__":
+    pelorus.setup_logging()
     provider_config = load_and_log(CommittimeTypeConfig)
 
     dyn_client = pelorus.utils.get_k8s_client()

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -208,6 +208,7 @@ def get_replicas(
 
 
 if __name__ == "__main__":
+    pelorus.setup_logging()
     dyn_client = pelorus.utils.get_k8s_client()
 
     namespaces = {

--- a/exporters/extra/releasetime/app.py
+++ b/exporters/extra/releasetime/app.py
@@ -3,9 +3,11 @@ import time
 from prometheus_client import start_http_server
 from prometheus_client.core import REGISTRY
 
+import pelorus
 from extra.releasetime import collector_github
 
 if __name__ == "__main__":
+    pelorus.setup_logging()
     collector = collector_github.make_collector()
 
     REGISTRY.register(collector)

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -70,6 +70,7 @@ class TrackerFactory:
 
 
 if __name__ == "__main__":
+    pelorus.setup_logging()
     logging.info("===== Starting Failure Collector =====")
 
     collector = TrackerFactory.getCollector()

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -55,7 +55,7 @@ def _print_version():
 
 
 # region: logging setup
-def _setup_logging():
+def setup_logging():
     _print_version()
     loglevel = utils.get_env_var("LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
     numeric_level = getattr(logging, loglevel, None)
@@ -71,8 +71,6 @@ def _setup_logging():
     root_logger.setLevel(numeric_level)
     print(f"Initializing Logger with LogLevel: {loglevel}")
 
-
-_setup_logging()
 
 
 # endregion

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -72,7 +72,6 @@ def setup_logging():
     print(f"Initializing Logger with LogLevel: {loglevel}")
 
 
-
 # endregion
 
 # A NamespaceSpec lists namespaces to restrict the search to.

--- a/exporters/tests/test_config.py
+++ b/exporters/tests/test_config.py
@@ -3,6 +3,7 @@ from typing import Optional
 import pytest
 from attrs import define, field
 
+import pelorus
 from pelorus.config import load_and_log
 from pelorus.config.converters import comma_separated
 from pelorus.config.loading import env_vars, no_env_vars
@@ -86,6 +87,8 @@ def test_loading_from_other():
 
 
 def test_logging(caplog: pytest.LogCaptureFixture):
+    pelorus.setup_logging()
+
     @define(kw_only=True)
     class Loggable:
         regular_field: str = field(default="LOG ME 1")


### PR DESCRIPTION
Addressing feedback from https://github.com/konveyor/pelorus/pull/615#pullrequestreview-1107138110 (and solving personal annoyances)

The logging system is now configured as part of exporter startup. Previously it was a side-effect of importing pelorus (bad!)