### PR TITLE
ensure CUSTOM_DATE_FORMAT does not crash committime exporter

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -24,6 +24,10 @@ Help:
 | buildConfig | supported     | requires exporter committime-exporter               |
 | s2i         | supported     | requires exporter committime-image-exporter with provider=image    |   
 
+
+An example values.yaml file that can be used as a template with the demo-tekton.sh
+script in the tekton-demo-setup directory.
+
 ## demo.sh
 
 See the [demo docs in the official pelorus documentation.](https://pelorus.readthedocs.io/en/latest/Demo/)

--- a/demo/tekton-demo-setup/03-build-and-deploy.yaml
+++ b/demo/tekton-demo-setup/03-build-and-deploy.yaml
@@ -94,7 +94,8 @@ objects:
             set -ex
             find /workspace
             cd /workspace/debug 
-            git log -1 --format=%cd > "$(results.commit-time.path)"
+            epoch_time=`git log -1 --format=%ct`
+            TZ=UTC date -d @`echo $epoch_time` | tee "$(results.commit-time.path)"
         - name: debug-time-last-commit
           image: ubi9/toolbox
           script: |

--- a/demo/tekton-demo-setup/values_example.yaml
+++ b/demo/tekton-demo-setup/values_example.yaml
@@ -1,0 +1,63 @@
+# Default values for deploy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# to reset password: htpasswd -s -b -n internal changeme
+openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
+openshift_prometheus_basic_auth_pass: changeme
+extra_prometheus_hosts:
+
+deployment:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: pelorus
+    app.kubernetes.io/version: v0.33.0
+
+exporters:
+  instances:
+  - app_name: deploytime-exporter
+    exporter_type: deploytime
+    extraEnv:
+    - name: LOG_LEVEL
+      value: DEBUG
+    - name: NAMESPACES
+      value: mongo-persistent,basic-python-tekton
+    source_ref: master
+    source_url: https://github.com/konveyor/pelorus.git
+  - app_name: committime-exporter
+    exporter_type: committime
+    extraEnv:
+    - name: LOG_LEVEL
+      value: DEBUG
+    - name: NAMESPACES
+      value: mongo-persistent,basic-python-tekton
+    source_ref: master
+    source_url: https://github.com/konveyor/pelorus.git
+  - app_name: committime-image-exporter
+    exporter_type: committime
+    extraEnv:
+    - name: LOG_LEVEL
+      value: DEBUG
+    - name: PROVIDER
+      value: image
+    - name: COMMIT_DATE_FORMAT 
+      value: "%a %b %d %H:%M:%S %Z %Y"
+    source_ref: master
+    source_url: https://github.com/konveyor/pelorus.git
+  - app_name: failure-exporter
+    exporter_type: failure
+    env_from_secrets:
+    - github-secret
+    extraEnv:
+    - name: LOG_LEVEL
+      value: DEBUG
+    - name: PROVIDER
+      value: github
+    - name: PROJECTS
+      value: <forked_org>/mig-demo-apps,<forked_org>/pelorus
+    - name: APP_LABEL
+      value: production_issue/name
+    source_ref: master
+    source_url: https://github.com/konveyor/pelorus.git
+
+snapshot_schedule: "@monthly"

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -120,10 +120,18 @@ class ImageCommitCollector(AbstractCommitCollector):
     def _set_commit_timestamp(self, metric, errors) -> CommitMetric:
         # Only convert when commit_time is in metric, previously should be
         # found from the Label with fallback to annotation
-        if metric.commit_time:
-            metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
-                metric.commit_time, self._timedate_format
+        try:
+            if metric.commit_time:
+                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
+                    metric.commit_time, self._timedate_format
+                )
+        except ValueError:
+            errors.append(
+                "COMMIT_DATE_FORMAT does not match annotation commit.date on the image\n"
             )
+            errors.append("Removing the offending timestamp")
+            metric.commit_timestamp = None
+
         return metric
 
     def get_commit_time(self, metric) -> Optional[CommitMetric]:


### PR DESCRIPTION
fix image-exporter date, and update tekton commit timestamp

The image exporter is crashing when the date format
and commit.date image annotation does not match.

currently the commit time is read in human readable from
git log.  It is safer to use the epoch time format
and set the committime-image-exporter to use epoch
as the COMMIT_DATE_FORMAT


