### PR TITLE
Tekton demo improvements

### DIFF
--- a/demo/demo-tekton.sh
+++ b/demo/demo-tekton.sh
@@ -26,11 +26,15 @@ Help()
 # Defaults
 current_branch="$(git symbolic-ref HEAD)"
 current_branch=${current_branch##refs/heads/}
-url="https://github.com/konveyor/pelorus"
+url=""
 build_type="binary"
 NO_HUMAN=false
 sleep_between=300
 no_deployments=1
+REMOTE_BRANCH_EXISTS=false
+PELORUS_WORKING_DIR=""
+PELORUS_DEMO_TMP_DIR=""
+TMP_DIR_PREFIX="pelorus_tkn_tmp_"
 
 # Get the options
 while getopts ":hg:b:r:n:t:c:a:" option; do
@@ -60,19 +64,17 @@ while getopts ":hg:b:r:n:t:c:a:" option; do
    esac
 done
 
-if [[ $(git status --porcelain --untracked-files=no) ]]; then
-  echo "Your local repository contains modified files and can not continue..."
-  git status --porcelain --untracked-files=no
-  exit 1
-fi
-
 echo "============================"
 echo "Executing the ${app_name} demo for Pelorus..."
 echo ""
 echo "*** Current Options used ***"
 echo "App name: ${app_name}"
 echo "Used namespace: ${app_namespace}"
-echo "Git URL: $url"
+if [[ "$url" != "" ]]; then
+  echo "Git URL: $url"
+else
+  echo "Git repository path: $(pwd)"
+fi
 echo "Git ref: $current_branch"
 echo "Build Type: $build_type"
 echo "No interaction mode: ${NO_HUMAN}"
@@ -95,6 +97,102 @@ if ! [[ $all_cmds_found ]]; then exit 1; fi
 tekton_setup_dir="$(dirname "${BASH_SOURCE[0]}")/tekton-demo-setup"
 python_example_txt="$(dirname "${BASH_SOURCE[0]}")/python-example/response.txt"
 
+# Fail early if master is being used
+if [[ "$current_branch" == "master" ]]; then
+  echo "Do not use master branch..."
+  exit 1
+fi
+
+# Use local directory as url
+if [[ "$url" == "" ]] && [[ $(git status --porcelain --untracked-files=no) ]]; then
+  echo "Your local repository contains modified files and can not continue..."
+  git status --porcelain --untracked-files=no
+  exit 1
+fi
+
+echo "Discovering Pelorus deployment in the 'pelorus' namespace"
+FOUND_COMMITTIME=false
+# Check if Pelorus is deployed on the cluster and monitors
+# required namespace or default one, which means all of them
+COMMITTIME_EXPORTERS=$(oc get pod -n pelorus -l pelorus.konveyor.io/exporter-type=committime --field-selector=status.phase==Running --no-headers -o custom-columns=":metadata.name")
+for committime_exporter in $COMMITTIME_EXPORTERS;
+do
+  committime_namespaces=$(oc exec -n pelorus "${committime_exporter}" -- printenv NAMESPACES)
+  echo ",${committime_namespaces},"  | grep ",${app_namespace}," > /dev/null && FOUND_COMMITTIME=true
+  echo "${committime_namespaces}"  | grep "default" > /dev/null && FOUND_COMMITTIME=true
+done
+
+if [ "${FOUND_COMMITTIME}" == false ]; then
+  echo "ERROR: Commit Time exporter for the Pelorus deployment in the 'pelorus' namespace do not"
+  echo "       monitor '${app_namespace}' namespace in which you are trying to deploy application."
+  echo "       Please correct your Pelorus deployment and restart demo script."
+  exit 1
+fi
+
+# Function to safely remove temporary files and temporary download dir
+# Argument is optional exit value to propagate it after cleanup
+function cleanup_and_exit() {
+    local exit_val=$1
+    if [ -z "${PELORUS_DEMO_TMP_DIR}" ]; then
+        echo "cleanup_and_exit(): Temp download dir not provided !" >&2
+    else
+      # Ensure dir exists and starts with prefix
+      if [ -d "${PELORUS_DEMO_TMP_DIR}" ]; then
+          PELORUS_TMP_DIR=$(basename "${PELORUS_DEMO_TMP_DIR}")
+          if [[ "${PELORUS_TMP_DIR}" =~ "${TMP_DIR_PREFIX}"* ]]; then
+              echo "Cleaning up temporary files"
+              eval rm -rf "${PELORUS_DEMO_TMP_DIR}/*"
+              rmdir "${PELORUS_DEMO_TMP_DIR}"
+          fi
+      fi
+    fi
+    # Propagate exit value if was provided
+    [ -n "${exit_val}" ] && exit "$exit_val"
+    exit 0
+}
+
+trap 'cleanup_and_exit 0' INT TERM EXIT
+
+# Check if the remote branch exists
+# if url is "" means user want to run script from within local folder
+# For the local folder, we prefer to run ls-remote over listing of branches, because
+# remote branch may have been removed
+if [[ "$url" == "" ]]; then
+  if git ls-remote --heads  2>/dev/null | grep "${current_branch}">/dev/null; then
+    REMOTE_BRANCH_EXISTS=true
+  fi
+  # Top level git repository
+  PELORUS_WORKING_DIR="$(git rev-parse --show-toplevel)" || exit 1
+elif [[ "$url" != "" ]]; then
+  # Create temporary directory
+  PELORUS_DEMO_TMP_DIR=$( mktemp -d -t "${TMP_DIR_PREFIX}_XXXXX" ) || exit 1
+  echo "Pre: Temp directory created: ${PELORUS_DEMO_TMP_DIR}"
+  if git ls-remote --heads "${url}" "${current_branch}"  2>/dev/null | grep "${current_branch}">/dev/null; then
+    REMOTE_BRANCH_EXISTS=true
+  fi
+  git clone "${url}" "${PELORUS_DEMO_TMP_DIR}/pelorus"
+  pushd "${PELORUS_DEMO_TMP_DIR}/pelorus" || exit 1
+    PELORUS_WORKING_DIR="$( git rev-parse --show-toplevel )" || exit 1
+  popd
+fi
+
+# Ensure we are on the proper branch, if branch is not in remote create one
+echo "Pre: Using Pelorus git dir: ${PELORUS_WORKING_DIR}"
+pushd "${PELORUS_WORKING_DIR}" || exit 1
+  if [ "${REMOTE_BRANCH_EXISTS}" == true ]; then
+    echo "Pre: Using existing remote branch: ${current_branch}"
+    git fetch origin
+    git checkout "${current_branch}"
+  elif [ "${REMOTE_BRANCH_EXISTS}" == false ]; then
+    echo "Pre: Creating new branch: ${current_branch}"
+    git checkout -b "${current_branch}"
+    git push --set-upstream origin "${current_branch}"
+  else
+    echo "ERROR: Remote branch check went terribly wrong, exitting"
+    exit 1
+  fi
+popd || exit 1
+
 # Create namespace if one doesn't exist
 if oc get namespace "${app_namespace}" >/dev/null 2>&1 ; then
     echo "1. Namespace '${app_namespace}' already exists"
@@ -103,18 +201,26 @@ else
     oc process -f "$tekton_setup_dir/01-new-project-request_template.yaml" -p PROJECT_NAME="${app_namespace}" | oc create -f -
 fi
 
-echo "Clean up resources prior to execution:"
+echo "Clean up resources prior to execution from '${app_namespace}' namespace:"
 # cleaning resources vs. deleting the namespace to preserve pipeline run history
 # resources are cleaned to ensure that the new running artifact is from the latest build
-oc delete --all imagestream -n "${app_namespace}" &> /dev/null || true
+printf "ImageStream(s): "
+oc delete --all imagestream -n "${app_namespace}" 2> /dev/null || echo "...done"
+printf "DeploymentConfig: "
 oc scale "dc/${app_name}" --replicas=0 -n "${app_namespace}" &> /dev/null || true
-oc delete "dc/${app_name}" -n "${app_namespace}" &> /dev/null || true
-oc delete buildConfig "${app_name}" -n "${app_namespace}" &> /dev/null || true
-oc delete "buildconfig.build.openshift.io/${app_name}" -n "${app_namespace}" &> /dev/null || true
-oc delete --all pods -n "${app_namespace}"  &> /dev/null || true
-oc delete --all replicationcontroller -n "${app_namespace}" &> /dev/null || true
-oc delete --all template.template.openshift.io -n "${app_namespace}" &> /dev/null || true
-oc delete "clusterrolebinding.rbac.authorization.k8s.io/pipeline-role-binding-${app_namespace}" &> /dev/null || true
+oc delete "dc/${app_name}" -n "${app_namespace}" 2> /dev/null || echo "...done"
+printf "BuildConfig: "
+oc delete buildConfig "${app_name}" -n "${app_namespace}" 2> /dev/null || echo "...done"
+printf "Build: "
+oc delete "buildconfig.build.openshift.io/${app_name}" -n "${app_namespace}" 2> /dev/null || echo "...done"
+printf "Pods: "
+oc delete --all pods -n "${app_namespace}"  2> /dev/null || echo "...done"
+printf "ReplicationController: "
+oc delete --all replicationcontroller -n "${app_namespace}" 2> /dev/null || echo "...done"
+printf "Templates: "
+oc delete --all template.template.openshift.io -n "${app_namespace}" 2> /dev/null || echo "...done"
+printf "RBAC Authorization: "
+oc delete "clusterrolebinding.rbac.authorization.k8s.io/pipeline-role-binding-${app_namespace}" 2> /dev/null || echo "...done"
 
 echo "Setting up resources:"
 
@@ -128,7 +234,23 @@ echo "4. Creating ClusterRoleBinding with ServiceAccount"
 oc process -f "$tekton_setup_dir/04-service-account_template.yaml" -p PROJECT_NAMESPACE="${app_namespace}" -n default | oc create -f -
 
 echo "5. Setting up build and deployment information"
-oc process -f "$tekton_setup_dir/05-build-and-deploy.yaml" -p NAMESPACE="${app_namespace}" -p APPLICATION_NAME="${app_name}" -n default > /tmp/05-build-and-deploy.yaml.out 2>/tmp/05-build-and-deploy.yaml.err
+pushd "${PELORUS_WORKING_DIR}" || exit 1
+  GIT_TKN_BRANCH=$(git symbolic-ref --short HEAD)
+  GIT_TKN_URL=$(git config --get remote.origin.url)
+  # Tekton does not have ssh certificates, so needs to use http/https
+  if [[ "${GIT_TKN_URL}" != http* ]]; then
+    if [[ "${GIT_TKN_URL}" == git@* ]]; then
+      # Replace git with https:
+      #   git@github.com:mpryc/pelorus.git
+      #   https://github.com/mpryc/pelorus.git
+      GIT_TKN_URL=$( echo "${GIT_TKN_URL}" | sed 's/\:/\//g' | sed 's/git\@/https\:\/\//g' )
+    fi
+  fi
+popd || exit 1
+
+oc process -f "$tekton_setup_dir/05-build-and-deploy.yaml" -p PROJECT_URI="${GIT_TKN_URL}" -p PROJECT_REF="${GIT_TKN_BRANCH}" \
+           -p NAMESPACE="${app_namespace}" -p APPLICATION_NAME="${app_name}" \
+           -n default > /tmp/05-build-and-deploy.yaml.out 2>/tmp/05-build-and-deploy.yaml.err
 oc apply -n "${app_namespace}" -f /tmp/05-build-and-deploy.yaml.out
 
 route=$(oc get -n "${app_namespace}" "route/${app_name}" --output=go-template='http://{{.spec.host}}')
@@ -136,13 +258,15 @@ route=$(oc get -n "${app_namespace}" "route/${app_name}" --output=go-template='h
 counter=1
 
 function run_pipeline {
-    set -x
-    tkn pipeline start -n "${app_namespace}" --showlog "${app_name}-pipeline" \
-      -w name=repo,claimName="${app_name}-build-pvc" \
-      -p git-url="$url" -p git-revision="$current_branch" \
-      -l app.kubernetes.io/name="${app_name}" \
-      -p BUILD_TYPE="$build_type"
-    set +x
+    pushd "${PELORUS_WORKING_DIR}" || exit 1
+      echo "Running pipeline for the '${GIT_TKN_URL}' repo and '${GIT_TKN_BRANCH}' branch"
+      tkn pipeline start -n "${app_namespace}" --showlog "${app_name}-pipeline" \
+        -w name=repo,claimName="${app_name}-build-pvc" \
+        -p git-url="${GIT_TKN_URL}" -p git-revision="${GIT_TKN_BRANCH}" \
+        -p build-no="${counter}" \
+        -l app.kubernetes.io/name="${app_name}" \
+        -p BUILD_TYPE="$build_type"
+    popd || exit 1
 }
 
 echo -e "\nRunning pipeline\n"
@@ -160,15 +284,17 @@ if [ "${NO_HUMAN}" == false ]; then
        echo ""
        case $a in
           1* )
-             echo "We've modified this file, time to build and deploy a new version. Times modified: $counter" | tee -a "$python_example_txt"
-             git commit -m "modifying python example, number $counter" -- "$python_example_txt"
-             git push origin "$current_branch"
+             pushd "${PELORUS_WORKING_DIR}" || exit 1
+               echo "We've modified this file, time to build and deploy a new version from ${GIT_TKN_BRANCH} branch and ${GIT_TKN_URL} repo. Times modified: $counter" | tee -a "demo/${python_example_txt}"
+               git commit -m "modifying python example, number $counter" -- "demo/${python_example_txt}"
+               git push origin "$current_branch"
 
-             run_pipeline
+               counter=$((counter+1))
+               run_pipeline
 
-             echo -e "\nWhen ready, page will be available at $route"
+               echo -e "\nWhen ready, page will be available at $route"
 
-             counter=$((counter+1))
+             popd || exit 1
           ;;
 
           2* ) exit 0 ;;
@@ -177,15 +303,19 @@ if [ "${NO_HUMAN}" == false ]; then
     done
 elif [ "${NO_HUMAN}" == true ]; then
     while [ $counter -lt "$no_deployments" ]; do
-        echo "We've modified this file, time to build and deploy a new version. Times modified: $counter" | tee -a "$python_example_txt"
-        git commit -m "modifying python example, number $counter" -- "$python_example_txt"
-        git push origin "$current_branch"
-        run_pipeline
-        echo -e "\nWhen ready, page will be available at $route"
-        counter=$((counter+1))
-        # Do not sleep on the last iteration
+        pushd "${PELORUS_WORKING_DIR}" || exit 1
+          echo "We've modified this file, time to build and deploy a new version from ${GIT_TKN_BRANCH} branch and ${GIT_TKN_URL} repo. Times modified: $counter" | tee -a "demo/${python_example_txt}"
+          git commit -m "modifying python example, number $counter" -- "demo/${python_example_txt}"
+          git push origin "$current_branch"
+          counter=$((counter+1))
+          run_pipeline
+          echo -e "\nWhen ready, page will be available at $route"
+        popd
+          # Do not sleep on the last iteration
         if [ $counter -lt "$no_deployments" ]; then
             sleep "$sleep_between"
         fi
     done
 fi
+
+echo "Finished. Consider removing remote branch: ${current_branch}"

--- a/demo/tekton-demo-setup/05-build-and-deploy.yaml
+++ b/demo/tekton-demo-setup/05-build-and-deploy.yaml
@@ -9,6 +9,12 @@ parameters:
   - name: NAMESPACE
     description: The namespace the various objects will be deployed in.
     value: basic-python-tekton
+  - name: PROJECT_URI
+    description: "Project URI with the python-demo"
+    value: https://github.com/konveyor/pelorus
+  - name: PROJECT_REF
+    description: "Project ref with the python-demo"
+    value: master
 objects:
   # Build
   - kind: BuildConfig
@@ -22,8 +28,8 @@ objects:
       source:
         type: Git
         git:
-          uri: https://github.com/konveyor/pelorus
-          ref: master
+          uri: ${PROJECT_URI}
+          ref: ${PROJECT_REF}
         contextDir: "demo/python-example"
       strategy:
         sourceStrategy:
@@ -121,10 +127,13 @@ objects:
       params:
         - name: git-url
           type: string
-          default: https://github.com/konveyor/pelorus
+          default: ${PROJECT_URI}
         - name: git-revision
           type: string
-          default: master
+          default: ${PROJECT_REF}
+        - name: build-no
+          type: string
+          default: "1"
         - name: BUILD_TYPE
           default: "buildconfig"
           description: "what type of build to run. One of buildconfig, binary, or s2i"
@@ -228,23 +237,28 @@ objects:
           params:
             - name: SCRIPT
               value: |
-                oc delete buildConfig ${APPLICATION_NAME} || true
-                #ls -la $(workspaces.manifest-dir.path)
+                if [ $(params.build-no) == "1" ]; then
+                  oc delete buildConfig ${APPLICATION_NAME} || true
+                fi
                 cd $(workspaces.manifest-dir.path)
                 pwd
                 # create build
-                echo "oc new-build python --name=${APPLICATION_NAME} --binary=true"
-                oc new-build python --name=${APPLICATION_NAME} --binary=true
-                # label build name
-                echo "oc label bc ${APPLICATION_NAME} app.kubernetes.io/name=${APPLICATION_NAME}"
-                oc label bc ${APPLICATION_NAME} app.kubernetes.io/name=${APPLICATION_NAME}
+                oc get bc "${APPLICATION_NAME}"
+                retVal=$?
+                if [ $retVal -ne 0 ]; then
+                  echo "oc new-build python --name=${APPLICATION_NAME} --binary=true"
+                  oc new-build python --name=${APPLICATION_NAME} --binary=true
+                  # label build name
+                  echo "oc label bc ${APPLICATION_NAME} app.kubernetes.io/name=${APPLICATION_NAME}"
+                  oc label bc ${APPLICATION_NAME} app.kubernetes.io/name=${APPLICATION_NAME}
+                fi
                 # start build
-                oc start-build bc/${APPLICATION_NAME} --from-dir=$(workspaces.manifest-dir.path)/demo/python-example --wait
+                oc start-build bc/${APPLICATION_NAME} --from-dir=$(workspaces.manifest-dir.path)/demo/python-example --wait || exit 2
                 # annotate build
-                echo "annotate binary build with git data: "
+                echo "annotate binary build no $(params.build-no) with git data: "
                 echo "git-url: $(params.git-url)"
                 echo "commit.id: $(tasks.checkout.results.commit)"
-                oc annotate build ${APPLICATION_NAME}-1 --overwrite \
+                oc annotate build "${APPLICATION_NAME}-$(params.build-no)" --overwrite \
                 io.openshift.build.commit.id="$(tasks.checkout.results.commit)" \
                 io.openshift.build.source-location="$(params.git-url)"
             - name: VERSION
@@ -267,15 +281,15 @@ objects:
                 printf "Build Type is $(params.BUILD_TYPE)\n"
                 if [[ "$(params.BUILD_TYPE)" == "buildconfig" ]]; then
                   printf "test buildconfig: requires exporter named committime-exporter \n"
-                  curl $(oc get route -n pelorus committime-exporter -o=template='http://{{.spec.host | printf "%s\n"}}') | grep "$(tasks.checkout.results.commit)" 
+                  curl $(oc get route -n pelorus committime-exporter -o=template='http://{{.spec.host | printf "%s\n"}}') | grep "$(tasks.checkout.results.commit)" || exit 2
                 fi
                 if [[ "$(params.BUILD_TYPE)" == "binary" ]]; then
                   printf "test binary: requires exporter named committime-exporter \n"
-                  curl $(oc get route -n pelorus committime-exporter -o=template='http://{{.spec.host | printf "%s\n"}}') | grep "$(tasks.checkout.results.commit)" 
+                  curl $(oc get route -n pelorus committime-exporter -o=template='http://{{.spec.host | printf "%s\n"}}') | grep "$(tasks.checkout.results.commit)" || exit 2
                 fi
                 if [[ "$(params.BUILD_TYPE)" == "s2i" ]]; then
                   printf "test s2i:  requires exporter named committime-image-exporter with variable PROVIDER=image \n"
-                  curl $(oc get route -n pelorus committime-image-exporter -o=template='http://{{.spec.host | printf "%s\n"}}') | grep "$(tasks.checkout.results.commit)"
+                  curl $(oc get route -n pelorus committime-image-exporter -o=template='http://{{.spec.host | printf "%s\n"}}') | grep "$(tasks.checkout.results.commit)" || exit 2
                 fi
           timeout: 2m
           retries: 3


### PR DESCRIPTION
Couple of changes:
 1. Tekton demo can ran from local source tree (without -g flag).
 2. Running with -g flag ensures modifications to the pelorus git project happens in the temporary directory and not local source tree
 3. Better handling of branches:
    - if remote branch exists, use it
    - if remote branch does not exists, create one
 4. Cleanup function added.
 5. Ensure we don't pollute master branch.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

## Testing Instructions

Local directory run:
clone pelorus fork, run demo on existing branch or non-exising, e.g.
```
git clone git@github.com:mpryc/pelorus.git
cd pelorus
./demo-tekton.sh -r non_existing_remote_branch -c 3
# Create new branch existing_remote_branch using GitHub UI (to ensure script works fine with remote branches not synced to current clone):
./demo-tekton.sh -r existing_remote_branch -c 3
```

Temp directory
- This is better as it works without polluting any of current files/branches from which script is being ran
- Ensure -g url is provided to location where local user have commit access, most likely https is not the one...
```
cd pelorus
./demo-tekton.sh -r non_existing_remote_branch -c 3 -g git@github.com:mpryc/pelorus.git
# Create new branch existing_remote_branch using GitHub UI (to ensure script works fine with remote branches not synced to current clone):
./demo-tekton.sh -r existing_remote_branch -c 3 -g  git@github.com:mpryc/pelorus.git
```

Failing master, we really don't want to run this script with master branch...
```
./demo-tekton.sh -r master -c 3 -g  git@github.com:mpryc/pelorus.git
```


@redhat-cop/mdt
