### PR TITLE
Fix pelorus operator script to add proper instructions and remove dup

### DIFF
--- a/scripts/create_pelorus_operator
+++ b/scripts/create_pelorus_operator
@@ -158,17 +158,19 @@ elif [ "$(ls -A "${patches_dir}/bundle-patches"/*.diff 2>/dev/null)" ]; then
         done
 fi
 
-# Correct operator version, to be latest +1
-OPERATOR_VERSION=$(curl -H "Authorization: Bearer XYZ" -X GET "https://quay.io/api/v1/repository/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}/tag/" | jq .tags[].name | head -1 | sed -e 's|\"||g')
+# Print operator versions
 echo "INFO: Current operator version: ${OPERATOR_VERSION}"
-NEW_OPERATOR_VERSION=$(echo ${OPERATOR_VERSION} | awk -F. -v OFS=. '{$NF += 1 ; print}')
 echo "INFO: New operator version: ${NEW_OPERATOR_VERSION}"
 
 echo "INFO: Operator crated and available at: ${destination_dir}"
 echo "To build and push to the quay use from the operator folder:"
 echo "  # podman login -u="migtools+pelorus" -p=\"\$QUAY_TOKEN\" quay.io"
-echo "  # make podman-build podman-push"
+echo "  # make podman-build"
+echo "  # make podman-push"
+echo "  # make bundle-build"
+echo "  # make bundle-push"
 echo "  # # Log in to your cluster or export KUBECONFIG"
-echo "  # make deploy"
-
-
+echo "  # # Deploy bundle, e.g. version v${NEW_OPERATOR_VERSION} in the pelorus namespace"
+echo "  # operator-sdk run bundle quay.io/migtools/pelorus-operator-bundle:v${NEW_OPERATOR_VERSION} --namespace pelorus"
+echo "  # # Create pelorus instance from example in the pelorus namespace"
+echo "  # oc apply -f pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml -n pelorus"


### PR DESCRIPTION
As found by @mateusoliveira43 there was duplication of logic in our Pelorus operator script to echo versions.
Fixed as well instructions that includes new bundle method.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

@redhat-cop/mdt
