### PR TITLE
Validation of Thanos data in e2e script

### DIFF
--- a/scripts/run-pelorus-e2e-tests
+++ b/scripts/run-pelorus-e2e-tests
@@ -561,3 +561,16 @@ if oc get pods -n pelorus | grep -q Crash ; then
     oc get pods -n pelorus
     exit 1
 fi
+
+# Validate Thanos, by querying thanos-query with the known data, 20 years from now should be sufficient and should
+# not be greater then this CI setup ;)
+if [ "${ENABLE_THANOS}" == true ]; then
+    THANOS_QUERY_HOST=$(oc get route thanos-pelorus -n pelorus --no-headers -o custom-columns="HOST:spec.host")
+    echo "Thanos query host: $THANOS_QUERY_HOST"
+    DEPLOY_NO=$(curl -u internal:changeme -k --data-urlencode 'query=count(count_over_time(deploy_timestamp{app="todolist"}[20y]))' "https://${THANOS_QUERY_HOST}/api/v1/query" | jq -r '.data.result[] | [.value]' | grep \" | tr -dc '0-9')
+    echo "Deploy count: $DEPLOY_NO"
+    if [ "$DEPLOY_NO" -lt "3" ]; then
+        echo "Thanos and s3 data is not as expected"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
Adds simple Thanos s3 bucket validation to the e2e script.

## Testing Instructions

run script with thanos enabled or allow e2e job to finish and check logs for deploy count that should be greater than 1, because 1 is data which is from the current run.

```
Thanos query host: thanos-pelorus-pelorus.apps.cluster-mpryc1502ocp49n.mpryc1502ocp49n.mg.dog8code.com
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   195  100   106  100    89    298    250 --:--:-- --:--:-- --:--:--   550
Deploy count: 3
Cleaning up temporary files
```

@redhat-cop/mdt
