### PR TITLE
Add operator-sdk support to dev env, add release URL extraction python script

### DIFF
--- a/scripts/get_github_dl_url.py
+++ b/scripts/get_github_dl_url.py
@@ -134,12 +134,12 @@ parser.add_argument(
     metavar="executable",
     type=str,
     help="The executable to retrieve the URL for.",
-    choices=ExecutableToTool._member_names_,
+    choices={name.replace("_", "-") for name in ExecutableToTool._member_names_},
 )
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    software: str = args.software
+    software: str = args.software.replace("-", "_")
 
     tool = ExecutableToTool[software].tool
 

--- a/scripts/get_github_dl_url.py
+++ b/scripts/get_github_dl_url.py
@@ -16,7 +16,7 @@ GITHUB_RELEASE_TEMPLATE = "https://api.github.com/repos/{}/releases/latest"
 OS = platform.system()
 ARCH = platform.machine()
 
-X86_64_ARCH_NAMES = {"x86_64", "arm64"}
+X86_64_ARCH_NAMES = {"x86_64", "amd64"}
 
 # TOOLS:
 # these are ways to test the URLs of each release asset
@@ -58,7 +58,7 @@ class Nooba:
     "Nooba's URL pattern."
 
     repo = "noobaa/noobaa-operator"
-    arch = "mac" if ARCH == "Darwin" else ARCH
+    arch = "mac" if OS == "Darwin" else "linux"
     pattern = re.compile(f"https://(.*)-{arch}-(.*)[0-9]")
 
     @classmethod

--- a/scripts/get_github_dl_url.py
+++ b/scripts/get_github_dl_url.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+import argparse
+import enum
+import platform
+import re
+import sys
+from typing import Callable, Iterable, NamedTuple
+
+import requests
+
+GITHUB_RELEASE_TEMPLATE = "https://api.github.com/repos/{}/releases/latest"
+
+OS = platform.system()
+ARCH = platform.machine()
+
+X86_64_ARCH_NAMES = {"x86_64", "arm64"}
+
+
+class StandardTool:
+    TAR_GZ_PATTERN = re.compile(r"https://.*\.tar\.gz")
+    KERNEL_PATTERN = re.compile(OS, re.IGNORECASE)
+
+    if OS == "Darwin":
+        # some projects ship "universal binaries" which support x86 and ARM.
+        # they usually use "all" in the "arch" portion.
+        if ARCH in X86_64_ARCH_NAMES:
+            ARCH_PATTERN = re.compile("all|" + "|".join(X86_64_ARCH_NAMES))
+        elif ARCH == "arm64":
+            ARCH_PATTERN = re.compile("all|arm64")
+        else:
+            sys.exit(f"Unsupported architecture {ARCH}")
+    elif OS == "Linux":
+        if ARCH in X86_64_ARCH_NAMES:
+            ARCH_PATTERN = re.compile("|".join(X86_64_ARCH_NAMES))
+        else:
+            sys.exit(f"Unsupported architecture {ARCH}")
+    else:
+        sys.exit(f"Unsupported OS {OS}")
+
+    PATTERNS = TAR_GZ_PATTERN, KERNEL_PATTERN, ARCH_PATTERN
+
+    @classmethod
+    def url_matches(cls, url: str) -> bool:
+        return all(pat.search(url) for pat in cls.PATTERNS)
+
+
+class Nooba:
+    repo = "noobaa/noobaa-operator"
+    arch = "mac" if ARCH == "Darwin" else ARCH
+    pattern = re.compile(f"https://(.*)-{arch}-(.*)[0-9]")
+
+    @classmethod
+    def url_matches(cls, url: str) -> bool:
+        return cls.pattern.search(url) is not None
+
+
+class OperatorSdk:
+    repo = "operator-framework/operator-sdk"
+
+    if ARCH in X86_64_ARCH_NAMES:
+        arch = "amd64"
+    else:
+        arch = ARCH
+
+    pattern = re.compile(f"operator-sdk_{OS.lower()}_{arch}")
+
+    @classmethod
+    def url_matches(cls, url: str) -> bool:
+        return cls.pattern.search(url) is not None
+
+
+class Tool(enum.Enum):
+    def __init__(self, repo: str, matcher: Callable[[str], bool]):
+        self.repo = repo
+        self.matcher = matcher
+
+    TEKTON = "tektoncd/cli", StandardTool.url_matches
+    CHART_TEST = "helm/chart-testing", StandardTool.url_matches
+    CONFTEST = "open-policy-agent/conftest", StandardTool.url_matches
+    PROMETHEUS = "prometheus/prometheus", StandardTool.url_matches
+
+    NOOBA = Nooba.repo, Nooba.url_matches
+
+    OPERATOR_SDK = OperatorSdk.repo, OperatorSdk.url_matches
+
+
+class ExecutableToTool(enum.Enum):
+    """
+    Maps an executable name to a tool.
+    """
+
+    def __init__(self, tool: Tool):
+        self.tool = tool
+
+    tkn = (Tool.TEKTON,)
+    ct = (Tool.CHART_TEST,)
+    promtool = (Tool.PROMETHEUS,)
+    conftest = (Tool.CONFTEST,)
+    noobaa = (Tool.NOOBA,)
+    operator_sdk = (Tool.OPERATOR_SDK,)
+
+
+class ReleaseAsset(NamedTuple):
+    name: str
+    url: str
+    """
+    The download url, not the release or asset URL.
+    """
+
+    @classmethod
+    def from_json(cls, asset_dict: dict):
+        name = asset_dict["name"]
+        url = asset_dict["browser_download_url"]
+        return cls(name, url)
+
+
+def get_latest_assets(repo: str) -> Iterable[ReleaseAsset]:
+    url = GITHUB_RELEASE_TEMPLATE.format(repo)
+
+    response = requests.get(url)
+    response.raise_for_status()
+
+    body = response.json()
+
+    for asset in body["assets"]:
+        yield ReleaseAsset.from_json(asset)
+
+
+parser = argparse.ArgumentParser(
+    description="Extract the download URL for software hosted on github, taking into account OS and Architecture."
+)
+parser.add_argument(
+    "software",
+    metavar="executable",
+    type=str,
+    help="The executable to retrieve the URL for.",
+    choices=ExecutableToTool._member_names_,
+)
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    software: str = args.software
+
+    tool = ExecutableToTool[software].tool
+
+    for asset in get_latest_assets(tool.repo):
+        if tool.matcher(asset.url):
+            print(asset.url)
+            sys.exit()

--- a/scripts/install_dev_tools
+++ b/scripts/install_dev_tools
@@ -345,3 +345,13 @@ if should_cli_be_installed "noobaa" "${cli_tools_arr[@]}" && \
       chmod +x "${VENV}/bin/noobaa"
 fi
 
+if should_cli_be_installed "operator-sdk" "${cli_tools_arr[@]}" && \
+    ! [ -x "$(command -v "${VENV}/bin/operator-sdk")" ]; then
+      OPERATOR_SDK_URL=$("${SCRIPT_DIR}/get_github_dl_url.py" operator-sdk) \
+                    || cleanup_and_exit 2
+      echo "$OPERATOR_SDK_URL"
+      download_file_from_url "${OPERATOR_SDK_URL}" "${DWN_DIR}"
+      ls -alR $DWN_DIR
+      mv "${DWN_DIR}"/operator-sdk_* "${VENV}/bin/operator-sdk"
+      chmod +x "${VENV}/bin/operator-sdk"
+fi

--- a/scripts/install_dev_tools
+++ b/scripts/install_dev_tools
@@ -351,7 +351,6 @@ if should_cli_be_installed "operator-sdk" "${cli_tools_arr[@]}" && \
                     || cleanup_and_exit 2
       echo "$OPERATOR_SDK_URL"
       download_file_from_url "${OPERATOR_SDK_URL}" "${DWN_DIR}"
-      ls -alR $DWN_DIR
       mv "${DWN_DIR}"/operator-sdk_* "${VENV}/bin/operator-sdk"
       chmod +x "${VENV}/bin/operator-sdk"
 fi


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

- Allows running `./scripts/install_dev_tools operator-sdk` to install the [operator sdk](https://sdk.operatorframework.io/)
- Moves github release url extraction to a separate python script
  - this is done because adding yet another exception to the URL extraction code was going to get messy.

## Testing Instructions

1. `./scripts/install_dev_tools operator-sdk`
2. `which operator-sdk`