### PR TITLE
timestamp timezone fix

### DIFF
--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -47,7 +47,15 @@ class CommitMetric:
     committer: Optional[str] = attr.field(default=None, kw_only=True)
     commit_hash: Optional[str] = attr.field(default=None, kw_only=True)
     commit_time: Optional[str] = attr.field(default=None, kw_only=True)
+    """
+    A human-readable timestamp.
+    In the future, this and commit_timestamp should be combined.
+    """
     commit_timestamp: Optional[float] = attr.field(default=None, kw_only=True)
+    """
+    The unix timestamp.
+    In the future, this and commit_time should be combined.
+    """
 
     build_name: Optional[str] = attr.field(default=None, kw_only=True)
     build_config_name: Optional[str] = attr.field(default=None, kw_only=True)

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -2,13 +2,12 @@ import logging
 
 import requests
 
-import pelorus
 from pelorus.certificates import set_up_requests_certs
+from pelorus.timeutil import parse_assuming_utc, second_precision
 
 from .collector_base import AbstractCommitCollector, UnsupportedGITProvider
 
-# import urllib3
-# urllib3.disable_warnings()
+_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 
 class GiteaCommitCollector(AbstractCommitCollector):
@@ -26,7 +25,7 @@ class GiteaCommitCollector(AbstractCommitCollector):
             namespaces,
             apps,
             "Gitea",
-            "%Y-%m-%dT%H:%M:%S",
+            _DATETIME_FORMAT,
             git_api,
         )
         if git_api is not None and len(git_api) > 0:
@@ -78,12 +77,16 @@ class GiteaCommitCollector(AbstractCommitCollector):
         else:
             commit = response.json()
             try:
-                metric.commit_time = commit["commit"]["committer"]["date"]
-                logging.debug("metric.commit_time %s" % (str(metric.commit_time)[:19]))
-                logging.debug("self._timedate_format %s" % (self._timedate_format))
-                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
-                    (str(metric.commit_time)[:19]), self._timedate_format
+                commit_time_str: str = commit["commit"]["committer"]["date"]
+                metric.commit_time = commit_time_str
+
+                commit_time = parse_assuming_utc(
+                    commit_time_str, format=_DATETIME_FORMAT
                 )
+                commit_time = second_precision(commit_time)
+
+                logging.debug("metric.commit_time %s", commit_time)
+                metric.commit_timestamp = commit_time.timestamp()
             except Exception:
                 logging.error(
                     "Failed processing commit time for build %s" % metric.build_name,

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -7,7 +7,7 @@ from pelorus.timeutil import parse_assuming_utc, second_precision
 
 from .collector_base import AbstractCommitCollector, UnsupportedGITProvider
 
-_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class GiteaCommitCollector(AbstractCommitCollector):

--- a/exporters/committime/collector_github.py
+++ b/exporters/committime/collector_github.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 import requests
 
-import pelorus
 from pelorus.certificates import set_up_requests_certs
+from provider_common.github import parse_datetime
 
 from .collector_base import AbstractCommitCollector, UnsupportedGITProvider
 
@@ -84,9 +84,7 @@ class GitHubCommitCollector(AbstractCommitCollector):
             commit = response.json()
             try:
                 metric.commit_time = commit["commit"]["committer"]["date"]
-                metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
-                    metric.commit_time, self._timedate_format
-                )
+                metric.commit_timestamp = parse_datetime(metric.commit_time).timestamp()
             except Exception:
                 logging.error(
                     "Failed processing commit time for build %s" % metric.build_name,

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -20,6 +20,7 @@ from typing import Iterable, Optional
 
 import pelorus
 from committime import CommitMetric
+from pelorus.timeutil import parse_guessing_timezone_DYNAMIC
 from pelorus.utils import collect_bad_attribute_path_error, get_env_var, get_nested
 
 from .collector_base import COMMIT_DATE_ANNOTATION_ENV, AbstractCommitCollector
@@ -117,13 +118,13 @@ class ImageCommitCollector(AbstractCommitCollector):
 
         return metric
 
-    def _set_commit_timestamp(self, metric, errors) -> CommitMetric:
+    def _set_commit_timestamp(self, metric: CommitMetric, errors) -> CommitMetric:
         # Only convert when commit_time is in metric, previously should be
         # found from the Label with fallback to annotation
         if metric.commit_time:
-            metric.commit_timestamp = pelorus.convert_date_time_to_timestamp(
-                metric.commit_time, self._timedate_format
-            )
+            metric.commit_timestamp = parse_guessing_timezone_DYNAMIC(
+                metric.commit_time, format=self._timedate_format
+            ).timestamp()
         return metric
 
     def get_commit_time(self, metric) -> Optional[CommitMetric]:

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -108,9 +108,8 @@ class ImageCommitCollector(AbstractCommitCollector):
             metric = self._set_commit_time_from_annotations(metric, errors)
 
         if not metric.commit_hash:
-            # We ignore all the errors by passing [], because commit hash isn't required.
-            metric = self._set_commit_hash_from_annotations(metric, [])
-
+            # We ignore all the errors by passing "None" as a string, because commit hash isn't required.
+            metric.commit_hash = "None"
         metric = self._set_commit_timestamp(metric, errors)
 
         if not metric.namespace:

--- a/exporters/deploytime/__init__.py
+++ b/exporters/deploytime/__init__.py
@@ -1,6 +1,8 @@
-from typing import Any
+from datetime import datetime
 
-from attrs import frozen
+from attrs import field, frozen
+
+from provider_common.openshift import convert_datetime
 
 
 @frozen
@@ -9,8 +11,12 @@ class DeployTimeMetric:
     namespace: str
     # WARNING: do not mutate the dict after hashing or things may break.
     labels: dict[str, str]
-    deploy_time: Any
+    deploy_time: datetime = field(converter=convert_datetime)
     image_sha: str
+
+    @property
+    def deploy_time_timestamp(self) -> float:
+        return self.deploy_time.timestamp()
 
     def __hash__(self):
         return hash(

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -37,6 +37,8 @@ class DeployTimeCollector:
             return []
 
         metrics = generate_metrics(namespaces, self.client)
+        # TODO: when merging 654, just ignore this whole section (overwrite with 654)
+        # all the code should be self-contained in the DeployTimeMetric anyway.
         for m in metrics:
             logging.info(
                 "Collected deploy_timestamp{namespace=%s, app=%s, image=%s} %s"
@@ -44,13 +46,13 @@ class DeployTimeCollector:
                     m.namespace,
                     m.name,
                     m.image_sha,
-                    pelorus.convert_date_time_to_timestamp(m.deploy_time),
+                    m.deploy_time_timestamp,
                 )
             )
             metric.add_metric(
-                [m.namespace, m.name, m.image_sha, m.deploy_time],
-                pelorus.convert_date_time_to_timestamp(m.deploy_time),
-                timestamp=pelorus.convert_date_time_to_timestamp(m.deploy_time),
+                [m.namespace, m.name, m.image_sha],
+                m.deploy_time_timestamp,
+                timestamp=m.deploy_time_timestamp,
             )
             yield (metric)
 

--- a/exporters/failure/collector_base.py
+++ b/exporters/failure/collector_base.py
@@ -72,11 +72,6 @@ class AbstractFailureCollector(pelorus.AbstractPelorusExporter):
         # This will be tracker specific
         pass
 
-    @abstractmethod
-    def convert_timestamp(self, date_time):
-        # This will format timestamp based on tracker specific data
-        pass
-
 
 class TrackerIssue:
     def __init__(self, issue_number, creationdate, resolutiondate, app):

--- a/exporters/failure/collector_github.py
+++ b/exporters/failure/collector_github.py
@@ -16,16 +16,15 @@
 #
 
 import logging
-from datetime import datetime
 from typing import Any, Optional, Union, cast
 
-import pytz
 import requests
 
 import pelorus
 from failure.collector_base import AbstractFailureCollector, TrackerIssue
 from pelorus.certificates import set_up_requests_certs
 from pelorus.utils import TokenAuth
+from provider_common.github import parse_datetime
 
 # One query limit, exporter will query multiple times.
 # Do not exceed 100 results
@@ -137,7 +136,7 @@ class GithubFailureCollector(AbstractFailureCollector):
                 )
 
                 # Create the GithubFailureMetric
-                created_ts = self.convert_timestamp(issue["created_at"])
+                created_ts = parse_datetime(issue["created_at"]).timestamp()
                 resolution_ts = None
                 if is_bug:
                     app_label = pelorus.get_app_label()
@@ -152,7 +151,9 @@ class GithubFailureCollector(AbstractFailureCollector):
                                 )
                             )
 
-                            resolution_ts = self.convert_timestamp(issue["closed_at"])
+                            resolution_ts = parse_datetime(
+                                issue["closed_at"]
+                            ).timestamp()
                         tracker_issue = TrackerIssue(
                             str(issue["number"]),
                             created_ts,
@@ -162,18 +163,6 @@ class GithubFailureCollector(AbstractFailureCollector):
 
                         critical_issues.append(tracker_issue)
         return critical_issues
-
-    @classmethod
-    def convert_timestamp(cls, date_time):
-        """Convert a Github datetime with TZ to UTC"""
-        # Change the datetime to a string
-        utc = datetime.strptime(date_time, "%Y-%m-%dT%H:%M:%S%z").astimezone(pytz.utc)
-        # Change the datetime to a string
-        utc_string = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-        # convert to timestamp
-        this_date = pelorus.convert_date_time_to_timestamp(utc_string)
-        # this_date is a float
-        return this_date
 
     def get_app_name(self, issue, label: Optional[dict[str, Any]]):
         if label:

--- a/exporters/pelorus/__init__.py
+++ b/exporters/pelorus/__init__.py
@@ -2,7 +2,6 @@ import logging
 import os
 import pathlib
 from abc import ABC
-from datetime import datetime, timezone
 from typing import Optional, Sequence
 
 from prometheus_client.registry import Collector
@@ -77,28 +76,6 @@ def setup_logging():
 # A NamespaceSpec lists namespaces to restrict the search to.
 # Use None or an empty list to include all namespaces.
 NamespaceSpec = Optional[Sequence[str]]
-
-
-def convert_date_time_to_timestamp(date_time, format_string="%Y-%m-%dT%H:%M:%SZ"):
-    timestamp = None
-    try:
-        if isinstance(date_time, datetime):
-            timestamp = date_time
-        else:
-            timestamp = datetime.strptime(date_time, format_string)
-    except ValueError:
-        raise
-    return timestamp.replace(tzinfo=timezone.utc).timestamp()
-
-
-def convert_timestamp_to_date_time_str(timestamp, format_string="%Y-%m-%dT%H:%M:%SZ"):
-    date_time_str = None
-    try:
-        date_time = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-        date_time_str = date_time.strftime(format_string)
-    except ValueError:
-        raise
-    return date_time_str
 
 
 def get_app_label():

--- a/exporters/pelorus/timeutil.py
+++ b/exporters/pelorus/timeutil.py
@@ -1,0 +1,85 @@
+"""
+Utilities to handle time correctly.
+
+Note: `parse_assuming_utc`, `parse_tz_aware`, and `parse_guessing_timezone_DYNAMIC`
+will _always_ produce timezone-aware objects,
+which are necessary for correctness with `astimezone(tz)`, `timestamp()`, and other methods.
+"""
+from datetime import datetime, timezone
+
+_ISO_ZULU_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def is_zone_aware(d: datetime) -> bool:
+    """
+    Is the datetime object aware of its timezone/offset?
+    See https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive
+    """
+    return d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None
+
+
+def parse_assuming_utc(timestring: str, format: str) -> datetime:
+    """
+    Parses assuming that the timestring is UTC only.
+    This means it _must_ be naive, e.g. has no zone/offset parsing in the format.
+    Otherwise, a ValueError will be raised.
+    """
+    parsed = datetime.strptime(timestring, format)
+    if is_zone_aware(parsed):
+        raise ValueError(
+            f"Tried to assume UTC with a timezone-aware time format of {format}"
+        )
+    else:
+        return parsed.replace(tzinfo=timezone.utc)
+
+
+def parse_tz_aware(timestring: str, format: str) -> datetime:
+    """
+    Parses a timestring that includes its timezone information.
+    That means it _must not_ be naive, e.g. has proper zone/parsing in the format.
+    Otherwise, a ValueError will be raised.
+    """
+    parsed = datetime.strptime(timestring, format)
+    if not is_zone_aware(parsed):
+        raise ValueError(
+            f"Tried to be timezone-aware with timezone-naive format of {format}"
+        )
+    else:
+        return parsed.astimezone(timezone.utc)
+
+
+def parse_guessing_timezone_DYNAMIC(timestring: str, format: str) -> datetime:
+    """
+    Assumes the timezone is correct if the format makes it aware, but otherwise assumes UTC.
+
+    This should only be used in a user-provided case.\
+    Otherwise, use one of the other methods to validate that an API contract hasn't been borken.
+    """
+    parsed = datetime.strptime(timestring, format)
+    if is_zone_aware(parsed):
+        return parsed
+    else:
+        return parsed.replace(tzinfo=timezone.utc)
+
+
+def second_precision(dt: datetime) -> datetime:
+    """
+    Change the datetime to have second precision (removing microseconds).
+    Useful for logging.
+    There are also places in legacy code that do this (via formatting and then re-parsing),
+    but those usages should be scrutinized.
+    """
+    return dt.replace(microsecond=0)
+
+
+def to_iso(dt: datetime) -> str:
+    """
+    Formats a datetime to an ISO string with a hard-coded Z.
+    If the input is naive, a ValueError is raised.
+    """
+    if not is_zone_aware(dt):
+        raise ValueError(
+            "tried to serialize datetime with hard-coded Z but it was timezone naive"
+        )
+
+    return dt.astimezone(timezone.utc).strftime(_ISO_ZULU_FMT)

--- a/exporters/provider_common/github.py
+++ b/exporters/provider_common/github.py
@@ -7,6 +7,7 @@ from urllib.error import HTTPError
 import requests
 from attrs import frozen
 
+from pelorus.timeutil import parse_assuming_utc
 from pelorus.utils import BadAttributePathError, get_nested
 
 # The maximum number of requests you're permitted to make per hour.
@@ -28,7 +29,7 @@ def parse_datetime(datetime_str: str) -> datetime:
 
     May throw a ValueError if it doesn't match the expected format.
     """
-    return datetime.strptime(datetime_str, _DATETIME_FORMAT).astimezone(timezone.utc)
+    return parse_assuming_utc(datetime_str, format=_DATETIME_FORMAT)
 
 
 @frozen

--- a/exporters/provider_common/openshift.py
+++ b/exporters/provider_common/openshift.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from typing import Union
+
+from pelorus.timeutil import parse_assuming_utc
+
+# https://docs.openshift.com/container-platform/4.10/rest_api/objects/index.html#io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def parse_datetime(dt_str: str) -> datetime:
+    return parse_assuming_utc(dt_str, _DATETIME_FORMAT)
+
+
+def convert_datetime(dt: Union[str, datetime]) -> datetime:
+    """
+    For use with attrs.
+    """
+    if isinstance(dt, datetime):
+        return dt
+    else:
+        return parse_datetime(dt)

--- a/exporters/tests/test_datetime.py
+++ b/exporters/tests/test_datetime.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timedelta, timezone
+
+import provider_common.github as github
+from pelorus.timeutil import (
+    parse_assuming_utc,
+    parse_guessing_timezone_DYNAMIC,
+    parse_tz_aware,
+)
+
+
+def test_parse_hard_utc():
+    FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+    TIMESTRING = "2020-06-27T03:17:8Z"
+    UNIX = 1593227828
+    DATETIME = datetime(2020, 6, 27, 3, 17, 8, tzinfo=timezone.utc)
+
+    actual_start = parse_assuming_utc(TIMESTRING, FORMAT)
+    assert actual_start == DATETIME
+
+    actual_start_unix = actual_start.timestamp()
+    assert actual_start_unix == UNIX
+
+
+def test_parse_tz_aware():
+    FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+    UTC_MINUS_5 = timezone(timedelta(hours=-5))
+
+    TIMESTRING = "2020-06-27T03:17:08.00000-0500"
+    UNIX = 1593245828
+    DATETIME = datetime(2020, 6, 27, 3, 17, 8, tzinfo=UTC_MINUS_5)
+
+    actual_start = parse_tz_aware(TIMESTRING, FORMAT)
+    assert actual_start == DATETIME
+
+    actual_start_unix = actual_start.timestamp()
+    assert actual_start_unix == UNIX
+
+
+def test_parse_tz_aware_diff_timezones():
+    FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+    UTC_MINUS_4 = timezone(timedelta(hours=-4))
+    UTC_PLUS_2 = timezone(timedelta(hours=2))
+
+    UNIX = 1663715897
+
+    TIMESTRING_IN_NY = "2022-09-20T19:18:17-0400"
+    DATETIME_NY = datetime(2022, 9, 20, 19, 18, 17, tzinfo=UTC_MINUS_4)
+
+    TIMESTRING_IN_PL = "2022-09-21T01:18:17+0200"
+    DATETIME_PL = datetime(2022, 9, 21, 1, 18, 17, tzinfo=UTC_PLUS_2)
+
+    actual_ny = parse_tz_aware(TIMESTRING_IN_NY, FORMAT)
+    actual_pl = parse_tz_aware(TIMESTRING_IN_PL, FORMAT)
+
+    assert DATETIME_NY == DATETIME_PL
+
+    assert actual_ny == DATETIME_NY
+    assert actual_pl == DATETIME_PL
+    assert actual_ny == actual_pl
+
+    assert actual_ny.timestamp() == UNIX
+    assert actual_pl.timestamp() == UNIX
+
+
+def test_dynamic_parsing_aware():
+    AWARE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+    UTC_MINUS_4 = timezone(timedelta(hours=-4))
+
+    UNIX = 1663715897
+
+    TIMESTRING = "2022-09-20T19:18:17-0400"
+    DATETIME = datetime(2022, 9, 20, 19, 18, 17, tzinfo=UTC_MINUS_4)
+
+    actual_parsed = parse_guessing_timezone_DYNAMIC(TIMESTRING, AWARE_FORMAT)
+
+    assert actual_parsed == DATETIME
+
+    assert actual_parsed.timestamp() == UNIX
+
+
+def test_dynamic_parsing_assumed():
+    ASSUMING_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+    UNIX = 1663715897
+
+    TIMESTRING = "2022-09-20T23:18:17Z"
+    DATETIME = datetime(2022, 9, 20, 23, 18, 17, tzinfo=timezone.utc)
+
+    actual_parsed = parse_guessing_timezone_DYNAMIC(TIMESTRING, ASSUMING_FORMAT)
+
+    assert actual_parsed == DATETIME
+
+    assert actual_parsed.timestamp() == UNIX
+
+
+def test_github():
+    TIMESTRING = "2022-05-11T21:50:08Z"
+    EXPECTED_UNIX = 1652305808
+
+    actual_unix = github.parse_datetime(TIMESTRING).timestamp()
+
+    assert actual_unix == EXPECTED_UNIX

--- a/exporters/tests/test_exporters.py
+++ b/exporters/tests/test_exporters.py
@@ -1,30 +1,6 @@
 import pytest
 
-import pelorus
 from committime.collector_base import CommitMetric
-
-
-@pytest.mark.parametrize(
-    "start_time,end_time,format",
-    [
-        ("2020-06-27T03:17:8Z", "2020-06-27T06:17:8Z", "%Y-%m-%dT%H:%M:%SZ"),
-        (
-            "2020-06-27T03:17:08.00000-0500",
-            "2020-06-27T06:17:08.000000-0500",
-            "%Y-%m-%dT%H:%M:%S.%f%z",
-        ),
-    ],
-)
-def test_convert_date_time_to_timestamp(start_time, end_time, format):
-    start_timestamp = 1593227828
-    end_timestamp = 1593238628
-    three_hours = 10800
-
-    calc_start = pelorus.convert_date_time_to_timestamp(start_time, format)
-    assert calc_start == start_timestamp
-    calc_end = pelorus.convert_date_time_to_timestamp(end_time, format)
-    assert calc_end == end_timestamp
-    assert calc_end - calc_start == three_hours
 
 
 # Unit tests for the CommitMetric

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -161,15 +161,6 @@ def test_github_connection():
     )
 
 
-@pytest.mark.parametrize(
-    "date_time",
-    [("2022-05-11T21:50:08Z")],
-)
-def test_github_timestamp(date_time):
-    test_time = GithubFailureCollector.convert_timestamp(date_time)
-    assert float("1652305808.0") == test_time
-
-
 def test_github_prometheus_register(monkeypatch: pytest.MonkeyPatch):
     def mock_search_issues(self):
         return []
@@ -366,7 +357,7 @@ def test_custom_resolved_timestamp(server, username, apikey):
         test_issue, "Done, Resolved, Other"
     )
 
-    assert resolution_timestamp == 1652395843.0
+    assert int(resolution_timestamp) == 1652395843
 
 
 @pytest.mark.parametrize(
@@ -400,4 +391,4 @@ def test_resolutiondate_timestamp(server, username, apikey):
 
     resolution_timestamp = collector._get_resolved_timestamp(test_issue)
 
-    assert resolution_timestamp == 1649803843.0
+    assert int(resolution_timestamp) == 1649803843

--- a/exporters/tests/test_pelorus.py
+++ b/exporters/tests/test_pelorus.py
@@ -1,33 +1,9 @@
 import os
-from datetime import datetime, timezone
 from typing import NamedTuple, Optional
 
 import pytest
 
 import pelorus
-
-
-@pytest.mark.parametrize(
-    "start_time,end_time,format",
-    [
-        ("2020-06-27T03:17:8Z", "2020-06-27T06:17:8Z", "%Y-%m-%dT%H:%M:%SZ"),
-        (
-            "2020-06-27T03:17:08.00000-0500",
-            "2020-06-27T06:17:08.000000-0500",
-            "%Y-%m-%dT%H:%M:%S.%f%z",
-        ),
-    ],
-)
-def test_convert_date_time_to_timestamp(start_time, end_time, format):
-    start_timestamp = 1593227828
-    end_timestamp = 1593238628
-    three_hours = 10800
-
-    calc_start = pelorus.convert_date_time_to_timestamp(start_time, format)
-    assert calc_start == start_timestamp
-    calc_end = pelorus.convert_date_time_to_timestamp(end_time, format)
-    assert calc_end == end_timestamp
-    assert calc_end - calc_start == three_hours
 
 
 def test_get_app_label():
@@ -49,34 +25,6 @@ def test_missing_configs():
     os.environ["VAR1"] = "value"
     os.environ["VAR2"] = "value"
     assert not pelorus.missing_configs(configs)
-
-
-@pytest.mark.parametrize("date_format", [("%Y-%m-%dT%H:%M:%S.%f")])
-def test_datetime_conversion_type(date_format):
-    d = datetime.now()
-    myts = d.replace(tzinfo=timezone.utc).timestamp()
-    ts = pelorus.convert_date_time_to_timestamp(d, date_format)
-    assert ts is not None
-    assert myts == ts
-
-
-@pytest.mark.parametrize(
-    "date_time, timestamp, date_format",
-    [("2020-06-27T06:17:08.000000", 1593238628, "%Y-%m-%dT%H:%M:%S.%f")],
-)
-def test_datetime__as_str_conversion_type(date_time, timestamp, date_format):
-    ts = pelorus.convert_date_time_to_timestamp(date_time, date_format)
-    assert ts is not None
-    assert timestamp == ts
-
-
-@pytest.mark.parametrize(
-    "timestamp, date_time_str", [(1599659116.0, "2020-09-09T13:45:16Z")]
-)
-def test_timestamp_to_datetime_conversion(timestamp, date_time_str):
-    date_time = pelorus.convert_timestamp_to_date_time_str(timestamp)
-    assert date_time is not None
-    assert date_time == date_time_str
 
 
 def unset_envs():


### PR DESCRIPTION
Fix timestamp parsing.

Timestamp parsing previously suffered from two issues:

1. The timezone was _replaced_ with UTC. This meant that any datetimes from other time zones were converted to incorrect times.
2. If fixed with using `astimezone`, then any timezone-naive timestamps _assumed the local system timezone_. This meant they were not only wrong, but wrong in different ways depending upon the time zone!

This now differentiates between three use cases:

1. The timezone is in the parsed datetime, and we expect that.
2. The timezone is not in the parsed datetime, and we explicitly say that it is UTC.
3. The format is user-supplied, and we can't be sure if it's aware or not. We will have to assume any timezone-aware datetimes are correct, and if they're naive, they are meant to be UTC.

There are also some small utilities / helpers for some miscellaneous use cases across the code base.

resolves #662
