### PR TITLE
Bump grafana version to the newest one.

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.8.0
+version: 1.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/operators/templates/grafana-subscription.yaml
+++ b/charts/operators/templates/grafana-subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v4.4.1
+  startingCSV: grafana-operator.v4.6.0

--- a/charts/operators/templates/installplan-approval-job.yaml
+++ b/charts/operators/templates/installplan-approval-job.yaml
@@ -20,7 +20,7 @@ spec:
             - |
               export HOME=/tmp/approver
 
-              echo "Approving operator Install096096
+              echo "Approving operator Install
               Plans.  Waiting a few seconds to make sure the InstallPlan gets created first."
               sleep 10
               for subscription in `oc get subscription.operators.coreos.com -o name`


### PR DESCRIPTION
Before we release MVR, bumping to the latest operator version of the grafana service.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

@redhat-cop/mdt
