### PR TITLE
clean up pv && pvc prior to execution

### DIFF
--- a/demo/demo-tekton.sh
+++ b/demo/demo-tekton.sh
@@ -221,6 +221,12 @@ printf "Templates: "
 oc delete --all template.template.openshift.io -n "${app_namespace}" 2> /dev/null || echo "...done"
 printf "RBAC Authorization: "
 oc delete "clusterrolebinding.rbac.authorization.k8s.io/pipeline-role-binding-${app_namespace}" 2> /dev/null || echo "...done"
+pv="$(oc get pv | grep "${app_name}" | cut -d " " -f 1)"
+pvc="$(oc get pvc -n "${app_name}" | cut -d " " -f 1 | tail -n 1)"
+printf "Remove PV's and PVC's associated w/ the tekton demo: %s and %s\n" "$pv" "$pvc" 
+oc delete pv "$pv" --grace-period=0 --wait=false || true
+oc delete pvc "$pvc" -n "${app_namespace}" --grace-period=0 --wait=false || true
+oc patch pvc "$pvc" -p '{"metadata":{"finalizers":null}}' -n "${app_namespace}" || true
 
 echo "Setting up resources:"
 


### PR DESCRIPTION
* not having the pv and pvc cleaned up will cause the demo to fail
* message user and delete both the pvc and pv

Note: this is getting cumbersome to clean $everything to keep the pipeline history but I suppose we're done now.  This is to be compared to just nuking the namespace.

Signed-off-by: Wesley Hayutin <weshayutin@gmail.com>
