### PR TITLE
Pin macOS oc version to 4.10, download ARM on ARM macs

### DIFF
--- a/scripts/install_dev_tools
+++ b/scripts/install_dev_tools
@@ -33,12 +33,6 @@ HELM_FALLBACK_VERSION="v3.9.2"
 # Bats are required for conftest
 BATS_REPO_URL="https://github.com/bats-core/bats-core"
 
-# Currently we are interested in development on Linux and Mac OS platforms
-# Because OCP_CLIENT URL links do not follow standard binary name format
-# e.g. Linux/Darwin we need to map those 
-PLATFORM="linux"
-[[ "$(uname -s)" =~ "Darwin" ]] && PLATFORM="mac"
-OCP_CLIENT_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-${PLATFORM}.tar.gz"
 
 
 function download_file_from_url() {
@@ -188,7 +182,7 @@ fi
 if should_cli_be_installed "tkn" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/tkn")" ]; then
       echo "Installing tkn CLI to: ${VENV}/bin/tkn"
-      TKN_CLIENT_URL=$("${SCRIPT_DIR}/get_github_dl_url.py" tkn) \
+      TKN_CLIENT_URL=$("${SCRIPT_DIR}/get_tool_dl_url.py" tkn) \
                     || cleanup_and_exit 2
       echo "$TKN_CLIENT_URL"
       download_file_from_url "${TKN_CLIENT_URL}" "${DWN_DIR}"
@@ -200,6 +194,8 @@ fi
 if should_cli_be_installed "oc" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/oc")" ]; then
       echo "Installing oc CLI to: ${VENV}/bin/oc"
+      OCP_CLIENT_URL=$("${SCRIPT_DIR}/get_tool_dl_url.py" oc) \
+                    || cleanup_and_exit 2
       download_file_from_url "${OCP_CLIENT_URL}" "${DWN_DIR}"
       OCP_CLIENT_PATH="${DWN_DIR}"/$(basename "${OCP_CLIENT_URL}")
       # We are interested only in oc/kubectl binaries
@@ -209,7 +205,7 @@ fi
 # CT install
 if should_cli_be_installed "ct" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/ct")" ]; then
-      CT_CLIENT_URL=$("${SCRIPT_DIR}/get_github_dl_url.py" ct) \
+      CT_CLIENT_URL=$("${SCRIPT_DIR}/get_tool_dl_url.py" ct) \
                     || cleanup_and_exit 2
       echo "$CT_CLIENT_URL"
       download_file_from_url "${CT_CLIENT_URL}" "${DWN_DIR}"
@@ -220,7 +216,7 @@ fi
 # Promtool install
 if should_cli_be_installed "promtool" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/promtool")" ]; then
-      PROMTOOL_CLIENT_URL=$("${SCRIPT_DIR}/get_github_dl_url.py" promtool) \
+      PROMTOOL_CLIENT_URL=$("${SCRIPT_DIR}/get_tool_dl_url.py" promtool) \
                     || cleanup_and_exit 2
       echo "$PROMTOOL_CLIENT_URL"
       download_file_from_url "${PROMTOOL_CLIENT_URL}" "${DWN_DIR}"
@@ -237,7 +233,7 @@ fi
 # Conftest CLI
 if should_cli_be_installed "conftest" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/conftest")" ]; then
-      CONFTEST_CLIENT_URL=$("${SCRIPT_DIR}/get_github_dl_url.py" conftest) \
+      CONFTEST_CLIENT_URL=$("${SCRIPT_DIR}/get_tool_dl_url.py" conftest) \
                     || cleanup_and_exit 2
       echo "$CONFTEST_CLIENT_URL"
       download_file_from_url "${CONFTEST_CLIENT_URL}" "${DWN_DIR}"
@@ -268,7 +264,7 @@ fi
 # nooba CLI
 if should_cli_be_installed "noobaa" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/noobaa")" ]; then
-      NOOBAA_CLIENT_URL=$("${SCRIPT_DIR}/get_github_dl_url.py" noobaa) \
+      NOOBAA_CLIENT_URL=$("${SCRIPT_DIR}/get_tool_dl_url.py" noobaa) \
                     || cleanup_and_exit 2
       echo "$NOOBAA_CLIENT_URL"
       download_file_from_url "${NOOBAA_CLIENT_URL}" "${DWN_DIR}"
@@ -279,7 +275,7 @@ fi
 
 if should_cli_be_installed "operator-sdk" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/operator-sdk")" ]; then
-      OPERATOR_SDK_URL=$("${SCRIPT_DIR}/get_github_dl_url.py" operator-sdk) \
+      OPERATOR_SDK_URL=$("${SCRIPT_DIR}/get_tool_dl_url.py" operator-sdk) \
                     || cleanup_and_exit 2
       echo "$OPERATOR_SDK_URL"
       download_file_from_url "${OPERATOR_SDK_URL}" "${DWN_DIR}"


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Pin `oc` on macs to 4.10 to work around a golang x509 bug.

Also install the arm version of `oc` on arm macs.

## Linked Issues?

resolves #707

## Testing Instructions

1. Delete `.venv/bin/oc`
2. Run `make .venv/bin/oc`
3. Verify it installs correctly.

If on a mac:

1. Follow the above
2. try connecting to an OpenShift cluster with untrusted certs
3. run `file .venv/bin/oc` and verify it is arm formatted.
