### PR TITLE
Script to create new operator from already existing helm charts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,3 +53,10 @@ for the commit time exporter using mocked data from mockoon server.
 Used by the makefile to setup pre-commit hook for local lint tests that are
 
 invoked before commit is prepared.
+
+## scripts/pelorus-operator-patches
+
+Used to create Pelorus helm based operator from the helm charts.
+
+Ensures modification to the operator files can be cleanly applied and allows
+to recreate operator easily.

--- a/scripts/create_pelorus_operator
+++ b/scripts/create_pelorus_operator
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+OPERATOR_PROJECT_NAME=pelorus-operator
+OPERATOR_ORG_NAME=migtools
+OPERATOR_PROJECT_DOMAIN=pelorus.konveyor.io
+
+# Get the full absolute path to the script. Needed while calling the script
+# via various partial paths or sourcing the file from shell
+# BASH_SOURCE[0] is safer then $0 when sourcing.
+# We enter the dirname of the invoked script and then get the current
+# path of the script using pwd
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+DEFAULT_PELORUS_CHARTS_DIR="${SCRIPT_DIR}/../charts/pelorus/"
+DEFAULT_PELORUS_OPERATOR_DIR="${SCRIPT_DIR}/../pelorus-operator/"
+DEFAULT_PELORUS_OPERATOR_PATCHES_DIR="${SCRIPT_DIR}/pelorus-operator-patches/"
+
+function print_help() {
+    printf "\nUsage: %s [OPTION]\n\n" "$0"
+    printf "\tStartup:\n"
+    printf "\t  -h\tprint this help\n"
+    printf "\n\tOptions:\n"
+    printf "\t  -s\tpath to source pelorus helm charts folder, default: %s\n" "${DEFAULT_PELORUS_CHARTS_DIR}"
+    printf "\t  -d\tpath to EMPTY destination folder, default: %s\n" "${DEFAULT_PELORUS_OPERATOR_DIR}"
+    printf "\t  -p\tpath to DIR with operator patches to be applied, default: %s\n" "${DEFAULT_PELORUS_OPERATOR_PATCHES_DIR}"
+    exit 0
+}
+
+### Options
+OPTIND=1
+while getopts "s:d:p:h?" option; do
+    case "$option" in
+    h|\?) print_help;;
+    s)    source_dir=$OPTARG;;
+    d)    destination_dir=$OPTARG;;
+    p)    patches_dir=$OPTARG;;
+    esac
+done
+
+if [ -z ${source_dir+x} ]; then
+    source_dir="${DEFAULT_PELORUS_CHARTS_DIR}"
+fi
+if [ -z ${destination_dir+x} ]; then
+    destination_dir="${DEFAULT_PELORUS_OPERATOR_DIR}"
+fi
+if [ -z ${patches_dir+x} ]; then
+    patches_dir="${DEFAULT_PELORUS_OPERATOR_PATCHES_DIR}"
+fi
+
+echo "INFO: Source directory: ${source_dir}"
+echo "INFO: Destination directory: ${destination_dir}"
+echo "INFO: Patches directory: ${patches_dir}"
+
+if ! [ -x "$(command -v "operator-sdk")" ]; then
+    echo "ERROR: operator-sdk CLI not found. Please activate Pelorus venv!"
+    exit 2
+else
+    echo "INFO: $(operator-sdk version)"
+fi
+
+# Check if source directory exists
+if [ ! -d "${source_dir}" ]; then
+	echo "ERROR: Source directory ${source_dir} does not exists."
+    exit 2
+fi
+
+# Check if destination directory is empty and exists
+if [ -d "${destination_dir}" ]; then
+	if [ "$(ls -A "${destination_dir}")" ]; then
+        echo "ERROR: Destination directory ${destination_dir} is not empty, can not continue."
+        exit 2
+	fi
+else
+	echo "ERROR: Destination directory ${destination_dir} do not exists, please create one and re-run script."
+    exit 2
+fi
+
+pushd "${destination_dir}" || exit 2
+    echo "INFO: Creating operator init files"
+    operator-sdk init --plugins=helm --domain "${OPERATOR_PROJECT_DOMAIN}" --project-name "${OPERATOR_PROJECT_NAME}" || exit 2
+    echo "INFO: Creating api"
+    operator-sdk create api --helm-chart="${source_dir}" || exit 2
+
+    # Correct operator version, to be latest +1
+    OPERATOR_VERSION=$(curl -H "Authorization: Bearer XYZ" -X GET "https://quay.io/api/v1/repository/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}/tag/" | jq .tags[].name | head -1 | sed -e 's|\"||g')
+    echo "INFO: Current operator version: ${OPERATOR_VERSION}"
+    NEW_OPERATOR_VERSION=$(echo ${OPERATOR_VERSION} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+    echo "INFO: New operator version: ${NEW_OPERATOR_VERSION}"
+    sed -i "s/VERSION ?= 0.0.1/VERSION ?= ${NEW_OPERATOR_VERSION}/g" Makefile || exit 2
+
+    # Correct IMAGE_TAG_BASE
+    IMAGE_TAG_BASE="quay.io/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}"
+    echo "INFO: Setting IMAGE_TAG_BASE to ${IMAGE_TAG_BASE}"
+    sed -i "s#IMAGE_TAG_BASE ?=.*#IMAGE_TAG_BASE ?= ${IMAGE_TAG_BASE}#g" Makefile || exit 2
+popd || exit 2
+
+# Check if patches directory exists
+if [ ! -d "${patches_dir}" ]; then
+	echo "WARNING: Patches directory ${patches_dir} do not exists, patches will not be applied."
+elif [ "$(ls -A "${patches_dir}"/*.diff 2>/dev/null)" ]; then
+        echo "INFO: Found patches in ${patches_dir}."
+        for patch_file in "${patches_dir}"/*.diff; do
+            echo "INFO: Applying patch ${patch_file}"
+            patch -d "${destination_dir}" -p0 < "${patch_file}"
+        done
+fi
+
+# Correct operator version, to be latest +1
+OPERATOR_VERSION=$(curl -H "Authorization: Bearer XYZ" -X GET "https://quay.io/api/v1/repository/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}/tag/" | jq .tags[].name | head -1 | sed -e 's|\"||g')
+echo "INFO: Current operator version: ${OPERATOR_VERSION}"
+NEW_OPERATOR_VERSION=$(echo ${OPERATOR_VERSION} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+echo "INFO: New operator version: ${NEW_OPERATOR_VERSION}"
+
+echo "INFO: Operator crated and available at: ${destination_dir}"
+echo "To build and push to the quay use from the operator folder:"
+echo "  # podman login -u="migtools+pelorus" -p=\"\$QUAY_TOKEN\" quay.io"
+echo "  # make podman-build podman-push"
+echo "  # # Log in to your cluster or export KUBECONFIG"
+echo "  # make deploy"
+
+

--- a/scripts/pelorus-operator-patches/01_podman_makefile_tool.diff
+++ b/scripts/pelorus-operator-patches/01_podman_makefile_tool.diff
@@ -1,0 +1,58 @@
+--- Makefile.orig	2022-11-09 11:41:34.719806848 +0100
++++ Makefile	2022-11-09 11:41:41.982838149 +0100
+@@ -50,7 +50,7 @@
+ IMG ?= controller:latest
+ 
+ .PHONY: all
+-all: docker-build
++all: podman-build
+ 
+ ##@ General
+ 
+@@ -75,13 +75,13 @@
+ run: helm-operator ## Run against the configured Kubernetes cluster in ~/.kube/config
+ 	$(HELM_OPERATOR) run
+ 
+-.PHONY: docker-build
+-docker-build: ## Build docker image with the manager.
+-	docker build -t ${IMG} .
+-
+-.PHONY: docker-push
+-docker-push: ## Push docker image with the manager.
+-	docker push ${IMG}
++.PHONY: podman-build
++podman-build: ## Build podman image with the manager.
++	podman build -t ${IMG} .
++
++.PHONY: podman-push
++podman-push: ## Push podman image with the manager.
++	podman push ${IMG}
+ 
+ ##@ Deployment
+ 
+@@ -146,11 +146,11 @@
+ 
+ .PHONY: bundle-build
+ bundle-build: ## Build the bundle image.
+-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
++	podman build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+ 
+ .PHONY: bundle-push
+ bundle-push: ## Push the bundle image.
+-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
++	$(MAKE) podman-push IMG=$(BUNDLE_IMG)
+ 
+ .PHONY: opm
+ OPM = ./bin/opm
+@@ -185,9 +185,9 @@
+ # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
+ .PHONY: catalog-build
+ catalog-build: opm ## Build a catalog image.
+-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
++	$(OPM) index add --container-tool podman --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+ 
+ # Push the catalog image.
+ .PHONY: catalog-push
+ catalog-push: ## Push a catalog image.
+-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
++	$(MAKE) podman-push IMG=$(CATALOG_IMG)

--- a/scripts/pelorus-operator-patches/02_makefile_image_url.diff
+++ b/scripts/pelorus-operator-patches/02_makefile_image_url.diff
@@ -1,0 +1,11 @@
+--- Makefile.orig	2022-11-09 11:56:41.174650219 +0100
++++ Makefile	2022-11-09 11:57:05.604748059 +0100
+@@ -47,7 +47,7 @@
+ endif
+ 
+ # Image URL to use all building/pushing image targets
+-IMG ?= controller:latest
++IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
+ 
+ .PHONY: all
+ all: podman-build

--- a/scripts/pelorus-operator-patches/03_pelorus_operators_roles.diff
+++ b/scripts/pelorus-operator-patches/03_pelorus_operators_roles.diff
@@ -1,0 +1,97 @@
+--- config/rbac/kustomization.yaml
++++ config/rbac/kustomization.yaml
+@@ -7,6 +7,8 @@ resources:
+ - service_account.yaml
+ - role.yaml
+ - role_binding.yaml
++- pelorus_manager_role.yaml
++- pelorus_role_binding.yaml
+ - leader_election_role.yaml
+ - leader_election_role_binding.yaml
+ # Comment the following 4 lines if you want to disable
+--- /dev/null
++++ config/rbac/pelorus_manager_role.yaml
+@@ -0,0 +1,67 @@
++apiVersion: rbac.authorization.k8s.io/v1
++kind: ClusterRole
++metadata:
++  name: pelorus-manager-role
++rules:
++# Needed to create or delete Prometheus and Grafana subscriptions
++- apiGroups:
++  - "operators.coreos.com"
++  resources:
++  - "operatorgroups"
++  - "subscriptions"
++  verbs:
++  - get
++  - create
++  - delete
++  - list
++  - watch
++- apiGroups:
++  - "batch"
++  resources:
++  - "jobs"
++  - "cronjobs"
++  verbs:
++  - list
++  - create
++  - get
++  - watch
++  - delete
++- apiGroups:
++  - ""
++  resources:
++  - "serviceaccounts"
++  verbs:
++  - create
++  - get
++  - list
++  - watch
++# Pelorus require new role to allow installplan approval job
++- apiGroups:
++  - "rbac.authorization.k8s.io"
++  resources:
++  - "roles"
++  - "rolebindings"
++  verbs:
++  - create
++  - get
++  - list
++  - watch
++  - delete
++# Required to grand permissions to the installplan-approver user
++- apiGroups:
++  - "operators.coreos.com"
++  resources:
++  - "installplans"
++  - "subscriptions"
++  verbs:
++  - get
++  - list
++  - patch
++# Required to grand permissions to the csv-deleter / attempting to grant RBAC permissions not currently held
++- apiGroups:
++  - "operators.coreos.com"
++  resources:
++  - "clusterserviceversions"
++  verbs:
++  - delete
++  - list
+--- /dev/null
++++ config/rbac/pelorus_role_binding.yaml
+@@ -0,0 +1,12 @@
++apiVersion: rbac.authorization.k8s.io/v1
++kind: ClusterRoleBinding
++metadata:
++  name: pelorus-manager-rolebinding
++roleRef:
++  apiGroup: rbac.authorization.k8s.io
++  kind: ClusterRole
++  name: pelorus-manager-role
++subjects:
++- kind: ServiceAccount
++  name: controller-manager
++  namespace: system
+


### PR DESCRIPTION
The intention of this script is to easy recreate operator files and ensure new version of operator-sdk can be used with our mods.

This script expects clean output directory where the operator will be generated.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

## Testing Instructions

Ensure you have correct helm charts (from the https://github.com/mpryc/pelorus-operator/tree/master/operator/helm-charts/pelorus-operators). Once they will be clean in the pelorus repo we will use them from default location.

$ source .venv/bin/activate
$ mkdir /tmp/operator
$ mkdir /tmp/generated-operator
$ pushd /tmp/operator
$ git clone git@github.com:mpryc/pelorus-operator.git
$ popd

$ ./scripts/create_pelorus_operator -h
$ ./scripts/create_pelorus_operator -s /tmp/operator/pelorus-operator/operator/helm-charts/pelorus-operators -d /tmp/generated-operator

@redhat-cop/mdt
