### PR TITLE
Add option to configure Prometheus retention

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.8.1
+version: 1.8.2
 
 dependencies:
   - name: exporters

--- a/charts/pelorus/templates/prometheus-cr.yaml
+++ b/charts/pelorus/templates/prometheus-cr.yaml
@@ -26,6 +26,7 @@ spec:
       name: thanos-objstore-config
   {{- end }}
   replicas: 2
+  retention: {{ .Values.prometheus_retention | default "1y" }}
   replicaExternalLabelName: ""
   ruleNamespaceSelector: {}
   ruleSelector: {}

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -19,6 +19,9 @@ extra_prometheus_hosts:
 ## Persistent storage for Prometheus Operator
 # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/storage.md
 
+# Set Prometheus retention time. Older data values are deleted
+# prometheus_retention: 1y
+
 # Uncomment to use PVC for Prometheus
 # prometheus_storage: true
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -50,6 +50,14 @@ You may additionally want to enabled other features for the core stack. Read on 
 
 See [Configuring the Pelorus Stack](Configuration.md) for a full readout of all possible configuration items. The following sections describe the  most common supported customizations that can be made to a Pelorus deployment.
 
+### Configure Prometheus Retention
+
+Prometheus is removing data older than 1 year, so if the metric you are interested in happened to be older than 1 year it won't be visible. This is configurable in the `values.yaml` file with the following option:
+
+```yaml
+prometheus_retention: 1y
+```
+
 ### Configure Prometheus Persistent Volume (Recommended)
 
 Unlike ephemeral volume that have a lifetime of a pod, persistent volume allows to withstand container restarts or crashes making Prometheus data resilient to such situations.


### PR DESCRIPTION
Allow to set Prometheus retention to configurable value, which defaults to 1y.


@redhat-cop/mdt
