### PR TITLE
fix: Allow missing projects in JIRA exporter

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,11 @@ on:
       - '.github/workflows/integration-tests.yml'
       - 'Makefile'
 
+env:
+  JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+  JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+  TEST_QUAY: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest
@@ -38,10 +43,6 @@ jobs:
         run: make dev-env
 
       - name: Run integration-test
-        env:
-          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
-          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-          TEST_QUAY: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
         run: |
           env
           make integration-tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,9 +35,10 @@ jobs:
             pyproject.toml
 
       - name: Install dependencies
-        run: |
-          make dev-env
+        run: make dev-env
 
       - name: Run integration-test
-        run: |
-          make integration-tests
+        env:
+          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+        run: make integration-tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,4 +41,6 @@ jobs:
         env:
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-        run: make integration-tests
+        run: |
+          env
+          make integration-tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          TEST_QUAY: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
         run: |
           env
           make integration-tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,11 +14,6 @@ on:
       - '.github/workflows/integration-tests.yml'
       - 'Makefile'
 
-env:
-  JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
-  JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-  TEST_QUAY: ${{ secrets.QUAY_IMAGE_NAMESPACE }}
-
 jobs:
   integration-test:
     runs-on: ubuntu-latest
@@ -43,6 +38,7 @@ jobs:
         run: make dev-env
 
       - name: Run integration-test
-        run: |
-          env
-          make integration-tests
+        env:
+          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+        run: make integration-tests

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -126,7 +126,7 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
     - Only applicable for [PROVIDER](#provider) set to `jira` or `github`
 - **Type:** comma separated list of strings
 
-: * Used by Jira to define which projects (keys or names) to monitor. Value is ignored if [JIRA_JQL_SEARCH_QUERY](#jira_jql_search_query) is defined. Ensure the project(s) exists, otherwise none of the metrics will get collected.
+: * Used by Jira to define which projects (keys or names) to monitor. Value is ignored if [JIRA_JQL_SEARCH_QUERY](#jira_jql_search_query) is defined.
 
 : * Used by GitHub to define which repositories' issues to monitor.
 

--- a/exporters/README.md
+++ b/exporters/README.md
@@ -5,4 +5,4 @@ Before deploying, you must export your GITHUB_REPOS, GITHUB_USER and GITHUB_TOKE
     oc process -f templates/github-secret.yaml -p GITHUB_USER=${GITHUB_USER} -p GITHUB_TOKEN=${GITHUB_TOKEN} -p GITHUB_REPOS=${GITHUB_REPOS} | oc apply -f-
     oc process -f templates/exporter.yaml -p APP_NAME=commit-exporter | oc apply -f-
 
-Configuration can be found in the [config guide](./docs/Configuration.md)
+Configuration can be found in the [config guide](https://pelorus.readthedocs.io/en/latest/Configuration/).

--- a/exporters/README.md
+++ b/exporters/README.md
@@ -5,4 +5,4 @@ Before deploying, you must export your GITHUB_REPOS, GITHUB_USER and GITHUB_TOKE
     oc process -f templates/github-secret.yaml -p GITHUB_USER=${GITHUB_USER} -p GITHUB_TOKEN=${GITHUB_TOKEN} -p GITHUB_REPOS=${GITHUB_REPOS} | oc apply -f-
     oc process -f templates/exporter.yaml -p APP_NAME=commit-exporter | oc apply -f-
 
-Configuration can be found in the [config guide](https://pelorus.readthedocs.io/en/latest/Configuration/).
+Configuration can be found in the [config guide](https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusExporters/).

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -49,7 +49,6 @@ DEFAULT_COMMIT_DATE_FORMAT = "%a %b %d %H:%M:%S %Y %z"
 
 @define(kw_only=True)
 class CommittimeTypeConfig:
-
     provider: str = field(
         default=DEFAULT_PROVIDER, validator=attrs.validators.in_(PROVIDER_TYPES)
     )
@@ -72,7 +71,6 @@ class ImageCommittimeConfig:
     )
 
     def make_collector(self) -> AbstractCommitCollector:
-
         # Image provider is a special case, where commit time
         # metadata is stored within image.openshift.io/v1 object
         #

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -209,7 +209,6 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
         """Expects a sorted array of build data sorted by app label"""
         metrics = []
         for app in apps:
-
             builds = apps[app]
             jenkins_builds = list(
                 filter(lambda b: b.spec.strategy.type == "JenkinsPipeline", builds)
@@ -318,7 +317,6 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
         elif repo_url:
             metric.repo_url = repo_url
         else:
-
             repo_from_annotation = metric.annotations.get(self.repo_url_annotation_name)
             if repo_from_annotation:
                 metric.repo_url = repo_from_annotation

--- a/exporters/committime/collector_gitea.py
+++ b/exporters/committime/collector_gitea.py
@@ -18,7 +18,6 @@ DEFAULT_GITEA_API = Url.parse("https://try.gitea.io")
 
 @define(kw_only=True)
 class GiteaCommitCollector(AbstractCommitCollector):
-
     session: requests.Session = field(factory=requests.Session, init=False)
 
     # overrides with default

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -29,7 +29,6 @@ from .collector_base import AbstractCommitCollector
 
 @define(kw_only=True)
 class ImageCommitCollector(AbstractCommitCollector):
-
     date_format: str
 
     date_annotation_name: str = CommitMetric._ANNOTATION_MAPPIG["commit_time"]
@@ -153,7 +152,6 @@ class ImageCommitCollector(AbstractCommitCollector):
 
     # overrides collector_base.generate_metric()
     def generate_metrics(self) -> Iterable[CommitMetric]:
-
         # Initialize metrics list
         metrics = []
         app_label = self.app_label

--- a/exporters/deploytime/app.py
+++ b/exporters/deploytime/app.py
@@ -108,7 +108,6 @@ class DeployTimeCollector(pelorus.AbstractPelorusExporter):
         return namespaces
 
     def generate_metrics(self) -> Iterable[DeployTimeMetric]:
-
         namespaces = self.get_and_log_namespaces()
         if not namespaces:
             return []

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -21,6 +21,9 @@ from typing import Any, Optional, cast
 from attrs import define, field
 from jira import JIRA
 from jira.client import ResultList
+from typing import List, Optional
+
+from jira import JIRA, Issue
 from jira.exceptions import JIRAError
 
 from failure.collector_base import AbstractFailureCollector, TrackerIssue
@@ -29,9 +32,6 @@ from pelorus.config.converters import comma_or_whitespace_separated
 from pelorus.config.log import REDACT, log
 from pelorus.timeutil import parse_tz_aware, second_precision
 
-# One query limit, exporter will query multiple times.
-# Do not exceed 100 as JIRA won't return more.
-JIRA_SEARCH_RESULTS = 50
 QUERY_RESULT_FIELDS = (
     "summary,labels,created,resolutiondate,status,statuscategorychangedate"
 )
@@ -39,16 +39,15 @@ DEFAULT_JQL_SEARCH_QUERY = 'type in ("Bug") AND priority in ("Highest")'
 JQL_SEARCH_QUERY_ENV = "JIRA_JQL_SEARCH_QUERY"
 # User specified JIRA comma separated statuses for resolved issue
 RESOLVED_STATUS_ENV = "JIRA_RESOLVED_STATUS"
-
+NON_EXISTING_PROJECT_ERROR_START = "The value '"
+NON_EXISTING_PROJECT_ERROR_END = "' does not exist for the field 'project'."
 
 _DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 
 
 @define(kw_only=True)
 class JiraFailureCollector(AbstractFailureCollector):
-    """
-    Jira implementation of a FailureCollector
-    """
+    """JIRA implementation of a FailureCollector."""
 
     username: str = field(default="", metadata=env_vars(*env_var_names.USERNAME))
 
@@ -79,88 +78,128 @@ class JiraFailureCollector(AbstractFailureCollector):
         if self.jql_query_string != DEFAULT_JQL_SEARCH_QUERY:
             self.query_result_fields_string = ""
         elif self.projects:
-            projects_str = '","'.join(self.projects)
+            _projects = '","'.join(self.projects)
             self.jql_query_string = (
-                self.jql_query_string + ' AND project in ("{}")'.format(projects_str)
+                f'{self.jql_query_string} AND project in ("{_projects}")'
             )
 
     def _connect_to_jira(self) -> JIRA:
-        """Method to connect to JIRA instance which may be cloud based
-        or self-hosted.
-        """
-        jira_client = None
-
-        # Connect to Jira
-        jira_client = JIRA(
-            options={"server": self.tracker_api}, basic_auth=(self.username, self.token)
-        )
-
-        # Ensure connection was performed
+        """Connect to JIRA instance which may be cloud based or self-hosted."""
         try:
+            # Connect to JIRA
+            jira_client = JIRA(
+                options={"server": self.server}, basic_auth=(self.user, self.apikey)
+            )
+            # Ensure connection was performed
             jira_client.session()
+            return jira_client
         except JIRAError as error:
             logging.error(
                 "Status: %s, Error Response: %s", error.status_code, error.text
             )
             raise
 
-        return jira_client
+    def _filter_projects_in_query_string(self, error_text: str) -> str:
+        """
+        Filter for only existing projects in JQL query string.
 
-    def search_issues(self):
+        Parameters
+        ----------
+        error_text : str
+            Error text to get non existing projects.
+
+        Returns
+        -------
+        str
+            Filtered query string, if there is at least one existing project;
+            else, an empty string.
+        """
+        if self.projects:
+            non_existing_projects = {
+                line.replace(NON_EXISTING_PROJECT_ERROR_START, "").replace(
+                    NON_EXISTING_PROJECT_ERROR_END, ""
+                )
+                for line in error_text.splitlines()
+            }
+            _projects = '","'.join(self.projects.difference(non_existing_projects))
+            return (
+                f'{DEFAULT_JQL_SEARCH_QUERY} AND project in ("{_projects}")'
+                if _projects
+                else ""
+            )
+        return ""
+
+    def _jql_query_issues(
+        self, jira_client: JIRA, query_string: str
+    ) -> List[TrackerIssue]:
+        """
+        Apply JQL query in JIRA instance to get issues.
+
+        Parameters
+        ----------
+        jira_client : JIRA
+            JIRA instance.
+        query_string : str
+            JQL query string.
+
+        Returns
+        -------
+        List[TrackerIssue]
+            List of issues.
+        """
+        logging.debug("JIRA JQL query: %s", query_string)
+        jira_issues = jira_client.search_issues(
+            query_string,
+            startAt=0,
+            maxResults=False,
+            fields=self.query_result_fields_string,
+        )
+
+        return [self._parse_issue(issue) for issue in jira_issues]
+
+    def _parse_issue(self, issue: Issue) -> TrackerIssue:
+        """Parse issue collected from JIRA."""
+        logging.debug(issue)
+        logging.debug(
+            "Found issue opened: %s, %s: %s",
+            issue.fields.created,
+            issue.key,
+            issue.fields.summary,
+        )
+        # Create the JiraFailureMetric
+        created_tz = parse_tz_aware(issue.fields.created, _DATETIME_FORMAT)
+        created_ts = second_precision(created_tz).timestamp()
+        resolution_ts = self._get_resolved_timestamp(issue, self.jira_resolved_statuses)
+        return TrackerIssue(
+            issue.key, created_ts, resolution_ts, self.get_app_name(issue)
+        )
+
+    def search_issues(self) -> List[TrackerIssue]:
+        """
+        Search for the matching issues in JIRA.
+
+        Returns
+        -------
+        List[TrackerIssue]
+            A list with the issues, if no error occurs; else, an empty list.
+        """
         jira_client = self._connect_to_jira()
-
-        critical_issues = []
-
         try:
-            logging.debug("JIRA JQL query: %s" % self.jql_query_string)
-            jira_issues = []
-            start_at = 0
-            while True:
-                jira_search_results = cast(
-                    ResultList,
-                    jira_client.search_issues(
-                        self.jql_query_string,
-                        startAt=start_at,
-                        maxResults=JIRA_SEARCH_RESULTS,
-                        fields=self.query_result_fields_string,
-                    ),
-                )
-                jira_issues += jira_search_results.iterable  # type: ignore
-                start_at += JIRA_SEARCH_RESULTS
-                logging.info("Getting jira results: %s" % start_at)
-                if start_at >= jira_search_results.total:
-                    break
-
-            for issue in jira_issues:
-                logging.debug(issue)
-                logging.debug(
-                    "Found issue opened: {}, {}: {}".format(
-                        str(issue.fields.created), issue.key, issue.fields.summary
-                    )
-                )
-                # Create the JiraFailureMetric
-                created_tz = parse_tz_aware(issue.fields.created, _DATETIME_FORMAT)
-                created_ts = second_precision(created_tz).timestamp()
-                resolution_ts = self._get_resolved_timestamp(
-                    issue, self.jira_resolved_statuses
-                )
-                tracker_issue = TrackerIssue(
-                    issue.key, created_ts, resolution_ts, self.get_app_name(issue)
-                )
-                critical_issues.append(tracker_issue)
+            return self._jql_query_issues(jira_client, self.jql_query_string)
         except JIRAError as error:
             if error.status_code == 400:
                 logging.error(
                     "Status: %s, Error Response: %s", error.status_code, error.text
                 )
-                logging.info("JIRA query: %s", self.jql_query_string)
-            else:
-                raise
-
-        return critical_issues
+                if NON_EXISTING_PROJECT_ERROR_END in error.text:
+                    new_query = self._filter_projects_in_query_string(error.text)
+                    if new_query:
+                        return self._jql_query_issues(jira_client, new_query)
+                return []
+            raise
 
     def _get_resolved_timestamp(
-        self, issue: Any, resolved_statuses: Optional[str] = None
+        self, issue: Issue, resolved_statuses: Optional[str] = None
     ) -> Optional[float]:
         """
         `_get_resolved_timestamp` finds timestamp when the issue was resolved or moved
@@ -174,12 +213,11 @@ class JiraFailureCollector(AbstractFailureCollector):
             ]
             if issue.fields.status.name.lower() in statuses:
                 logging.debug(
-                    "Found issue {}: {}, {}: {}".format(
-                        issue.fields.status.name,
-                        str(issue.fields.statuscategorychangedate),
-                        issue.key,
-                        issue.fields.summary,
-                    )
+                    "Found issue %s: %s, %s: %s",
+                    issue.fields.status.name,
+                    issue.fields.statuscategorychangedate,
+                    issue.key,
+                    issue.fields.summary,
                 )
                 resolution_tz = parse_tz_aware(
                     issue.fields.statuscategorychangedate, _DATETIME_FORMAT
@@ -187,11 +225,10 @@ class JiraFailureCollector(AbstractFailureCollector):
         else:
             if issue.fields.resolutiondate:
                 logging.debug(
-                    "Found issue close: {}, {}: {}".format(
-                        str(issue.fields.resolutiondate),
-                        issue.key,
-                        issue.fields.summary,
-                    )
+                    "Found issue close: %s, %s: %s",
+                    issue.fields.resolutiondate,
+                    issue.key,
+                    issue.fields.summary,
                 )
                 resolution_tz = parse_tz_aware(
                     issue.fields.resolutiondate, _DATETIME_FORMAT
@@ -201,9 +238,9 @@ class JiraFailureCollector(AbstractFailureCollector):
 
         return resolution_ts
 
-    def get_app_name(self, issue):
-        app_label = self.app_label
+    def get_app_name(self, issue: Issue) -> str:
         for label in issue.fields.labels:
-            if label.startswith("%s=" % app_label):
-                return label.replace("%s=" % app_label, "")
+            matcher = f"{pelorus.get_app_label()}="
+            if label.startswith(matcher):
+                return label.replace(matcher, "")
         return "unknown"

--- a/exporters/failure/collector_jira.py
+++ b/exporters/failure/collector_jira.py
@@ -16,13 +16,9 @@
 #
 
 import logging
-from typing import Any, Optional, cast
-
-from attrs import define, field
-from jira import JIRA
-from jira.client import ResultList
 from typing import List, Optional
 
+from attrs import define, field
 from jira import JIRA, Issue
 from jira.exceptions import JIRAError
 
@@ -88,7 +84,8 @@ class JiraFailureCollector(AbstractFailureCollector):
         try:
             # Connect to JIRA
             jira_client = JIRA(
-                options={"server": self.server}, basic_auth=(self.user, self.apikey)
+                options={"server": self.tracker_api},
+                basic_auth=(self.username, self.token),
             )
             # Ensure connection was performed
             jira_client.session()
@@ -240,7 +237,7 @@ class JiraFailureCollector(AbstractFailureCollector):
 
     def get_app_name(self, issue: Issue) -> str:
         for label in issue.fields.labels:
-            matcher = f"{pelorus.get_app_label()}="
+            matcher = f"{self.app_label}="
             if label.startswith(matcher):
                 return label.replace(matcher, "")
         return "unknown"

--- a/exporters/pelorus/deserialization/errors.py
+++ b/exporters/pelorus/deserialization/errors.py
@@ -144,6 +144,7 @@ class DeserializationErrors(ExceptionGroup[DeserializationError], Deserializatio
 
         Similar behavior to `ExceptionGroup.split`.
         """
+
         # these can technically never be none at the same time, but the caller
         # has to handle it as if that's possible anyway.
         def matches(err):

--- a/exporters/pelorus/utils/__init__.py
+++ b/exporters/pelorus/utils/__init__.py
@@ -234,7 +234,6 @@ class Url(urllib3.util.Url):
 
     @classmethod
     def parse(cls, url: str):
-
         parsed = urllib3.util.parse_url(url)
 
         if parsed.scheme is None:

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -89,7 +89,6 @@ class CommitMetricEssentials:
 
 @pytest.mark.mockoon
 def test_github_provider(github_collector: GitHubCommitCollector):
-
     actual = [
         CommitMetricEssentials.from_commit_metric(cm)
         for cm in github_collector.generate_metrics()

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -42,6 +42,8 @@ JIRA_VALUES = [
 PROJECTS_COMMA = "proj1,proj2,proj1,proj3,proj3"
 PROJECTS_SPACES = "proj1 proj2 proj1 proj3 proj3"
 PROJECTS_UNIQUE = {"proj1", "proj2", "proj3"}
+JIRA_USERNAME = os.environ.get("JIRA_USERNAME")
+JIRA_TOKEN = os.environ.get("JIRA_TOKEN")
 
 
 def setup_jira_collector(
@@ -76,21 +78,27 @@ def test_jira_pass_connection(server, username, apikey):
     assert "Basic authentication with passwords is deprecated" in str(context_ex.value)
 
 
-# TODO write mockoon or integration to test success (and success without finding any issue)
-# @pytest.mark.parametrize("projects", ["non_existing,Test,wrong_name", "Test"])
-# @pytest.mark.parametrize(
-#     JIRA_PARAMETERS,
-#     [("https://pelorustest.atlassian.net", "valid_username", "valid_token")],
-# )
-# @pytest.mark.integration
-# def test_jira_search(server, username, apikey, projects):
-#     collector = setup_jira_collector(server, username, apikey, projects)
+# TODO write mockoon or integration to test success without finding any issue
+@pytest.mark.parametrize("projects", ["non_existing,Test,wrong_name", "Test"])
+@pytest.mark.parametrize(
+    JIRA_PARAMETERS,
+    [("https://pelorustest.atlassian.net", JIRA_USERNAME, JIRA_TOKEN)],
+)
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not JIRA_USERNAME, reason="No Jira username set, run export JIRA_USERNAME=username"
+)
+@pytest.mark.skipif(
+    not JIRA_TOKEN, reason="No Jira token set, run export JIRA_TOKEN=token"
+)
+def test_jira_search(server, username, apikey, projects):
+    collector = setup_jira_collector(server, username, apikey, projects)
 
-#     with nullcontext() as context:
-#         issues = collector.search_issues()
+    with nullcontext() as context:
+        issues = collector.search_issues()
 
-#     assert context is None
-#     assert len(issues) == 103
+    assert context is None
+    assert len(issues) == 103
 
 
 @pytest.mark.parametrize(JIRA_PARAMETERS, JIRA_VALUES)


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Ignores missing projects when exporting JIRA issues. 

## Linked Issues?

resolves #455

## Testing Instructions

Uncomment the test in `exporters/tests/test_failure_exporter.py` with your credentials and run integration tests.

@redhat-cop/mdt
