### PR TITLE
clean up committime exporter

### DIFF
--- a/exporters/committime/__init__.py
+++ b/exporters/committime/__init__.py
@@ -89,6 +89,32 @@ class GitRepo:
 
 
 @attrs.define
+class CommitTimeRetrievalInput:
+    """
+    Information used to retrieve commit time information.
+    Previously, this information wasn't guaranteed to be present,
+    which made the code messy with various checks and exceptions, etc.
+    Or worse, just hoping things weren't None and we wouldn't crash the exporter.
+
+    In addition, it was unclear how exporters should report the commit time:
+    they change it on the metric, but also return the metric,
+    but if they return None, it shouldn't be counted... confusing.
+    This allows us to handle things more consistently.
+    """
+
+    repo: GitRepo
+    commit_hash: str
+
+    @property
+    def repo_url(self) -> Optional[str]:
+        return self.repo.url if self.repo else None
+
+    @repo_url.setter
+    def repo_url(self, url: str):
+        self.repo = GitRepo.from_url(url)
+
+
+@attrs.define
 class CommitMetric:
     name: str = attrs.field()
     annotations: dict[str, str] = attrs.field(factory=dict, kw_only=True)

--- a/exporters/committime/app.py
+++ b/exporters/committime/app.py
@@ -67,7 +67,7 @@ class ImageCommittimeConfig:
     )
 
     date_annotation_name: str = field(
-        default=CommitMetric._ANNOTATION_MAPPIG["commit_time"],
+        default=CommitMetric._ANNOTATION_MAPPING["commit_time"],
         metadata=env_vars(COMMIT_DATE_ANNOTATION_ENV),
     )
 

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -299,7 +299,11 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
         return metric
 
     def _set_repo_url(
-        self, metric: CommitMetric, repo_url: Optional[str], build, errors: list
+        self,
+        metric: CommitMetric,
+        repo_url: Optional[str],
+        build: CommonResourceInstance,
+        errors: list,
     ) -> CommitMetric:
         # Logic to get repo_url, first conditon wins
         # 1. Gather repo_url from the build from spec.source.git.uri
@@ -334,7 +338,9 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
 
         return metric
 
-    def _is_metric_ready(self, namespace: str, metric: CommitMetric, build) -> bool:
+    def _is_metric_ready(
+        self, namespace: str, metric: CommitMetric, build: CommonResourceInstance
+    ) -> bool:
         """
         Determine if a build is ready to be examined.
 

--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -113,14 +113,12 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
 
         for my_metric in commit_metrics:
             logging.info(
-                "Collected commit_timestamp{ namespace=%s, app=%s, commit=%s, image_sha=%s } %s"
-                % (
-                    my_metric.namespace,
-                    my_metric.name,
-                    my_metric.commit_hash,
-                    my_metric.image_hash,
-                    str(float(my_metric.commit_timestamp)),
-                )
+                "Collected commit_timestamp{ namespace=%s, app=%s, commit=%s, image_sha=%s } %s",
+                my_metric.namespace,
+                my_metric.name,
+                my_metric.commit_hash,
+                my_metric.image_hash,
+                my_metric.commit_timestamp,
             )
             commit_metric.add_metric(
                 [

--- a/exporters/committime/collector_gitlab.py
+++ b/exporters/committime/collector_gitlab.py
@@ -52,7 +52,7 @@ class GitLabCommitCollector(AbstractCommitCollector):
             gitlab_client = gitlab.Gitlab(
                 git_server,
                 private_token=self.token,
-                api_version=4,
+                api_version="4",
                 session=self.session,
             )
         else:
@@ -61,7 +61,7 @@ class GitLabCommitCollector(AbstractCommitCollector):
                 "Connecting to GitLab server without token: %s" % (git_server)
             )
             gitlab_client = gitlab.Gitlab(
-                git_server, api_version=4, session=self.session
+                git_server, api_version="4", session=self.session
             )
 
         return gitlab_client

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -130,7 +130,7 @@ class ImageCommitCollector(AbstractCommitCollector):
                 ).timestamp()
         return metric
 
-    def get_commit_time(self, metric) -> Optional[CommitMetric]:
+    def get_commit_time(self, metric: CommitMetric) -> Optional[CommitMetric]:
         return super().get_commit_time(metric)
 
     def _set_commit_time_from_annotations(

--- a/exporters/committime/collector_image.py
+++ b/exporters/committime/collector_image.py
@@ -32,7 +32,7 @@ class ImageCommitCollector(AbstractCommitCollector):
 
     date_format: str
 
-    date_annotation_name: str = CommitMetric._ANNOTATION_MAPPIG["commit_time"]
+    date_annotation_name: str = CommitMetric._ANNOTATION_MAPPING["commit_time"]
 
     # maps attributes to their location in a `image.openshift.io/v1`.
     # Similar to Build Mapping from committime.__init__.py

--- a/exporters/pelorus/config/__init__.py
+++ b/exporters/pelorus/config/__init__.py
@@ -61,7 +61,7 @@ class _LoggingLoader(Generic[ConfigClass]):
     errors: list[MissingDataError] = attrs.field(factory=list, init=False)
 
     def _load(self):
-        for field in attrs.fields(self.cls):
+        for field in attrs.fields(self.cls):  # type: ignore
             if not field.init:
                 # field does not get set during instance creation,
                 # so don't load it.
@@ -115,7 +115,7 @@ class _LoggingLoader(Generic[ConfigClass]):
 
         kwargs = dict(_prepare_kwargs(self.results))
 
-        return self.cls(**kwargs)
+        return self.cls(**kwargs)  # type: ignore
 
 
 def load_and_log(

--- a/exporters/pelorus/type_compat/openshift.py
+++ b/exporters/pelorus/type_compat/openshift.py
@@ -1,5 +1,10 @@
 """
 Type stubs to make working with openshift objects a little easier.
+These are not meant to be "real" types. Instead, you can claim
+that untyped, dynamic data from openshift "fits" these shapes.
+
+These should probably be type stubs only, but I can't figure
+out how to do that yet.
 """
 from typing import Any, Generic, TypeVar
 
@@ -7,6 +12,14 @@ from openshift.dynamic.client import DynamicClient
 
 
 class ResourceInstance:
+    """
+    A resource as returned by the openshift library.
+
+    `client` highlights that it still references the client,
+    and the `__getattribute__ -> Any` makes the type checker
+    not complain about attribute accesses.
+    """
+
     client: DynamicClient
 
     def __getattribute__(self, __name: str) -> Any:
@@ -14,12 +27,17 @@ class ResourceInstance:
 
 
 class Metadata:
+    """
+    OpenShift metadata. Almost always guaranteed to be present.
+    """
+
     name: str
     labels: dict[str, str]
     annotations: dict[str, str]
 
 
 class CommonResourceInstance(ResourceInstance):
+    "Resource instances that we work with usually have the typical metadata."
     apiVersion: str
     kind: str
     metadata: Metadata
@@ -29,6 +47,7 @@ R = TypeVar("R", bound=CommonResourceInstance)
 
 
 class CommonResourceInstanceList(CommonResourceInstance, Generic[R]):
+    "We work with lists a lot. This lets us easily mark what they contain."
     items: list[R]
 
 

--- a/exporters/pelorus/type_compat/openshift.py
+++ b/exporters/pelorus/type_compat/openshift.py
@@ -1,0 +1,35 @@
+"""
+Type stubs to make working with openshift objects a little easier.
+"""
+from typing import Any, Generic, TypeVar
+
+from openshift.dynamic.client import DynamicClient
+
+
+class ResourceInstance:
+    client: DynamicClient
+
+    def __getattribute__(self, __name: str) -> Any:
+        ...
+
+
+class Metadata:
+    name: str
+    labels: dict[str, str]
+    annotations: dict[str, str]
+
+
+class CommonResource(ResourceInstance):
+    apiVersion: str
+    kind: str
+    metadata: Metadata
+
+
+R = TypeVar("R", bound=CommonResource)
+
+
+class ResourceInstanceList(CommonResource, Generic[R]):
+    items: list[R]
+
+
+__all__ = ["ResourceInstance", "Metadata", "CommonResource", "ResourceInstanceList"]

--- a/exporters/pelorus/type_compat/openshift.py
+++ b/exporters/pelorus/type_compat/openshift.py
@@ -19,17 +19,22 @@ class Metadata:
     annotations: dict[str, str]
 
 
-class CommonResource(ResourceInstance):
+class CommonResourceInstance(ResourceInstance):
     apiVersion: str
     kind: str
     metadata: Metadata
 
 
-R = TypeVar("R", bound=CommonResource)
+R = TypeVar("R", bound=CommonResourceInstance)
 
 
-class ResourceInstanceList(CommonResource, Generic[R]):
+class CommonResourceInstanceList(CommonResourceInstance, Generic[R]):
     items: list[R]
 
 
-__all__ = ["ResourceInstance", "Metadata", "CommonResource", "ResourceInstanceList"]
+__all__ = [
+    "ResourceInstance",
+    "Metadata",
+    "CommonResourceInstance",
+    "CommonResourceInstanceList",
+]

--- a/exporters/tests/integration/test_bitbucket.py
+++ b/exporters/tests/integration/test_bitbucket.py
@@ -8,11 +8,10 @@ from committime.collector_bitbucket import BitbucketCommitCollector
 @pytest.fixture
 def bitbucket_collector(openshift_client: DynamicClient):
     return BitbucketCommitCollector(
-        openshift_client,
+        kube_client=openshift_client,
         username="",
         token="",
-        namespaces=[],
-        apps=[],
+        namespaces=set(),
         tls_verify=False,
     )
 

--- a/exporters/tests/integration/test_committime.py
+++ b/exporters/tests/integration/test_committime.py
@@ -71,7 +71,7 @@ def expected_commits() -> list[CommitMetricEssentials]:
             image_hash="sha256:71309995e6da43b76079a649b00e0aa8378443e72f1fccc76af0d73d67a7f644",
         ),
     ]
-    metrics.sort(key=lambda commit: commit.commit_timestamp)
+    metrics.sort(key=lambda commit: commit.commit_timestamp)  # type: ignore
     return metrics
 
 
@@ -104,6 +104,6 @@ def test_github_provider():
         for cm in collector.generate_metrics()
     ]
 
-    actual.sort(key=lambda commit: commit.commit_timestamp)
+    actual.sort(key=lambda commit: commit.commit_timestamp)  # type: ignore
 
     assert actual == expected_commits()

--- a/exporters/tests/openshift_mocks.py
+++ b/exporters/tests/openshift_mocks.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Optional, Sequence, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 import attr
 
@@ -11,7 +11,7 @@ class OwnerRef:
 
 @attr.define
 class Metadata:
-    name: Optional[str] = None
+    name: str
     namespace: Optional[str] = None
     ownerReferences: list[OwnerRef] = attr.Factory(list)
     labels: dict[str, str] = attr.Factory(dict)
@@ -60,9 +60,9 @@ Item = TypeVar("Item")
 
 @attr.define
 class ResourceGetResponse(Generic[Item]):
-    items: Sequence[Item] = attr.Factory(list)
+    items: list[Item] = attr.Factory(list)
 
     @classmethod
     def of(cls, *items: Item):
         """Puts all arguments into the items list"""
-        return cls(items)
+        return cls(list(items))

--- a/exporters/tests/test_deploytime.py
+++ b/exporters/tests/test_deploytime.py
@@ -1,8 +1,10 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 from random import randrange
+from typing import Optional
 from unittest.mock import NonCallableMock
 
+import attrs
 import pytest
 from openshift.dynamic import DynamicClient  # type: ignore
 from openshift.dynamic.discovery import Discoverer  # type: ignore
@@ -10,7 +12,17 @@ from openshift.dynamic.discovery import Discoverer  # type: ignore
 import pelorus
 from deploytime import DeployTimeMetric
 from deploytime.app import DeployTimeCollector, image_sha
-from tests.openshift_mocks import *
+from tests.openshift_mocks import (
+    Container,
+    ContainerStatus,
+    Metadata,
+    OwnerRef,
+    Pod,
+    PodSpec,
+    PodStatus,
+    Replicator,
+    ResourceGetResponse,
+)
 
 # pylava:ignore=W0401
 
@@ -61,7 +73,7 @@ QUUX_POD_SHAS = [
 # region mock data creation helpers
 
 
-@attr.define(slots=False)
+@attrs.define(slots=False)
 class DynClientMockData:
     pods: list[Pod]
     replicators: list[Replicator]

--- a/exporters/tests/test_exporters.py
+++ b/exporters/tests/test_exporters.py
@@ -34,7 +34,6 @@ def test_commitmetric_initial(appname):
 def test_commitmetric_repos(url, repo_protocol, fqdn, project_name):
     test_name = "pytest"
     metric = CommitMetric(test_name)
-    metric.name == test_name
     assert metric.repo_url is None
     assert metric.repo_protocol is None
     assert metric.git_fqdn is None

--- a/scripts/troubleshooting/missing_labels.py
+++ b/scripts/troubleshooting/missing_labels.py
@@ -12,6 +12,7 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from openshift.dynamic import DynamicClient
 
 import pelorus
+import pelorus.config
 import pelorus.utils
 from pelorus.utils import paginate_resource
 
@@ -68,7 +69,13 @@ BuildId = NewType("BuildId", ResourceIdentifier)
 
 # endregion
 
-APP_LABEL = pelorus.get_app_label()
+
+@frozen
+class TroubleshootingConfig:
+    app_label: str = pelorus.DEFAULT_APP_LABEL
+
+
+APP_LABEL = pelorus.config.load_and_log(TroubleshootingConfig).app_label
 
 
 @define


### PR DESCRIPTION
(Depends on #713, wait until that is merged.)

There were several typing issues and unclear APIs in the committime exporter.

`CommitMetric` was used as a big blob.
It carried all inputs and outputs, with almost no guarantees for
when and where things would be set. It also had several unused fields.

The way it was meant to be handled by implementors was also unclear:
- do they modify it on the passed in `CommitMetric`? 
- do they return a `CommitMetric` with the committime updated?
- what if they return None?
- what if the information needed is missing?

There are several spots where a type checker would complain.
Including some spots where the variable being used could be unbound!

This PR will help things be cleaner, and handled more consistently.
