### PR TITLE
Introduce the start of automatic type checking

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -41,6 +41,4 @@ jobs:
         run: sudo apt-get install nodejs
 
       - name: Type Check
-        # we are not treating type checking errors as fatal for now.
-        continue-on-error: true
         run: make typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -34,7 +34,7 @@ jobs:
         run: make dev-env
       
       - name: Install node
-        run: sudo apt install node
+        run: sudo apt install nodejs
 
       - name: Type Check
         # we are not treating type checking errors as fatal for now.

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,4 +1,4 @@
-name: Type Check
+name: Type Check (ignore failures for now)
 on:
   push:
     paths:
@@ -41,4 +41,5 @@ jobs:
         run: sudo apt-get install nodejs
 
       - name: Type Check
+        continue-on-error: true
         run: make typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,42 @@
+name: Type Check
+on:
+  push:
+    paths:
+      - 'exporters/**'
+      - 'pyproject.toml'
+      - '.github/workflows/typecheck.yml'
+      - 'Makefile'
+
+  pull_request:
+    paths:
+      - 'exporters/**'
+      - 'pyproject.toml'
+      - '.github/workflows/typecheck.yml'
+      - 'Makefile'
+  
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: make dev-env
+      
+      - name: Install node
+        run: sudo apt install node
+
+      - name: Type Check
+        # we are not treating type checking errors as fatal for now.
+        continue-on-error: true
+        run: make typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,12 +23,16 @@ jobs:
         python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: make dev-env

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -38,7 +38,7 @@ jobs:
         run: make dev-env
       
       - name: Install node
-        run: sudo apt install nodejs
+        run: sudo apt-get install nodejs
 
       - name: Type Check
         # we are not treating type checking errors as fatal for now.

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ isort-check: $(PELORUS_VENV)
 
 # Linting
 
-.PHONY: lint python-lint pylava chart-lint chart-lint-optional shellcheck shellcheck-optional chart-check-bump
+.PHONY: lint python-lint pylava chart-lint chart-lint-optional shellcheck shellcheck-optional chart-check-bump typecheck
 ## lint: lint python code, shell scripts, and helm charts
 lint: python-lint chart-lint-optional shellcheck-optional
 
@@ -220,7 +220,7 @@ python-lint: $(PELORUS_VENV)
 pylava: python-lint
 
 typecheck:
-	mypy
+	pyright
 
 # chart-lint allows us to fail properly when run from CI,
 # while chart-lint-optional allows graceful degrading when

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,8 @@ python-lint: $(PELORUS_VENV)
 
 pylava: python-lint
 
-typecheck:
+typecheck: $(PELORUS_VENV)
+	. ${PELORUS_VENV}/bin/activate && \
 	pyright
 
 # chart-lint allows us to fail properly when run from CI,

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ python-lint: $(PELORUS_VENV)
 pylava: python-lint
 
 typecheck: $(PELORUS_VENV)
+	$(warning Type checking is not fully ready yet, the issues below may be ignorable)
 	. ${PELORUS_VENV}/bin/activate && \
 	pyright
 

--- a/exporters/requirements-dev.txt
+++ b/exporters/requirements-dev.txt
@@ -18,6 +18,7 @@ mkdocs
 black
 isort
 pylama[toml] >= 8.4.0
+pyright
 
 # # Issue #584
 # pyflakes <= 2.4.0

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -18,6 +18,12 @@ if ! make -k lint; then
     failed=1
 fi
 
+# echo "📋 Type Checking, expect failures for now"
+# if ! make -k typecheck; then
+#     printf "\n\n"
+#     echo "Type checking failed, although this is to be expected for now." >&2
+# fi
+
 printf "\n\n"
 
 if [[ failed -ne 0 ]]; then


### PR DESCRIPTION
We're not running it as part of pre-commit yet so we don't get error fatigue. ~~Unfortunately, it doesn't seem like there's an easy way to mark a check as a "warning": https://github.com/actions/toolkit/issues/399~~. Never mind! We can just mark the check as not required for merging.

## Describe the behavior changes introduced in this PR

Adds a type check target and runs type checking in CI.

Type checking is not a hard requirement, and is just informational right now.

## Linked Issues?

related to #708

## Testing Instructions

See CI logs.

To run it yourself, update your venv, make sure you have node installed on your system, and run `pyright`.

If you use VS Code and the python extension, you're probably already using pyright!