### PR TITLE
Allow to use EPOCH timestamp in the image annotation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -477,7 +477,7 @@ Example image metadata with `io.openshift.build.commit.date` Docker Labels and `
 ```
 IMAGE_SHA=588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
 
-$ oc describe "sha256:${IMAGE_SHA}"
+$ oc describe image "sha256:${IMAGE_SHA}"
 
 Docker Image:	image-registry.openshift-image-registry.svc:5000/mongo-persistent/todolist-mongo-go@sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
 Name:		    sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
@@ -520,6 +520,21 @@ $ oc annotate image "sha256:${IMAGE_SHA}" --overwrite \
     io.openshift.build.commit.date="Mon Aug 8 13:13:58 2022 -0600"
 
 > image.image.openshift.io/sha256:588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e annotated
+```
+
+The Image may be also annotated with 10 digit EPOCH timestamp. Allowed format is one, where milliseconds are ignored:
+
+```
+$ EPOCH_TIMESTAMP=`git log -1 --format=%ct`
+$ echo ${EPOCH_TIMESTAMP}
+1663770655
+
+$ NAME=my-application
+$ IMAGE_SHA=588fb67a63ccbadf245b6d30747c404d809a851551b67c615a18217bf443a78e
+$ oc label image "sha256:${IMAGE_SHA}" "app.kubernetes.io/name=${NAME}"
+
+$ oc annotate image "sha256:${IMAGE_SHA}" --overwrite \
+     io.openshift.build.commit.date="${EPOCH_TIMESTAMP}"
 ```
 
 ### Configuring JIRA workflow(s)

--- a/exporters/pelorus/timeutil.py
+++ b/exporters/pelorus/timeutil.py
@@ -62,6 +62,24 @@ def parse_guessing_timezone_DYNAMIC(timestring: str, format: str) -> datetime:
         return parsed.replace(tzinfo=timezone.utc)
 
 
+def to_epoch_from_string(timestring: str) -> datetime:
+    """
+    It's really EPOCH to EPOCH conversion with datetime return object.
+
+    If timestring matches expected EPOCH format a proper datetime object is returned,
+    otherwise raises ValueError and consumer of this function probably want's to use
+    other format of timestamp.
+    """
+    epoch_date_time = timestring.split(".")[0]
+    # Try to convert to an EPOCH, but only if it's 10 digit
+    if len(epoch_date_time) != 10:
+        raise ValueError(
+            f"Tried to get epoch from not allowed string length: {timestring}"
+        )
+    else:
+        return datetime.fromtimestamp(int(epoch_date_time))
+
+
 def second_precision(dt: datetime) -> datetime:
     """
     Change the datetime to have second precision (removing microseconds).

--- a/exporters/tests/test_datetime.py
+++ b/exporters/tests/test_datetime.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 import provider_common.github as github
 from pelorus.timeutil import (
     parse_assuming_utc,
     parse_guessing_timezone_DYNAMIC,
     parse_tz_aware,
+    to_epoch_from_string,
 )
 
 
@@ -102,3 +105,29 @@ def test_github():
     actual_unix = github.parse_datetime(TIMESTRING).timestamp()
 
     assert actual_unix == EXPECTED_UNIX
+
+
+@pytest.mark.parametrize(
+    "timestamps, expected",
+    [
+        ("1652305808.000", "1652305808.0"),
+        ("1652305808.122", "1652305808.0"),
+        ("1652305808", "1652305808.0"),
+        ("1652305808.0", "1652305808.0"),
+    ],
+)
+def test_to_epoch_from_string(timestamps, expected):
+    epoch_from_str = to_epoch_from_string(timestamps)
+    assert str(epoch_from_str.timestamp()) == expected
+
+
+@pytest.mark.xfail(raises=ValueError)
+@pytest.mark.parametrize("timestamps", ["1652305803822.0", "1652305", "112322142321"])
+def test_to_epoch_from_string_bad_value(timestamps):
+    to_epoch_from_string(timestamps)
+
+
+@pytest.mark.xfail(raises=AttributeError)
+@pytest.mark.parametrize("timestamps", [1652305808, None])
+def test_to_epoch_from_string_bad_arg(timestamps):
+    to_epoch_from_string(timestamps)


### PR DESCRIPTION
For the images that were build without commit time or hash data we allow to annotate them for the Commit Time exporter to work properly. This change allows to annotate with EPOCH time format.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

@redhat-cop/mdt
