### PR TITLE
azure-devops: fix url connection string

### DIFF
--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -28,14 +28,16 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
             raise UnsupportedGITProvider(
                 "Skipping non Azure DevOps server, found %s" % (git_server)
             )
-
         logging.debug("metric.repo_project %s" % (metric.repo_project))
-        logging.debug("metric.git_api %s" % (self.git_api))  # TODO: metric, not self
+        logging.debug(
+            "metric.git_api %s" % (str(self.git_api))
+        )  # TODO: metric, not self
 
-        # Private or personal token
         # Fill in with your personal access token and org URL
+        # personal_access_token = 'YOURPAT'
+        # organization_url = 'https://dev.azure.com/YOURORG'
         personal_access_token = self.token
-        organization_url = self.git_api
+        organization_url = str(self.git_api)
 
         # Create a connection to the org
         credentials = BasicAuthentication("", personal_access_token)

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -29,9 +29,7 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
                 "Skipping non Azure DevOps server, found %s" % (git_server)
             )
         logging.debug("metric.repo_project %s" % (metric.repo_project))
-        logging.debug(
-            "metric.git_api %s" % (str(self.git_api))
-        )  # TODO: metric, not self
+        logging.debug("metric.git_api %s", self.git_api)  # TODO: metric, not self
 
         # Fill in with your personal access token and org URL
         # personal_access_token = 'YOURPAT'

--- a/exporters/committime/collector_azure_devops.py
+++ b/exporters/committime/collector_azure_devops.py
@@ -45,7 +45,7 @@ class AzureDevOpsCommitCollector(AbstractCommitCollector):
         # personal_access_token = 'YOURPAT'
         # organization_url = 'https://dev.azure.com/YOURORG'
         personal_access_token = self.token
-        organization_url = self.git_api
+        organization_url = self.git_api.url
 
         # Create a connection to the org
         credentials = BasicAuthentication("", personal_access_token)

--- a/exporters/tests/test_exporters.py
+++ b/exporters/tests/test_exporters.py
@@ -23,6 +23,7 @@ def test_commitmetric_initial(appname):
         ("http://noabank.git.foo/chase/git.git", "http", "noabank.git.foo", "git"),
         ("ssh://git.moos.foo/maverick/tootsie.git", "ssh", "git.moos.foo", "tootsie"),
         ("git@github.com:konveyor/pelorus.git", "ssh", "github.com", "pelorus"),
+        ("https://dev.azure.com/azuretest", "https", "dev.azure.com", "azuretest"),
         (
             "https://gitlab.com/firstgroup/secondgroup/myrepo.git",
             "https",
@@ -45,7 +46,10 @@ def test_commitmetric_repos(url, repo_protocol, fqdn, project_name):
     assert metric.repo_url == url
     assert metric.repo_protocol == repo_protocol
     assert metric.git_fqdn is not None
-    assert metric.repo_group is not None
+    if metric.repo_url != "https://dev.azure.com/azuretest":
+        assert metric.repo_group is not None
+    else:
+        assert metric.repo_group is None
     assert metric.repo_project is not None
     assert metric.git_fqdn == fqdn
     #    assert metric.git_server == str(protocol + '://' + fqdn)


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

## Linked Issues?

resolves #724 

w/ fix:
```
11-18-2022 17:07:17 INFO     Loading CommittimeTypeConfig, inputs below:
11-18-2022 17:07:17 INFO     provider='git', from env var PROVIDER
11-18-2022 17:07:17 INFO     Loading GitCommittimeConfig, inputs below:
11-18-2022 17:07:17 INFO     username='whayutin', from env var API_USER
11-18-2022 17:07:17 INFO     token=REDACTED, from env var TOKEN
11-18-2022 17:07:17 INFO     namespaces='mongo-persistent,basic-python-tekton', from env var NAMESPACES
11-18-2022 17:07:17 INFO     git_api='https://dev.azure.com/whayutin', from env var GIT_API
11-18-2022 17:07:17 INFO     git_provider='azure-devops', from env var GIT_PROVIDER
11-18-2022 17:07:17 INFO     tls_verify=True, default value; TLS_VERIFY was not set
11-18-2022 17:07:17 INFO     Watching namespaces: {'mongo-persistent', 'basic-python-tekton'}
/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/.venv/lib64/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-wdh11092022b.wdh11092022b.mg.dog8code.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
11-18-2022 17:07:18 INFO     metric.commit_time 2022-11-11 19:59:51+00:00
/home/whayutin/OPENSHIFT/git/KONVEYOR/PELORUS/upstream/pelorus/.venv/lib64/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.cluster-wdh11092022b.wdh11092022b.mg.dog8code.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
11-18-2022 17:07:18 INFO     Collected commit_timestamp{ namespace=mongo-persistent, app=todolist, commit=247e9859fb232f2b59b17391c7402814d82651d9, image_sha=sha256:04559c4ebdde446ade9a67cd58124fdcb9e28f2ffc7fac923e0f3845c9f3d54a } 1668196791.0


```
