### PR TITLE
Update GH actions, cache python deps

### DIFF
--- a/.github/workflows/build-pelorus.yaml
+++ b/.github/workflows/build-pelorus.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup S2i and Build container image
       - name: Setup and Build
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup S2i and Build container image
       - name: Setup and Build
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup S2i and Build container image
       - name: Setup and Build
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup S2i and Build container image
       - name: Setup and Build

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -32,9 +32,13 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Lint charts
         run: make chart-lint

--- a/.github/workflows/conftest.yaml
+++ b/.github/workflows/conftest.yaml
@@ -24,12 +24,16 @@ jobs:
         python-version: ['3.9']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,12 +23,16 @@ jobs:
         python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/mockoon-tests.yml
+++ b/.github/workflows/mockoon-tests.yml
@@ -25,12 +25,16 @@ jobs:
         python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout opl-content-api
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Tag committime with (pre)release version
         uses: tinact/docker.image-retag@1.0.2

--- a/.github/workflows/prometheus-rules.yml
+++ b/.github/workflows/prometheus-rules.yml
@@ -21,12 +21,16 @@ jobs:
         python-version: ['3.9']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-formatting.yml
+++ b/.github/workflows/python-formatting.yml
@@ -17,12 +17,16 @@ jobs:
         python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Check for formatting
         run: make format-check

--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -17,12 +17,16 @@ jobs:
         python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Lint
         run: make python-lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout opl-content-api
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Tag committime with release version
         uses: tinact/docker.image-retag@1.0.2

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -32,12 +32,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Test with shellcheck
         run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -23,12 +23,16 @@ jobs:
         python-version: ['3.9', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Updates the checkout and python github actions we use. This is to avoid bitrot, and get rid of deprecation warnings.

This also now lets us cache python dependencies-- now if you have actions run again for the same PR, it will reuse those dependencies unless any of the requirements files changed.

## Linked Issues?

resolves #711

## Testing Instructions

See GitHub actions and verify that they are working properly.
