### PR TITLE
Automate tekton subsequent runs, add timeout for git clone

### DIFF
--- a/demo/tekton-demo-setup/03-build-and-deploy.yaml
+++ b/demo/tekton-demo-setup/03-build-and-deploy.yaml
@@ -135,6 +135,7 @@ objects:
             kind: ClusterTask
             name: openshift-client
         - name: checkout
+          timeout: "0h1m0s"
           runAfter:
             - import-build-image
           taskRef:


### PR DESCRIPTION
Allows to run Tekton demo in automated fashion by passing number of runs and time between them on the CLI as follows:
 -n flag for no-human re-runs
 -c flag for count of runs
 -t time between subsequent runs

E.g.:
 ./demo-tekton.sh -g https://github.com/mpryc/pelorus -b buildconfig -c 5 -t 600 -n

Adds timeout for the git clone tekton Task in situation where PV is br8ken. 1minute is way over the usual clone time which finishes in 2-3seconds.

## Testing Instructions

```
# Clone the fork and switch to a NEW branch:
export PELORUS_FORK=https://github.com/mpryc/pelorus
export NEW_BRANCH=pelorus_test_1

git clone  "${PELORUS_FORK}" pelorus-test
pushd pelorus-test
git checkout -b "${NEW_BRANCH}"
pushd demo

# Run the demo with example number of deployments 7 and time between them 10minutes (600s)
# Note this will use NEW_BRANCH to which commits in subsequent runs happens
export KUBECONFIG=.........
./demo-tekton.sh -g "${PELORUS_FORK}" -b buildconfig   -c 7 -t 600 -n
```

@redhat-cop/mdt
