### PR TITLE
RBAC permissions for the deployment from source

### DIFF
--- a/pelorus-operator/Dockerfile
+++ b/pelorus-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.25.2
+FROM quay.io/operator-framework/helm-operator:v1.25.3
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.3
+VERSION ?= 0.0.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -146,7 +146,7 @@ ifeq (,$(shell which helm-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(HELM_OPERATOR)) ;\
-	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.25.2/helm-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.25.3/helm-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(HELM_OPERATOR) ;\
 	}
 else

--- a/pelorus-operator/bundle.Dockerfile
+++ b/pelorus-operator/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=pelorus-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
 

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -27,9 +27,9 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.25.2
+    operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
-  name: pelorus-operator.v0.0.3
+  name: pelorus-operator.v0.0.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,27 +88,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - '*'
-        - apiGroups:
-          - integreatly.org
-          resources:
-          - grafanadashboards
-          - grafanadatasources
-          - grafanas
-          verbs:
-          - '*'
-        - apiGroups:
           - image.openshift.io
           resources:
           - imagestreams
@@ -138,6 +117,27 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          - grafanadatasources
+          - grafanas
+          verbs:
+          - '*'
+        - apiGroups:
           - operators.coreos.com
           resources:
           - operatorgroups
@@ -152,7 +152,6 @@ spec:
           - batch
           resources:
           - jobs
-          - cronjobs
           verbs:
           - list
           - create
@@ -208,6 +207,17 @@ spec:
           - watch
           - create
           - delete
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          verbs:
+          - get
+          - create
+          - delete
+          - list
+          - watch
+          - patch
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -266,7 +276,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/migtools/pelorus-operator:0.0.3
+                image: quay.io/migtools/pelorus-operator:0.0.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -358,4 +368,4 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.3
+  version: 0.0.5

--- a/pelorus-operator/bundle/metadata/annotations.yaml
+++ b/pelorus-operator/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: pelorus-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
 

--- a/pelorus-operator/bundle/tests/scorecard/config.yaml
+++ b/pelorus-operator/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/migtools/pelorus-operator
-  newTag: 0.0.3
+  newTag: 0.0.5

--- a/pelorus-operator/config/rbac/pelorus_manager_role.yaml
+++ b/pelorus-operator/config/rbac/pelorus_manager_role.yaml
@@ -19,7 +19,6 @@ rules:
   - "batch"
   resources:
   - "jobs"
-  - "cronjobs"
   verbs:
   - list
   - create
@@ -79,3 +78,15 @@ rules:
   - watch
   - create
   - delete
+# Required to build and deploy exporters from the source code
+- apiGroups:
+  - "build.openshift.io"
+  resources:
+  - "buildconfigs"
+  verbs:
+  - get
+  - create
+  - delete
+  - list
+  - watch
+  - patch

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,27 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  - "rolebindings"
-  - "roles"
-- verbs:
-  - "*"
-  apiGroups:
-  - "apps.openshift.io"
-  resources:
-  - "deploymentconfigs"
-- verbs:
-  - "*"
-  apiGroups:
-  - "integreatly.org"
-  resources:
-  - "grafanadashboards"
-  - "grafanadatasources"
-  - "grafanas"
-- verbs:
-  - "*"
-  apiGroups:
   - "image.openshift.io"
   resources:
   - "imagestreams"
@@ -102,5 +81,26 @@ rules:
   - "secrets"
   - "serviceaccounts"
   - "services"
+- verbs:
+  - "*"
+  apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "rolebindings"
+  - "roles"
+- verbs:
+  - "*"
+  apiGroups:
+  - "apps.openshift.io"
+  resources:
+  - "deploymentconfigs"
+- verbs:
+  - "*"
+  apiGroups:
+  - "integreatly.org"
+  resources:
+  - "grafanadashboards"
+  - "grafanadatasources"
+  - "grafanas"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/scorecard/patches/basic.config.yaml
+++ b/pelorus-operator/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/pelorus-operator/config/scorecard/patches/olm.config.yaml
+++ b/pelorus-operator/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.25.2
+    image: quay.io/operator-framework/scorecard-test:v1.25.3
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./subcharts/exporters
   version: 2.0.3
 digest: sha256:0e2f5ab71eff50f4d8a517ea12f5f1b61c981211d8f28d49640362ef0454d61b
-generated: "2022-12-06T13:29:33.607877179+01:00"
+generated: "2022-12-08T13:41:01.529889503+01:00"

--- a/scripts/pelorus-operator-patches/03_pelorus_operators_roles.diff
+++ b/scripts/pelorus-operator-patches/03_pelorus_operators_roles.diff
@@ -11,7 +11,7 @@
  # Comment the following 4 lines if you want to disable
 --- /dev/null	2022-10-24 10:19:28.874279599 +0200
 +++ config/rbac/pelorus_manager_role.yaml	2022-11-25 14:01:11.286892725 +0100
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,92 @@
 +apiVersion: rbac.authorization.k8s.io/v1
 +kind: ClusterRole
 +metadata:
@@ -33,7 +33,6 @@
 +  - "batch"
 +  resources:
 +  - "jobs"
-+  - "cronjobs"
 +  verbs:
 +  - list
 +  - create
@@ -93,6 +92,18 @@
 +  - watch
 +  - create
 +  - delete
++# Required to build and deploy exporters from the source code
++- apiGroups:
++  - "build.openshift.io"
++  resources:
++  - "buildconfigs"
++  verbs:
++  - get
++  - create
++  - delete
++  - list
++  - watch
++  - patch
 --- /dev/null
 +++ config/rbac/pelorus_role_binding.yaml
 @@ -0,0 +1,12 @@


### PR DESCRIPTION
This fixes 742 issue where rbac was not sufficient to deploy exporters using source instead of quay images.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

## Testing Instructions
```
$  operator-sdk run bundle quay.io/migtools/pelorus-operator-bundle:v0.0.5 --namespace pelorus
# Make sure to include source_ref/source_url in the yaml instance of the Pelorus operator and create such instance
# Observe logs in the operator manager pod

# Sample exporter from source:

      - app_name: committime-exporter
        exporter_type: committime
        env_from_secrets:
        - github-secret
        source_ref: master
        source_url: https://github.com/konveyor/pelorus.git

```
Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).

@redhat-cop/mdt
