### PR TITLE
Thanos rbac for the pelorus-operator

### DIFF
--- a/scripts/pelorus-operator-patches/03_pelorus_operators_roles.diff
+++ b/scripts/pelorus-operator-patches/03_pelorus_operators_roles.diff
@@ -10,8 +10,8 @@
  - leader_election_role_binding.yaml
  # Comment the following 4 lines if you want to disable
 --- /dev/null	2022-10-24 10:19:28.874279599 +0200
-+++ config/rbac/pelorus_manager_role.yaml	2022-11-25 14:01:11.286892725 +0100
-@@ -0,0 +1,92 @@
++++ config/rbac/pelorus_manager_role.yaml	2022-12-09 23:19:02.166199096 +0100
+@@ -0,0 +1,104 @@
 +apiVersion: rbac.authorization.k8s.io/v1
 +kind: ClusterRole
 +metadata:
@@ -104,6 +104,18 @@
 +  - list
 +  - watch
 +  - patch
++# Required to deploy Thanos
++- apiGroups:
++  - "apps"
++  resources:
++  - "deployments"
++  verbs:
++  - get
++  - create
++  - delete
++  - list
++  - watch
++
 --- /dev/null
 +++ config/rbac/pelorus_role_binding.yaml
 @@ -0,0 +1,12 @@


### PR DESCRIPTION
Adding rbac to cover installation methods that requires Thanos sidecar.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

@redhat-cop/mdt
