### PR TITLE
Pelorus community operator fixes

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.3
+version: 2.0.4

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.3
+version: 2.0.4
 
 dependencies:
   - name: exporters
-    version: "v2.0.3"
+    version: "v2.0.4"
     repository: file://./subcharts/exporters

--- a/charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.3
+version: 2.0.4

--- a/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.3" }}
+      ref: {{ .source_ref | default "v2.0.4" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/charts/pelorus/subcharts/exporters/templates/exporters.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/exporters.yaml
@@ -1,28 +1,30 @@
 {{- range $index, $exporter := .Values.instances }}
-  # https://hackmd.io/@openshift-mig-eng/rkNC3W8dq
-  {{- if and ($exporter.image_name) (or $exporter.source_ref $exporter.source_url) }}
-    {{- fail "ERROR: image_name configuration can't be used with source_ref or source_url" }}
-  {{- end }}
-  {{- if and ($exporter.image_tag) (or $exporter.source_ref $exporter.source_url) }}
-    {{- fail "ERROR: image_tag configuration can't be used with source_ref or source_url" }}
-  {{- end }}
-  {{- if and $exporter.image_name $exporter.image_tag }}
-    {{- if contains ":" $exporter.image_name }}
-      {{- fail "ERROR: image_tag configuration can't be used with image_name that includes tag e.g. generic-exporter:tag-name" }}
+  {{- if ne ($exporter.enabled | toString) "false" }}
+    # https://hackmd.io/@openshift-mig-eng/rkNC3W8dq
+    {{- if and ($exporter.image_name) (or $exporter.source_ref $exporter.source_url) }}
+      {{- fail "ERROR: image_name configuration can't be used with source_ref or source_url" }}
     {{- end }}
+    {{- if and ($exporter.image_tag) (or $exporter.source_ref $exporter.source_url) }}
+      {{- fail "ERROR: image_tag configuration can't be used with source_ref or source_url" }}
+    {{- end }}
+    {{- if and $exporter.image_name $exporter.image_tag }}
+      {{- if contains ":" $exporter.image_name }}
+        {{- fail "ERROR: image_tag configuration can't be used with image_name that includes tag e.g. generic-exporter:tag-name" }}
+      {{- end }}
+    {{- end }}
+    {{- if or $exporter.source_ref $exporter.source_url }}
+      {{ include "exporters.buildconfig" $exporter }}
+    {{- end }}
+      {{ include "exporters.deploymentconfig" $exporter }}
+    {{- if or $exporter.source_ref $exporter.source_url }}
+      {{ include "exporters.imagestream" $exporter }}
+    {{- else }}
+      {{- if not $exporter.exporter_type }}
+        {{- fail "ERROR: exporter_type must be provided when using podman image installation method" }}
+      {{- end}}
+      {{ include "exporters.imagestream_from_image" $exporter }}
+    {{- end }}
+      {{ include "exporters.route" $exporter }}
+      {{ include "exporters.service" $exporter }}
   {{- end }}
-  {{- if or $exporter.source_ref $exporter.source_url }}
-    {{ include "exporters.buildconfig" $exporter }}
-  {{- end }}
-    {{ include "exporters.deploymentconfig" $exporter }}
-  {{- if or $exporter.source_ref $exporter.source_url }}
-    {{ include "exporters.imagestream" $exporter }}
-  {{- else }}
-    {{- if not $exporter.exporter_type }}
-      {{- fail "ERROR: exporter_type must be provided when using podman image installation method" }}
-    {{- end}}
-    {{ include "exporters.imagestream_from_image" $exporter }}
-  {{- end }}
-    {{ include "exporters.route" $exporter }}
-    {{ include "exporters.service" $exporter }}
 {{- end }}

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -19,18 +19,18 @@ extra_prometheus_hosts:
 ## Persistent storage for Prometheus Operator
 # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/storage.md
 
-# Uncomment to use PVC for Prometheus
-# prometheus_storage: true
+# Set to true to use PVC for Prometheus
+prometheus_storage: false
 
 # Additional configuration options for Prometheus PVC
-# prometheus_storage_pvc_capacity: 2Gi
-# prometheus_storage_pvc_storageclass: "gp2"
+prometheus_storage_pvc_capacity: 2Gi
+prometheus_storage_pvc_storageclass: "gp2"
 
 # Set Prometheus retention time. Older data values are deleted
-# prometheus_retention: 1y
+prometheus_retention: 1y
 # Set Prometheus retention size. If data grows over old values are deleted
 # This should be lower of what's defined in the prometheus_storage_pvc_capacity
-# prometheus_retention_size: 1GB
+prometheus_retention_size: 1GB
 
 exporters:
   instances:
@@ -40,16 +40,17 @@ exporters:
     # - pelorus-config
     # - deploytime-config
 
-#  - app_name: failuretime-exporter
-#    exporter_type: failure
-#    env_from_configmaps:
-#    - pelorus-config
-#    - failuretime-config
-#    env_from_secrets:
-#    - jira-secret
+  - app_name: failuretime-exporter
+    exporter_type: failure
+    enabled: false
+    env_from_configmaps:
+    - pelorus-config
+    - failuretime-config
+    env_from_secrets:
+    - jira-secret
 
-#  - app_name: committime-exporter
-#    exporter_type: committime
+  - app_name: committime-exporter
+    exporter_type: committime
 #    env_from_configmaps:
 #    - pelorus-config
 #    - committime-config

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.9
+VERSION ?= 0.0.38
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/charts.pelorus.konveyor.io_pelorus.yaml
+++ b/pelorus-operator/bundle/manifests/charts.pelorus.konveyor.io_pelorus.yaml
@@ -15,7 +15,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Pelorus is the Schema for the pelorus API
+        description: Configure a running instance of Pelorus
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -23,16 +23,48 @@ spec:
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
+            description: |-
+              Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of Pelorus
+            description: 'PelorusSpec defines state of the Pelorus application and
+              allows to configure for the desired workflow. More information about
+              Pelorus configuration that can be used in the Spec section is available
+              at: https://pelorus.readthedocs.io/en/latest/Configuration/'
+            properties:
+              exporters:
+                description: |-
+                  References configuration for the Pelorus exporters. More info about exporters configuration: https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters-details
+
+
+                    Example:
+                      instances:
+                        - app_name: < instance_name >
+                          enabled: < won't be created if set to false >
+                          exporter_type: < deploytime, committime, failure >
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              prometheus_retention:
+                description: 'Prometheus Retention time. More information: https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-retention'
+                type: string
+              prometheus_retention_size:
+                description: 'Prometheus Retention Size. More information: https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-retention'
+                type: string
+              prometheus_storage:
+                description: 'Use Prometheus Persistent Volume. More information:
+                  https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-persistent-volume-recommended'
+                type: boolean
+              prometheus_storage_pvc_capacity:
+                description: Prometheus Persistent Volume capacity.
+                type: string
+              prometheus_storage_pvc_storageclass:
+                description: Prometheus Persistent Volume storage class to be used.
+                type: string
             type: object
-            x-kubernetes-preserve-unknown-fields: true
           status:
             description: Status defines the observed state of Pelorus
             type: object

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -17,33 +17,103 @@ metadata:
                 {
                   "app_name": "deploytime-exporter",
                   "exporter_type": "deploytime"
+                },
+                {
+                  "app_name": "failuretime-exporter",
+                  "enabled": false,
+                  "env_from_configmaps": [
+                    "pelorus-config",
+                    "failuretime-config"
+                  ],
+                  "env_from_secrets": [
+                    "jira-secret"
+                  ],
+                  "exporter_type": "failure"
+                },
+                {
+                  "app_name": "committime-exporter",
+                  "exporter_type": "committime"
                 }
               ]
             },
             "extra_prometheus_hosts": null,
             "openshift_prometheus_basic_auth_pass": "changeme",
-            "openshift_prometheus_htpasswd_auth": "internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM="
+            "openshift_prometheus_htpasswd_auth": "internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=",
+            "prometheus_retention": "1y",
+            "prometheus_retention_size": "1GB",
+            "prometheus_storage": false,
+            "prometheus_storage_pvc_capacity": "2Gi",
+            "prometheus_storage_pvc_storageclass": "gp2"
           }
         }
       ]
     capabilities: Basic Install
-    createdAt: "2022-12-12T11:45:07Z"
+    categories: |
+      Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
+    createdAt: "2022-12-16T15:10:12Z"
+    description: |
+      Tool that helps IT organizations measure their impact on the overall performance of their organization
+    operatorframework.io/suggested-namespace: pelorus
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
-  name: pelorus-operator.v0.0.9
+    repository: https://github.com/konveyor/pelorus/
+    support: Pelorus Community
+  name: pelorus-operator.v0.0.38
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: Pelorus
+    - description: Pelorus is the Schema for pelorus API to adopt instance to the
+        requested workflow
+      displayName: Pelorus
+      kind: Pelorus
       name: pelorus.charts.pelorus.konveyor.io
       version: v1alpha1
   description: |
-    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole.
+    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
+
+    - Software Delivery Performance
+    - Product Quality and Sustainability
+    - Customer experience
+
+    For more background on the project you can read [@trevorquinn](https://github.com/trevorquinn)'s blog post on [Metrics Driven Transformation](https://www.openshift.com/blog/exploring-a-metrics-driven-approach-to-transformation).
+
+    ## Software Delivery Performance as an outcome
+
+    Currently, Pelorus functionality can capture proven metrics that measure Software Delivery Performance -- a significant outcome that IT organizations aim to deliver.
+
+    Pelorus is a Grafana dashboard that can easily be deployed to an OpenShift cluster, and provides an organizational-level view of the [four critical measures of software delivery performance](https://blog.openshift.com/exploring-a-metrics-driven-approach-to-transformation/).
+
+    ## Software Delivery Metrics Dashboard
+
+    A short video describing each of metrics provided by Pelorus is available [here](https://www.youtube.com/watch?v=7-iB_KhUaQg).
+
+    ## Demo
+
+    [YouTube Video](https://www.youtube.com/watch?v=VPCOIfDcgso) with the Pelorus in action recorded during online Konveyor Community event.
+
+    ## Documentation
+
+    Pelorus documentation is available at [pelorus.readthedocs.io](https://pelorus.readthedocs.io/en/latest/).
+
+    ## Contributing to Pelorus
+
+    If you are interested in contributing to the Pelorus project, please review our Contribution guide which can be found in the [contribution guide](https://github.com/konveyor/pelorus/blob/master/CONTRIBUTING.md)
+
+    ## Statement of Support
+
+    Our support policy can be found in the [Upstream Support statement](https://github.com/konveyor/pelorus/blob/master/docs/UpstreamSupport.md)
+
+    ## Code of Conduct
+    Refer to Konveyor's Code of Conduct [here](https://github.com/konveyor/community/blob/main/CODE_OF_CONDUCT.md).
+
+    ## License
+
+    This repository is licensed under the terms of [Apache-2.0 License](https://raw.githubusercontent.com/konveyor/pelorus/master/LICENSE).
   displayName: Pelorus Operator
   icon:
-  - base64data: iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5gsdDTUcZ4LhxgAACXFJREFUeNrtnVusVcUdh7/Z55K2kmCDUkBSK5eTthoraGqMlEDAaKxWHkpAbvXWOSSNaVKfMLHGmNS+6JuJjFBszwGh9EFjNRJRqaExGATaatMAttooUKxpScE257L/fViHA+e+L7PWXmuf3/d4svecuXz7P7NmZs2AEEIUBTfpK8DbdIP1F/3JgCfHqKwZFtw/pM3EtE6q0nr78YA43wA2nrdISKxqRfoRcCNDI5KQWFWLdA1wA7BNTSuxYgi1HviVmlNixZBpAfAz4DY1o8SKIdT3gd1qOokVS6i7gBfUZBIrllDfBX6rppJYsYRaCLyrJpJYMYXaAixQ80isWFItAd5Us1zAeZth0AHcCmya6OPAMqAPOEdwDYv4LidCXQvsAK7OdSNntVbobRYwGzhAsupUazuVgVuAfxPcockllrebgf2FiB5pi5UI9QjggVLk1E8CtxPckeYXy9tRYH5huqU0xfK2FbgnBaGGc7oVZvUF1998Yyxv1wHvAG0aQ9nlBqcyEOo80/vgc7zdQnBvpfVPSg2Q6lvAIUkFeOu2pIvKuh3agX14W9rirbXQYrV3Wglv1wOH0QZD8LYdWAu0NPDB7Y1+OJWGXJmI1dZppR7jr8BBSQV4ex5Yk5PcTEtDrlIGUrX0JlJdiQBvO4HVOctVdLlKGUj1gaQalOo5YFVOczetH76Te7EUqUY8/U0F1uU8m6/jbXFuxbooUn1VSiUYfNbAgXo1A/rXWr215E6stk4rqfsb0QV2FUCqwQf4PjiRK7HaE6nU/Y1kVcHyO31gEjsfYvUoUo0Wrbop5mTwK/kQK5lRl1QjWVnQfM8c2BvXQLGSsKkZ9dHHVu0FLsGljY5Y70iqUZld8Py/1jixkq0vWlAexpROc8CSghfj/PpuxmIlm/TmS6ORfG5N82O7JFuxku3E+6XQ6JRhb5MU5dmsI9YO6TMuzXJC0vzsxEreprla7oh4YiVzG3pFS0SPWFtUbePT3mklYLHEqi5a6Q1lET1i6SwFEVms5NQXUQGXOAz4s8SqDB0lVCH/esYZ8E+JNXG0uku6iDQilk7Sq56WJinHE+mIlZz5KaoluEVNUpI9aUUsHSRbAwO7G4qOOTgaXyxv66RIbZzd7IziL0Q7C+5UGhFrrRSpr0MseP5vjD94T7Yb63D++sZZu4HjBc19Gfg4jadC7V6Iw0eFjbbBnUhDrG45ESVqLS9otHq8ngRKY3SD18iIqGwoWH631ROtxotYN8iFqFGrq2Bd4qP1JlAa01gRW66vFSCX/Q6mE9wn8cXy9nVZkBr35Tx/Oy24T2MkNFrEWqr2Ty1qbQPuz2nudhBctAnx0cS6SQakKtcvcijXToKLOhk+mli6mHtyybWL4O6OnWhp2PjqKrV6pnI1esz1a4JL5aDd4RHrTrV4xmOu4FwDpiL6HVxKcKkdCDdcrLJau2FTEVlMovYC3QTXasGdSfMfuWFdoamVx62s9K+V87aX5AC7eRFT7QF2x3zqm4hW6ZK76LV8QLCVJNfL1bPWuA/4mODWN+BHqIiVq4g1jCmd5s5udoa3/cD5q+AuA7550cf+Q3KiIoArwfIvOXoHNhs2qq4GpfoJ8KT0yZdYo/HljebO2YW2KwH/2+xyNT5uHTN6idwy8N5irnuXkppJpC2WxlciFbE0vhLqCoXEEhJLCIklJJaYbGitsAoMLnNeszLj1tHAysSgWA5mqFrGlwp4T1pNiBsiVh7WwHJdW940g6wxlpBYQmIJIbGExBJNw0MSS6Ty8CyxhLpCIbHE5GZwDrmha4VTN5rrNzhrPEtldw8/McWxp5GvNYlxCO6phopV8vaFMrx8psxNwBer+OriswZ4OwqcJLglas18kq1Y3rqBlWVorzOlDqBj4AXb48CjBLdDzTnZxljeuvDWQ3LTRXvk1OcB2/F2HG8b1KQN48HMxHLepuKtD1gHtKVcsLnAL/H2otq48UEqPbG8PWfwGdnf2/c9vH2At/vV1pnyUvpiedsJ/IDGXQY5B9iCt/vU3pk9Ef4tXbG8PQ+syklxt0quTOhKd/DubTuwOmeFllzpcyA9sZKphDU5LfhWjblS7QafTkUs5+3yHEaq4TwsAxr0iFhjpLrC4DT5v7V9Dt4+VJNH5950xILHClQJV2oSNToH44vlbdZYxuaYn8qFqOOr99KIWI9QvK03c/G2RkZEYUP8MVYSrXxBK+QxORElWnWlMXifTXE3Cs6TFXXzalpPhQcKXS3e9smNung4uljO2wyKfxjuTLlRVzd4OLpYlmy0K/q58B1TOk1n29fGyok+UGtXeGsz1M5Za45yNCBa/SYtsTY1SRVtkiVVs6KSD+n1L1FttHpRYonY3FHpByWWqCZavSyxRGyur+bDEktUwmGCOySxRGweqPYLEktMxNJqo5XEEhPxPsHtq+WLtYp1rEkq7pjcGZea963VKtYPm6HWprjmKEdKLCK4P2Yt1rkmqLj/tmgJeuxIHtzv60mgNrGCexcoF7zy3j7zjA5wG4VeguuoN5F6Bu+fFLwCT8ihERjw7RgJ1SPWigJXYA/BrZdHI6RaQHBHGitWMrdxsqCVuFsejeAjgvtDrMTqnce6vaBjiHXyaKhU7Y65MROsT6wkbJ4uWCXukkdDpWpzzOnZ7Mr5EStheYEqsV9jqxFSze2NLFUcsYL7E7CsCFI5mCaXBvn7gFT9aSQeZa2wBd4iOW80z3RbcGfk04XuLy2poonVH1xfS3JZeV7l2kVw98inId1ff5r/JNruhhzLtZPgVsunbCJVdLFyKtcOgrtbPmHAh+2JVJksxUXfj5UTufqB7QS3Vk4Nzqhf1ZORVKmINUyuhjwtOpipSVAAeoGFMWfUGyrWebkI7g3gWrKZRC0DW4HZFtyncopjBNcea+2vhh93Rni7DniF+Ke8lIEAPE5wqe1YcN6+YnCqIFItqnc/VXHEuiDYQuAF4Io6I2YZeBr4eZpCFUys94E19ez8LK5YQyVbTHIr2F5GnrflxvjbzUAbwf0u04rKv1hLa33xofnEGl+6ZQT3em4qKr9iHQYeqOUVrckpVs7IqVi3EdyePNZXq5QpJHdUc0CHxBITsaLS86kklqiElZUczyixRCW8SrIs1V3EzEus/LGO5MyEI0UuhMTKB/cCB8e68EhiiUrpAt4G3iS4vzRjASVWNjxIsnz10vDb3psViRWPh7gw4WwE95SqRAghisD/AUMDnng/PMaPAAAAAElFTkSuQmCC
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABmJLR0QA/wD/AP+gvaeTAAAGAElEQVR42u2dzYscRRiHf9X27F8gsiclBoOiqJsEP0gO7i3giDmYS0yEQJgIEgRz8w/wllzEg01AcGMuelASIZ7iQXENa1YlAVHi1y3/wi7Z9tC7637MzvT0vFVd3f08x2Gmp7rep96q7q6ukgAAmoLrfAUM8kdy6fSWj3JJF/eorNk8c/fRZjxpp852kL+7Ls5Tkt7esAgQa1KR3pH0orZnJECsiUV6RtJhSZ8QWsSyEOq0pE8JJ2JZyDQn6QNJxwgjYlkI9YakzwkdYlkJ9bqkLwkZYlkJ9aqk64QKsayEOijpJ0KEWJZCXZY0R3gQy0qqVyTdJCz/0+svVn44sHr9JddtsQb5s5KuSnoalaaTaa/jhJYsjUCqI5K+Qyc7oUYdO5Rgac1S/S7pCZTyK1UdgqU1CfW8pFuSegi1mNf1vz7lSmuQ6jlJt8VcsNqkCpG9klAnMXMuTzTID0laRqr6pfJdliBi9c7lyUquPyUtIVVcUvkqUxJAqodWC6keY4gep1Q+ypYEkOoeUsUvVWO6QjJVM6WyKmfiUap7kh5FqW42gsSDVAndX3e7QC9izRRS0f3RGGzFWiFTka3MxSruqCMVjcJQrOLZH3fUyVbmGesWUoGtWMXUlx5V2c5sVfU8kimlOiLmU4GpWMV0YmZ+gnnGukr1ga1Yxds0vPgAhmIV7/3xihaYZ6zLVFs3rgjDiVVkK95QBvOMxVoKYCxWseoLgHnGYimhktS5ZkKzxCoWPQMwz1ispAfGYhVrfgLdoXnGYiHZCnT9XlYyJludQpFuZ6yq5zEuY72JImArVjHdmMX5yVrmXSGzF2gYzodYV6haspatWMUuWkCDMO8KD1O1ZC0fYrHfX4flsihrMqQbfBINaAA+MtY81dvNrGVZvmFivYwC3ZPLulzDxGJj7o7J5X857kG+j7B3Sy5f5diZsV4j5GGDWqdgPv97p1hrhLv92SuE0Du3PPmQMNcrl895XCEFTglp+wWro7tNCGX846+qYtQ5hnNbrgjfk3SRkI6srNk8c/frLsewbBbbLYx0qGTAYJ+uEGIXK6c6wIdYjK+ArhAQCxALALEAsaBr8KxwAnLpYTfgrszIOlp/MrEplpNmqZbRUkm6g1ZjcdvEiuEZWNS1Nci5g8wYCxALEAsAsQCxoDVcQCzwcvGMWEBXCIgF3WbzHnKtzwqrvjvHJkiRkrlLtYo17cuYG79HsHhJmyTUqOMhWQfFCrGvDFmsds4HG7z3+ot56M2K2Og7jgvBpI0BrkNo0DXvYsUSVOQKekX4l1exYgsmcgVhYWS/2NYgIpd3fvQmVuzBQy6v3eBHXsQiaGAuVpOkogF44YwXsZoGcpmzZC4WQQJl7g4ZiwZhzVvmYyyCA8rcgrfBO3SWG16vCukOO8v75mIRFFDmlslYNBBrToz7AmMsqJKtvkAssOZ4mS8hFkyarb5CLLCmX/aLiAWTZKuvEQusOTTJlxELyrCszN1GLLDm7KQ/QCwYx/yk2QqxYBx3lblvq/wQsWAUJ6v+ELFgL44qc78iFljyhzL3/TQHqCRWW1Z0YWWa4dWizB2Y9iBkLNhKLukFiwN1dls5stVQqeaUuV8sDpYQGFjnHyupOtsV0ih2SzXjtN/ygAkBQqqe0+MrH7u1aMQiW7VCqv2rxlKZiEWgGsu/61I98HHwTmUsGsH27s+XVGZiNSFgSLWr+3vg80+SLgQOqcJlKi9dYYwBRCpJxc3Pv2cKqdZC/GHS5kAi1aZUc8rcvpVAUnkbvMcQUKQqqkHSQcs76mVJfQe2jvURkEpSMfXlQF1/noYKcgjBEGqTo9POp4perBCCIdQmdyWdnGbmZ+PEGibBNJIh0y7mq7740AqxysrR6y/myFOKZUlnq7yi1VqxyEhTc0yZ+ybGgqXEppH0J1mgA7FgHMfLrk+FWFCGE2WWZ0QsKMMNSZ8pc1eaWHjEio9TKtZM+LnJJ4FYcXBG0tJeGx4hFpRlQdIPkm4qc7+18QQRKwznVcwkubZzt/e2glh2XJC0cVM3V+YuUSUAAE3gP+A0Ht6wIBpBAAAAAElFTkSuQmCC
     mediatype: image/png
   install:
     spec:
@@ -89,6 +159,15 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - rolebindings
@@ -127,15 +206,6 @@ spec:
           - route.openshift.io
           resources:
           - routes
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - services
           verbs:
           - '*'
         - apiGroups:
@@ -287,7 +357,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/migtools/pelorus-operator:0.0.9
+                image: quay.io/migtools/pelorus-operator:0.0.38
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -361,8 +431,18 @@ spec:
     type: AllNamespaces
   keywords:
   - pelorus-operator
+  - dora
+  - dora metrics
+  - pelorus
+  - metrics
+  - transformation
+  - devops
   links:
-  - name: Pelorus Operator
+  - name: Pelorus Docs
+    url: https://pelorus.readthedocs.io/en/latest/
+  - name: Pelorus Configuration Docs
+    url: https://pelorus.readthedocs.io/en/latest/Configuration/
+  - name: Pelorus GIT repository
     url: https://github.com/konveyor/pelorus/
   maintainers:
   - email: kgranger@redhat.com
@@ -371,10 +451,12 @@ spec:
     name: Wesley Hayutin
   - email: mpryc@redhat.com
     name: Michal Pryc
+  - email: msouzaol@redhat.com
+    name: Mateus Souza Oliveira
   - email: esauer@redhat.com
     name: Eric Sauer
   maturity: alpha
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.9
+  version: 0.0.38

--- a/pelorus-operator/config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml
+++ b/pelorus-operator/config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml
@@ -15,29 +15,77 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Pelorus is the Schema for the pelorus API
+        description: >-
+          Configure a running instance of Pelorus
+        type: object
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: >-
+              APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the
+              latest internal value, and may reject unrecognized values. More
+              info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: >-
+              Kind is a string value representing the REST resource this
+
+              object represents. Servers may infer this from the endpoint the
+              client
+
+              submits requests to. Cannot be updated. In CamelCase. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: Spec defines the desired state of Pelorus
+            description: >-
+              PelorusSpec defines state of the Pelorus application and allows
+              to configure for the desired workflow. More information about
+              Pelorus configuration that can be used in the Spec section is
+              available at:
+              https://pelorus.readthedocs.io/en/latest/Configuration/
             type: object
-            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              exporters:
+                description: >-
+                  References configuration for the Pelorus exporters. More
+                  info about exporters configuration:
+                  https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters-details
+
+                    Example:
+                      instances:
+                        - app_name: < instance_name >
+                          enabled: < won't be created if set to false >
+                          exporter_type: < deploytime, committime, failure >
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              prometheus_retention:
+                description: >-
+                  Prometheus Retention time. More information:
+                  https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-retention
+                type: string
+              prometheus_retention_size:
+                description: >-
+                  Prometheus Retention Size. More information:
+                  https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-retention
+                type: string
+              prometheus_storage:
+                description: >-
+                  Use Prometheus Persistent Volume. More information:
+                  https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-persistent-volume-recommended
+                type: boolean
+              prometheus_storage_pvc_capacity:
+                description: Prometheus Persistent Volume capacity.
+                type: string
+              prometheus_storage_pvc_storageclass:
+                description: Prometheus Persistent Volume storage class to be used.
+                type: string
           status:
             description: Status defines the observed state of Pelorus
             type: object
             x-kubernetes-preserve-unknown-fields: true
-        type: object
     served: true
     storage: true
     subresources:

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/migtools/pelorus-operator
-  newTag: 0.0.9
+  newTag: 0.0.38

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -4,16 +4,69 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    categories: |
+      Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
+    description: |
+      Tool that helps IT organizations measure their impact on the overall performance of their organization
+    operatorframework.io/suggested-namespace: pelorus
+    repository: https://github.com/konveyor/pelorus/
+    support: Pelorus Community
   name: pelorus-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Pelorus is the Schema for pelorus API to adopt instance to the
+        requested workflow
+      displayName: Pelorus
+      kind: Pelorus
+      name: pelorus.charts.pelorus.konveyor.io
+      version: v1alpha1
   description: |
-    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole.
+    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
+
+    - Software Delivery Performance
+    - Product Quality and Sustainability
+    - Customer experience
+
+    For more background on the project you can read [@trevorquinn](https://github.com/trevorquinn)'s blog post on [Metrics Driven Transformation](https://www.openshift.com/blog/exploring-a-metrics-driven-approach-to-transformation).
+
+    ## Software Delivery Performance as an outcome
+
+    Currently, Pelorus functionality can capture proven metrics that measure Software Delivery Performance -- a significant outcome that IT organizations aim to deliver.
+
+    Pelorus is a Grafana dashboard that can easily be deployed to an OpenShift cluster, and provides an organizational-level view of the [four critical measures of software delivery performance](https://blog.openshift.com/exploring-a-metrics-driven-approach-to-transformation/).
+
+    ## Software Delivery Metrics Dashboard
+
+    A short video describing each of metrics provided by Pelorus is available [here](https://www.youtube.com/watch?v=7-iB_KhUaQg).
+
+    ## Demo
+
+    [YouTube Video](https://www.youtube.com/watch?v=VPCOIfDcgso) with the Pelorus in action recorded during online Konveyor Community event.
+
+    ## Documentation
+
+    Pelorus documentation is available at [pelorus.readthedocs.io](https://pelorus.readthedocs.io/en/latest/).
+
+    ## Contributing to Pelorus
+
+    If you are interested in contributing to the Pelorus project, please review our Contribution guide which can be found in the [contribution guide](https://github.com/konveyor/pelorus/blob/master/CONTRIBUTING.md)
+
+    ## Statement of Support
+
+    Our support policy can be found in the [Upstream Support statement](https://github.com/konveyor/pelorus/blob/master/docs/UpstreamSupport.md)
+
+    ## Code of Conduct
+    Refer to Konveyor's Code of Conduct [here](https://github.com/konveyor/community/blob/main/CODE_OF_CONDUCT.md).
+
+    ## License
+
+    This repository is licensed under the terms of [Apache-2.0 License](https://raw.githubusercontent.com/konveyor/pelorus/master/LICENSE).
   displayName: Pelorus Operator
   icon:
-  - base64data: iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5gsdDTUcZ4LhxgAACXFJREFUeNrtnVusVcUdh7/Z55K2kmCDUkBSK5eTthoraGqMlEDAaKxWHkpAbvXWOSSNaVKfMLHGmNS+6JuJjFBszwGh9EFjNRJRqaExGATaatMAttooUKxpScE257L/fViHA+e+L7PWXmuf3/d4svecuXz7P7NmZs2AEEIUBTfpK8DbdIP1F/3JgCfHqKwZFtw/pM3EtE6q0nr78YA43wA2nrdISKxqRfoRcCNDI5KQWFWLdA1wA7BNTSuxYgi1HviVmlNixZBpAfAz4DY1o8SKIdT3gd1qOokVS6i7gBfUZBIrllDfBX6rppJYsYRaCLyrJpJYMYXaAixQ80isWFItAd5Us1zAeZth0AHcCmya6OPAMqAPOEdwDYv4LidCXQvsAK7OdSNntVbobRYwGzhAsupUazuVgVuAfxPcockllrebgf2FiB5pi5UI9QjggVLk1E8CtxPckeYXy9tRYH5huqU0xfK2FbgnBaGGc7oVZvUF1998Yyxv1wHvAG0aQ9nlBqcyEOo80/vgc7zdQnBvpfVPSg2Q6lvAIUkFeOu2pIvKuh3agX14W9rirbXQYrV3Wglv1wOH0QZD8LYdWAu0NPDB7Y1+OJWGXJmI1dZppR7jr8BBSQV4ex5Yk5PcTEtDrlIGUrX0JlJdiQBvO4HVOctVdLlKGUj1gaQalOo5YFVOczetH76Te7EUqUY8/U0F1uU8m6/jbXFuxbooUn1VSiUYfNbAgXo1A/rXWr215E6stk4rqfsb0QV2FUCqwQf4PjiRK7HaE6nU/Y1kVcHyO31gEjsfYvUoUo0Wrbop5mTwK/kQK5lRl1QjWVnQfM8c2BvXQLGSsKkZ9dHHVu0FLsGljY5Y70iqUZld8Py/1jixkq0vWlAexpROc8CSghfj/PpuxmIlm/TmS6ORfG5N82O7JFuxku3E+6XQ6JRhb5MU5dmsI9YO6TMuzXJC0vzsxEreprla7oh4YiVzG3pFS0SPWFtUbePT3mklYLHEqi5a6Q1lET1i6SwFEVms5NQXUQGXOAz4s8SqDB0lVCH/esYZ8E+JNXG0uku6iDQilk7Sq56WJinHE+mIlZz5KaoluEVNUpI9aUUsHSRbAwO7G4qOOTgaXyxv66RIbZzd7IziL0Q7C+5UGhFrrRSpr0MseP5vjD94T7Yb63D++sZZu4HjBc19Gfg4jadC7V6Iw0eFjbbBnUhDrG45ESVqLS9otHq8ngRKY3SD18iIqGwoWH631ROtxotYN8iFqFGrq2Bd4qP1JlAa01gRW66vFSCX/Q6mE9wn8cXy9nVZkBr35Tx/Oy24T2MkNFrEWqr2Ty1qbQPuz2nudhBctAnx0cS6SQakKtcvcijXToKLOhk+mli6mHtyybWL4O6OnWhp2PjqKrV6pnI1esz1a4JL5aDd4RHrTrV4xmOu4FwDpiL6HVxKcKkdCDdcrLJau2FTEVlMovYC3QTXasGdSfMfuWFdoamVx62s9K+V87aX5AC7eRFT7QF2x3zqm4hW6ZK76LV8QLCVJNfL1bPWuA/4mODWN+BHqIiVq4g1jCmd5s5udoa3/cD5q+AuA7550cf+Q3KiIoArwfIvOXoHNhs2qq4GpfoJ8KT0yZdYo/HljebO2YW2KwH/2+xyNT5uHTN6idwy8N5irnuXkppJpC2WxlciFbE0vhLqCoXEEhJLCIklJJaYbGitsAoMLnNeszLj1tHAysSgWA5mqFrGlwp4T1pNiBsiVh7WwHJdW940g6wxlpBYQmIJIbGExBJNw0MSS6Ty8CyxhLpCIbHE5GZwDrmha4VTN5rrNzhrPEtldw8/McWxp5GvNYlxCO6phopV8vaFMrx8psxNwBer+OriswZ4OwqcJLglas18kq1Y3rqBlWVorzOlDqBj4AXb48CjBLdDzTnZxljeuvDWQ3LTRXvk1OcB2/F2HG8b1KQN48HMxHLepuKtD1gHtKVcsLnAL/H2otq48UEqPbG8PWfwGdnf2/c9vH2At/vV1pnyUvpiedsJ/IDGXQY5B9iCt/vU3pk9Ef4tXbG8PQ+syklxt0quTOhKd/DubTuwOmeFllzpcyA9sZKphDU5LfhWjblS7QafTkUs5+3yHEaq4TwsAxr0iFhjpLrC4DT5v7V9Dt4+VJNH5950xILHClQJV2oSNToH44vlbdZYxuaYn8qFqOOr99KIWI9QvK03c/G2RkZEYUP8MVYSrXxBK+QxORElWnWlMXifTXE3Cs6TFXXzalpPhQcKXS3e9smNung4uljO2wyKfxjuTLlRVzd4OLpYlmy0K/q58B1TOk1n29fGyok+UGtXeGsz1M5Za45yNCBa/SYtsTY1SRVtkiVVs6KSD+n1L1FttHpRYonY3FHpByWWqCZavSyxRGyur+bDEktUwmGCOySxRGweqPYLEktMxNJqo5XEEhPxPsHtq+WLtYp1rEkq7pjcGZea963VKtYPm6HWprjmKEdKLCK4P2Yt1rkmqLj/tmgJeuxIHtzv60mgNrGCexcoF7zy3j7zjA5wG4VeguuoN5F6Bu+fFLwCT8ihERjw7RgJ1SPWigJXYA/BrZdHI6RaQHBHGitWMrdxsqCVuFsejeAjgvtDrMTqnce6vaBjiHXyaKhU7Y65MROsT6wkbJ4uWCXukkdDpWpzzOnZ7Mr5EStheYEqsV9jqxFSze2NLFUcsYL7E7CsCFI5mCaXBvn7gFT9aSQeZa2wBd4iOW80z3RbcGfk04XuLy2poonVH1xfS3JZeV7l2kVw98inId1ff5r/JNruhhzLtZPgVsunbCJVdLFyKtcOgrtbPmHAh+2JVJksxUXfj5UTufqB7QS3Vk4Nzqhf1ZORVKmINUyuhjwtOpipSVAAeoGFMWfUGyrWebkI7g3gWrKZRC0DW4HZFtyncopjBNcea+2vhh93Rni7DniF+Ke8lIEAPE5wqe1YcN6+YnCqIFItqnc/VXHEuiDYQuAF4Io6I2YZeBr4eZpCFUys94E19ez8LK5YQyVbTHIr2F5GnrflxvjbzUAbwf0u04rKv1hLa33xofnEGl+6ZQT3em4qKr9iHQYeqOUVrckpVs7IqVi3EdyePNZXq5QpJHdUc0CHxBITsaLS86kklqiElZUczyixRCW8SrIs1V3EzEus/LGO5MyEI0UuhMTKB/cCB8e68EhiiUrpAt4G3iS4vzRjASVWNjxIsnz10vDb3psViRWPh7gw4WwE95SqRAghisD/AUMDnng/PMaPAAAAAElFTkSuQmCC
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABmJLR0QA/wD/AP+gvaeTAAAGAElEQVR42u2dzYscRRiHf9X27F8gsiclBoOiqJsEP0gO7i3giDmYS0yEQJgIEgRz8w/wllzEg01AcGMuelASIZ7iQXENa1YlAVHi1y3/wi7Z9tC7637MzvT0vFVd3f08x2Gmp7rep96q7q6ukgAAmoLrfAUM8kdy6fSWj3JJF/eorNk8c/fRZjxpp852kL+7Ls5Tkt7esAgQa1KR3pH0orZnJECsiUV6RtJhSZ8QWsSyEOq0pE8JJ2JZyDQn6QNJxwgjYlkI9YakzwkdYlkJ9bqkLwkZYlkJ9aqk64QKsayEOijpJ0KEWJZCXZY0R3gQy0qqVyTdJCz/0+svVn44sHr9JddtsQb5s5KuSnoalaaTaa/jhJYsjUCqI5K+Qyc7oUYdO5Rgac1S/S7pCZTyK1UdgqU1CfW8pFuSegi1mNf1vz7lSmuQ6jlJt8VcsNqkCpG9klAnMXMuTzTID0laRqr6pfJdliBi9c7lyUquPyUtIVVcUvkqUxJAqodWC6keY4gep1Q+ypYEkOoeUsUvVWO6QjJVM6WyKmfiUap7kh5FqW42gsSDVAndX3e7QC9izRRS0f3RGGzFWiFTka3MxSruqCMVjcJQrOLZH3fUyVbmGesWUoGtWMXUlx5V2c5sVfU8kimlOiLmU4GpWMV0YmZ+gnnGukr1ga1Yxds0vPgAhmIV7/3xihaYZ6zLVFs3rgjDiVVkK95QBvOMxVoKYCxWseoLgHnGYimhktS5ZkKzxCoWPQMwz1ispAfGYhVrfgLdoXnGYiHZCnT9XlYyJludQpFuZ6yq5zEuY72JImArVjHdmMX5yVrmXSGzF2gYzodYV6haspatWMUuWkCDMO8KD1O1ZC0fYrHfX4flsihrMqQbfBINaAA+MtY81dvNrGVZvmFivYwC3ZPLulzDxGJj7o7J5X857kG+j7B3Sy5f5diZsV4j5GGDWqdgPv97p1hrhLv92SuE0Du3PPmQMNcrl895XCEFTglp+wWro7tNCGX846+qYtQ5hnNbrgjfk3SRkI6srNk8c/frLsewbBbbLYx0qGTAYJ+uEGIXK6c6wIdYjK+ArhAQCxALALEAsaBr8KxwAnLpYTfgrszIOlp/MrEplpNmqZbRUkm6g1ZjcdvEiuEZWNS1Nci5g8wYCxALEAsAsQCxoDVcQCzwcvGMWEBXCIgF3WbzHnKtzwqrvjvHJkiRkrlLtYo17cuYG79HsHhJmyTUqOMhWQfFCrGvDFmsds4HG7z3+ot56M2K2Og7jgvBpI0BrkNo0DXvYsUSVOQKekX4l1exYgsmcgVhYWS/2NYgIpd3fvQmVuzBQy6v3eBHXsQiaGAuVpOkogF44YwXsZoGcpmzZC4WQQJl7g4ZiwZhzVvmYyyCA8rcgrfBO3SWG16vCukOO8v75mIRFFDmlslYNBBrToz7AmMsqJKtvkAssOZ4mS8hFkyarb5CLLCmX/aLiAWTZKuvEQusOTTJlxELyrCszN1GLLDm7KQ/QCwYx/yk2QqxYBx3lblvq/wQsWAUJ6v+ELFgL44qc78iFljyhzL3/TQHqCRWW1Z0YWWa4dWizB2Y9iBkLNhKLukFiwN1dls5stVQqeaUuV8sDpYQGFjnHyupOtsV0ih2SzXjtN/ygAkBQqqe0+MrH7u1aMQiW7VCqv2rxlKZiEWgGsu/61I98HHwTmUsGsH27s+XVGZiNSFgSLWr+3vg80+SLgQOqcJlKi9dYYwBRCpJxc3Pv2cKqdZC/GHS5kAi1aZUc8rcvpVAUnkbvMcQUKQqqkHSQcs76mVJfQe2jvURkEpSMfXlQF1/noYKcgjBEGqTo9POp4perBCCIdQmdyWdnGbmZ+PEGibBNJIh0y7mq7740AqxysrR6y/myFOKZUlnq7yi1VqxyEhTc0yZ+ybGgqXEppH0J1mgA7FgHMfLrk+FWFCGE2WWZ0QsKMMNSZ8pc1eaWHjEio9TKtZM+LnJJ4FYcXBG0tJeGx4hFpRlQdIPkm4qc7+18QQRKwznVcwkubZzt/e2glh2XJC0cVM3V+YuUSUAAE3gP+A0Ht6wIBpBAAAAAElFTkSuQmCC
     mediatype: image/png
   install:
     spec:
@@ -30,8 +83,18 @@ spec:
     type: AllNamespaces
   keywords:
   - pelorus-operator
+  - dora
+  - dora metrics
+  - pelorus
+  - metrics
+  - transformation
+  - devops
   links:
-  - name: Pelorus Operator
+  - name: Pelorus Docs
+    url: https://pelorus.readthedocs.io/en/latest/
+  - name: Pelorus Configuration Docs
+    url: https://pelorus.readthedocs.io/en/latest/Configuration/
+  - name: Pelorus GIT repository
     url: https://github.com/konveyor/pelorus/
   maintainers:
   - email: kgranger@redhat.com
@@ -40,6 +103,8 @@ spec:
     name: Wesley Hayutin
   - email: mpryc@redhat.com
     name: Michal Pryc
+  - email: msouzaol@redhat.com
+    name: Mateus Souza Oliveira
   - email: esauer@redhat.com
     name: Eric Sauer
   maturity: alpha

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,15 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
+- verbs:
+  - "*"
+  apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - "rolebindings"
@@ -93,14 +102,5 @@ rules:
   - "route.openshift.io"
   resources:
   - "routes"
-- verbs:
-  - "*"
-  apiGroups:
-  - ""
-  resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
+++ b/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
@@ -9,8 +9,23 @@ spec:
     instances:
     - app_name: deploytime-exporter
       exporter_type: deploytime
+    - app_name: failuretime-exporter
+      enabled: false
+      env_from_configmaps:
+      - pelorus-config
+      - failuretime-config
+      env_from_secrets:
+      - jira-secret
+      exporter_type: failure
+    - app_name: committime-exporter
+      exporter_type: committime
   extra_prometheus_hosts: null
   openshift_prometheus_basic_auth_pass: changeme
   openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
+  prometheus_retention: 1y
+  prometheus_retention_size: 1GB
+  prometheus_storage: false
+  prometheus_storage_pvc_capacity: 2Gi
+  prometheus_storage_pvc_storageclass: gp2
   
   

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: 2.0.3
-digest: sha256:0e2f5ab71eff50f4d8a517ea12f5f1b61c981211d8f28d49640362ef0454d61b
-generated: "2022-12-12T12:45:02.895920727+01:00"
+  version: 2.0.4
+digest: sha256:76d6f1ef53a7d8586a7d04dac9932b82460dcf135e48901741f510b401b906c3
+generated: "2022-12-16T16:10:07.264461881+01:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: v2.0.3
+  version: v2.0.4
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.3
+version: 2.0.4

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.3
+version: 2.0.4

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.3" }}
+      ref: {{ .source_ref | default "v2.0.4" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/exporters.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/exporters.yaml
@@ -1,28 +1,30 @@
 {{- range $index, $exporter := .Values.instances }}
-  # https://hackmd.io/@openshift-mig-eng/rkNC3W8dq
-  {{- if and ($exporter.image_name) (or $exporter.source_ref $exporter.source_url) }}
-    {{- fail "ERROR: image_name configuration can't be used with source_ref or source_url" }}
-  {{- end }}
-  {{- if and ($exporter.image_tag) (or $exporter.source_ref $exporter.source_url) }}
-    {{- fail "ERROR: image_tag configuration can't be used with source_ref or source_url" }}
-  {{- end }}
-  {{- if and $exporter.image_name $exporter.image_tag }}
-    {{- if contains ":" $exporter.image_name }}
-      {{- fail "ERROR: image_tag configuration can't be used with image_name that includes tag e.g. generic-exporter:tag-name" }}
+  {{- if ne ($exporter.enabled | toString) "false" }}
+    # https://hackmd.io/@openshift-mig-eng/rkNC3W8dq
+    {{- if and ($exporter.image_name) (or $exporter.source_ref $exporter.source_url) }}
+      {{- fail "ERROR: image_name configuration can't be used with source_ref or source_url" }}
     {{- end }}
+    {{- if and ($exporter.image_tag) (or $exporter.source_ref $exporter.source_url) }}
+      {{- fail "ERROR: image_tag configuration can't be used with source_ref or source_url" }}
+    {{- end }}
+    {{- if and $exporter.image_name $exporter.image_tag }}
+      {{- if contains ":" $exporter.image_name }}
+        {{- fail "ERROR: image_tag configuration can't be used with image_name that includes tag e.g. generic-exporter:tag-name" }}
+      {{- end }}
+    {{- end }}
+    {{- if or $exporter.source_ref $exporter.source_url }}
+      {{ include "exporters.buildconfig" $exporter }}
+    {{- end }}
+      {{ include "exporters.deploymentconfig" $exporter }}
+    {{- if or $exporter.source_ref $exporter.source_url }}
+      {{ include "exporters.imagestream" $exporter }}
+    {{- else }}
+      {{- if not $exporter.exporter_type }}
+        {{- fail "ERROR: exporter_type must be provided when using podman image installation method" }}
+      {{- end}}
+      {{ include "exporters.imagestream_from_image" $exporter }}
+    {{- end }}
+      {{ include "exporters.route" $exporter }}
+      {{ include "exporters.service" $exporter }}
   {{- end }}
-  {{- if or $exporter.source_ref $exporter.source_url }}
-    {{ include "exporters.buildconfig" $exporter }}
-  {{- end }}
-    {{ include "exporters.deploymentconfig" $exporter }}
-  {{- if or $exporter.source_ref $exporter.source_url }}
-    {{ include "exporters.imagestream" $exporter }}
-  {{- else }}
-    {{- if not $exporter.exporter_type }}
-      {{- fail "ERROR: exporter_type must be provided when using podman image installation method" }}
-    {{- end}}
-    {{ include "exporters.imagestream_from_image" $exporter }}
-  {{- end }}
-    {{ include "exporters.route" $exporter }}
-    {{ include "exporters.service" $exporter }}
 {{- end }}

--- a/pelorus-operator/helm-charts/pelorus/values.yaml
+++ b/pelorus-operator/helm-charts/pelorus/values.yaml
@@ -19,18 +19,18 @@ extra_prometheus_hosts:
 ## Persistent storage for Prometheus Operator
 # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/storage.md
 
-# Uncomment to use PVC for Prometheus
-# prometheus_storage: true
+# Set to true to use PVC for Prometheus
+prometheus_storage: false
 
 # Additional configuration options for Prometheus PVC
-# prometheus_storage_pvc_capacity: 2Gi
-# prometheus_storage_pvc_storageclass: "gp2"
+prometheus_storage_pvc_capacity: 2Gi
+prometheus_storage_pvc_storageclass: "gp2"
 
 # Set Prometheus retention time. Older data values are deleted
-# prometheus_retention: 1y
+prometheus_retention: 1y
 # Set Prometheus retention size. If data grows over old values are deleted
 # This should be lower of what's defined in the prometheus_storage_pvc_capacity
-# prometheus_retention_size: 1GB
+prometheus_retention_size: 1GB
 
 exporters:
   instances:
@@ -40,16 +40,17 @@ exporters:
     # - pelorus-config
     # - deploytime-config
 
-#  - app_name: failuretime-exporter
-#    exporter_type: failure
-#    env_from_configmaps:
-#    - pelorus-config
-#    - failuretime-config
-#    env_from_secrets:
-#    - jira-secret
+  - app_name: failuretime-exporter
+    exporter_type: failure
+    enabled: false
+    env_from_configmaps:
+    - pelorus-config
+    - failuretime-config
+    env_from_secrets:
+    - jira-secret
 
-#  - app_name: committime-exporter
-#    exporter_type: committime
+  - app_name: committime-exporter
+    exporter_type: committime
 #    env_from_configmaps:
 #    - pelorus-config
 #    - committime-config

--- a/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
+++ b/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
@@ -1,17 +1,75 @@
---- config/manifests/bases/pelorus-operator.clusterserviceversion.yaml.original	2022-11-25 18:33:56.279866205 +0100
-+++ config/manifests/bases/pelorus-operator.clusterserviceversion.yaml	2022-11-27 14:47:49.109292021 +0100
-@@ -9,34 +9,41 @@
+--- config/manifests/bases/pelorus-operator.clusterserviceversion.yaml.original	2022-12-15 17:01:35.384242008 +0100
++++ config/manifests/bases/pelorus-operator.clusterserviceversion.yaml	2022-12-15 17:01:46.425296201 +0100
+@@ -4,39 +4,110 @@
+   annotations:
+     alm-examples: '[]'
+     capabilities: Basic Install
++    categories: |
++      Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
++    description: |
++      Tool that helps IT organizations measure their impact on the overall performance of their organization
++    operatorframework.io/suggested-namespace: pelorus
++    repository: https://github.com/konveyor/pelorus/
++    support: Pelorus Community
+   name: pelorus-operator.v0.0.0
+   namespace: placeholder
  spec:
    apiservicedefinitions: {}
-   customresourcedefinitions: {}
+-  customresourcedefinitions: {}
 -  description: Pelorus Operator description. TODO.
++  customresourcedefinitions:
++    owned:
++    - description: Pelorus is the Schema for pelorus API to adopt instance to the requested workflow
++      displayName: Pelorus
++      kind: Pelorus
++      name: pelorus.charts.pelorus.konveyor.io
++      version: v1alpha1
 +  description: |
-+    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole.
++    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
++
++    - Software Delivery Performance
++    - Product Quality and Sustainability
++    - Customer experience
++
++    For more background on the project you can read [@trevorquinn](https://github.com/trevorquinn)'s blog post on [Metrics Driven Transformation](https://www.openshift.com/blog/exploring-a-metrics-driven-approach-to-transformation).
++
++    ## Software Delivery Performance as an outcome
++
++    Currently, Pelorus functionality can capture proven metrics that measure Software Delivery Performance -- a significant outcome that IT organizations aim to deliver.
++
++    Pelorus is a Grafana dashboard that can easily be deployed to an OpenShift cluster, and provides an organizational-level view of the [four critical measures of software delivery performance](https://blog.openshift.com/exploring-a-metrics-driven-approach-to-transformation/).
++
++    ## Software Delivery Metrics Dashboard
++
++    A short video describing each of metrics provided by Pelorus is available [here](https://www.youtube.com/watch?v=7-iB_KhUaQg).
++
++    ## Demo
++
++    [YouTube Video](https://www.youtube.com/watch?v=VPCOIfDcgso) with the Pelorus in action recorded during online Konveyor Community event.
++
++    ## Documentation
++
++    Pelorus documentation is available at [pelorus.readthedocs.io](https://pelorus.readthedocs.io/en/latest/).
++
++    ## Contributing to Pelorus
++
++    If you are interested in contributing to the Pelorus project, please review our Contribution guide which can be found in the [contribution guide](https://github.com/konveyor/pelorus/blob/master/CONTRIBUTING.md)
++
++    ## Statement of Support
++
++    Our support policy can be found in the [Upstream Support statement](https://github.com/konveyor/pelorus/blob/master/docs/UpstreamSupport.md)
++
++    ## Code of Conduct
++    Refer to Konveyor's Code of Conduct [here](https://github.com/konveyor/community/blob/main/CODE_OF_CONDUCT.md).
++
++    ## License
++
++    This repository is licensed under the terms of [Apache-2.0 License](https://raw.githubusercontent.com/konveyor/pelorus/master/LICENSE).
    displayName: Pelorus Operator
    icon:
 -  - base64data: ""
 -    mediatype: ""
-+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH5gsdDTUcZ4LhxgAACXFJREFUeNrtnVusVcUdh7/Z55K2kmCDUkBSK5eTthoraGqMlEDAaKxWHkpAbvXWOSSNaVKfMLHGmNS+6JuJjFBszwGh9EFjNRJRqaExGATaatMAttooUKxpScE257L/fViHA+e+L7PWXmuf3/d4svecuXz7P7NmZs2AEEIUBTfpK8DbdIP1F/3JgCfHqKwZFtw/pM3EtE6q0nr78YA43wA2nrdISKxqRfoRcCNDI5KQWFWLdA1wA7BNTSuxYgi1HviVmlNixZBpAfAz4DY1o8SKIdT3gd1qOokVS6i7gBfUZBIrllDfBX6rppJYsYRaCLyrJpJYMYXaAixQ80isWFItAd5Us1zAeZth0AHcCmya6OPAMqAPOEdwDYv4LidCXQvsAK7OdSNntVbobRYwGzhAsupUazuVgVuAfxPcockllrebgf2FiB5pi5UI9QjggVLk1E8CtxPckeYXy9tRYH5huqU0xfK2FbgnBaGGc7oVZvUF1998Yyxv1wHvAG0aQ9nlBqcyEOo80/vgc7zdQnBvpfVPSg2Q6lvAIUkFeOu2pIvKuh3agX14W9rirbXQYrV3Wglv1wOH0QZD8LYdWAu0NPDB7Y1+OJWGXJmI1dZppR7jr8BBSQV4ex5Yk5PcTEtDrlIGUrX0JlJdiQBvO4HVOctVdLlKGUj1gaQalOo5YFVOczetH76Te7EUqUY8/U0F1uU8m6/jbXFuxbooUn1VSiUYfNbAgXo1A/rXWr215E6stk4rqfsb0QV2FUCqwQf4PjiRK7HaE6nU/Y1kVcHyO31gEjsfYvUoUo0Wrbop5mTwK/kQK5lRl1QjWVnQfM8c2BvXQLGSsKkZ9dHHVu0FLsGljY5Y70iqUZld8Py/1jixkq0vWlAexpROc8CSghfj/PpuxmIlm/TmS6ORfG5N82O7JFuxku3E+6XQ6JRhb5MU5dmsI9YO6TMuzXJC0vzsxEreprla7oh4YiVzG3pFS0SPWFtUbePT3mklYLHEqi5a6Q1lET1i6SwFEVms5NQXUQGXOAz4s8SqDB0lVCH/esYZ8E+JNXG0uku6iDQilk7Sq56WJinHE+mIlZz5KaoluEVNUpI9aUUsHSRbAwO7G4qOOTgaXyxv66RIbZzd7IziL0Q7C+5UGhFrrRSpr0MseP5vjD94T7Yb63D++sZZu4HjBc19Gfg4jadC7V6Iw0eFjbbBnUhDrG45ESVqLS9otHq8ngRKY3SD18iIqGwoWH631ROtxotYN8iFqFGrq2Bd4qP1JlAa01gRW66vFSCX/Q6mE9wn8cXy9nVZkBr35Tx/Oy24T2MkNFrEWqr2Ty1qbQPuz2nudhBctAnx0cS6SQakKtcvcijXToKLOhk+mli6mHtyybWL4O6OnWhp2PjqKrV6pnI1esz1a4JL5aDd4RHrTrV4xmOu4FwDpiL6HVxKcKkdCDdcrLJau2FTEVlMovYC3QTXasGdSfMfuWFdoamVx62s9K+V87aX5AC7eRFT7QF2x3zqm4hW6ZK76LV8QLCVJNfL1bPWuA/4mODWN+BHqIiVq4g1jCmd5s5udoa3/cD5q+AuA7550cf+Q3KiIoArwfIvOXoHNhs2qq4GpfoJ8KT0yZdYo/HljebO2YW2KwH/2+xyNT5uHTN6idwy8N5irnuXkppJpC2WxlciFbE0vhLqCoXEEhJLCIklJJaYbGitsAoMLnNeszLj1tHAysSgWA5mqFrGlwp4T1pNiBsiVh7WwHJdW940g6wxlpBYQmIJIbGExBJNw0MSS6Ty8CyxhLpCIbHE5GZwDrmha4VTN5rrNzhrPEtldw8/McWxp5GvNYlxCO6phopV8vaFMrx8psxNwBer+OriswZ4OwqcJLglas18kq1Y3rqBlWVorzOlDqBj4AXb48CjBLdDzTnZxljeuvDWQ3LTRXvk1OcB2/F2HG8b1KQN48HMxHLepuKtD1gHtKVcsLnAL/H2otq48UEqPbG8PWfwGdnf2/c9vH2At/vV1pnyUvpiedsJ/IDGXQY5B9iCt/vU3pk9Ef4tXbG8PQ+syklxt0quTOhKd/DubTuwOmeFllzpcyA9sZKphDU5LfhWjblS7QafTkUs5+3yHEaq4TwsAxr0iFhjpLrC4DT5v7V9Dt4+VJNH5950xILHClQJV2oSNToH44vlbdZYxuaYn8qFqOOr99KIWI9QvK03c/G2RkZEYUP8MVYSrXxBK+QxORElWnWlMXifTXE3Cs6TFXXzalpPhQcKXS3e9smNung4uljO2wyKfxjuTLlRVzd4OLpYlmy0K/q58B1TOk1n29fGyok+UGtXeGsz1M5Za45yNCBa/SYtsTY1SRVtkiVVs6KSD+n1L1FttHpRYonY3FHpByWWqCZavSyxRGyur+bDEktUwmGCOySxRGweqPYLEktMxNJqo5XEEhPxPsHtq+WLtYp1rEkq7pjcGZea963VKtYPm6HWprjmKEdKLCK4P2Yt1rkmqLj/tmgJeuxIHtzv60mgNrGCexcoF7zy3j7zjA5wG4VeguuoN5F6Bu+fFLwCT8ihERjw7RgJ1SPWigJXYA/BrZdHI6RaQHBHGitWMrdxsqCVuFsejeAjgvtDrMTqnce6vaBjiHXyaKhU7Y65MROsT6wkbJ4uWCXukkdDpWpzzOnZ7Mr5EStheYEqsV9jqxFSze2NLFUcsYL7E7CsCFI5mCaXBvn7gFT9aSQeZa2wBd4iOW80z3RbcGfk04XuLy2poonVH1xfS3JZeV7l2kVw98inId1ff5r/JNruhhzLtZPgVsunbCJVdLFyKtcOgrtbPmHAh+2JVJksxUXfj5UTufqB7QS3Vk4Nzqhf1ZORVKmINUyuhjwtOpipSVAAeoGFMWfUGyrWebkI7g3gWrKZRC0DW4HZFtyncopjBNcea+2vhh93Rni7DniF+Ke8lIEAPE5wqe1YcN6+YnCqIFItqnc/VXHEuiDYQuAF4Io6I2YZeBr4eZpCFUys94E19ez8LK5YQyVbTHIr2F5GnrflxvjbzUAbwf0u04rKv1hLa33xofnEGl+6ZQT3em4qKr9iHQYeqOUVrckpVs7IqVi3EdyePNZXq5QpJHdUc0CHxBITsaLS86kklqiElZUczyixRCW8SrIs1V3EzEus/LGO5MyEI0UuhMTKB/cCB8e68EhiiUrpAt4G3iS4vzRjASVWNjxIsnz10vDb3psViRWPh7gw4WwE95SqRAghisD/AUMDnng/PMaPAAAAAElFTkSuQmCC
++  - base64data: iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABmJLR0QA/wD/AP+gvaeTAAAGAElEQVR42u2dzYscRRiHf9X27F8gsiclBoOiqJsEP0gO7i3giDmYS0yEQJgIEgRz8w/wllzEg01AcGMuelASIZ7iQXENa1YlAVHi1y3/wi7Z9tC7637MzvT0vFVd3f08x2Gmp7rep96q7q6ukgAAmoLrfAUM8kdy6fSWj3JJF/eorNk8c/fRZjxpp852kL+7Ls5Tkt7esAgQa1KR3pH0orZnJECsiUV6RtJhSZ8QWsSyEOq0pE8JJ2JZyDQn6QNJxwgjYlkI9YakzwkdYlkJ9bqkLwkZYlkJ9aqk64QKsayEOijpJ0KEWJZCXZY0R3gQy0qqVyTdJCz/0+svVn44sHr9JddtsQb5s5KuSnoalaaTaa/jhJYsjUCqI5K+Qyc7oUYdO5Rgac1S/S7pCZTyK1UdgqU1CfW8pFuSegi1mNf1vz7lSmuQ6jlJt8VcsNqkCpG9klAnMXMuTzTID0laRqr6pfJdliBi9c7lyUquPyUtIVVcUvkqUxJAqodWC6keY4gep1Q+ypYEkOoeUsUvVWO6QjJVM6WyKmfiUap7kh5FqW42gsSDVAndX3e7QC9izRRS0f3RGGzFWiFTka3MxSruqCMVjcJQrOLZH3fUyVbmGesWUoGtWMXUlx5V2c5sVfU8kimlOiLmU4GpWMV0YmZ+gnnGukr1ga1Yxds0vPgAhmIV7/3xihaYZ6zLVFs3rgjDiVVkK95QBvOMxVoKYCxWseoLgHnGYimhktS5ZkKzxCoWPQMwz1ispAfGYhVrfgLdoXnGYiHZCnT9XlYyJludQpFuZ6yq5zEuY72JImArVjHdmMX5yVrmXSGzF2gYzodYV6haspatWMUuWkCDMO8KD1O1ZC0fYrHfX4flsihrMqQbfBINaAA+MtY81dvNrGVZvmFivYwC3ZPLulzDxGJj7o7J5X857kG+j7B3Sy5f5diZsV4j5GGDWqdgPv97p1hrhLv92SuE0Du3PPmQMNcrl895XCEFTglp+wWro7tNCGX846+qYtQ5hnNbrgjfk3SRkI6srNk8c/frLsewbBbbLYx0qGTAYJ+uEGIXK6c6wIdYjK+ArhAQCxALALEAsaBr8KxwAnLpYTfgrszIOlp/MrEplpNmqZbRUkm6g1ZjcdvEiuEZWNS1Nci5g8wYCxALEAsAsQCxoDVcQCzwcvGMWEBXCIgF3WbzHnKtzwqrvjvHJkiRkrlLtYo17cuYG79HsHhJmyTUqOMhWQfFCrGvDFmsds4HG7z3+ot56M2K2Og7jgvBpI0BrkNo0DXvYsUSVOQKekX4l1exYgsmcgVhYWS/2NYgIpd3fvQmVuzBQy6v3eBHXsQiaGAuVpOkogF44YwXsZoGcpmzZC4WQQJl7g4ZiwZhzVvmYyyCA8rcgrfBO3SWG16vCukOO8v75mIRFFDmlslYNBBrToz7AmMsqJKtvkAssOZ4mS8hFkyarb5CLLCmX/aLiAWTZKuvEQusOTTJlxELyrCszN1GLLDm7KQ/QCwYx/yk2QqxYBx3lblvq/wQsWAUJ6v+ELFgL44qc78iFljyhzL3/TQHqCRWW1Z0YWWa4dWizB2Y9iBkLNhKLukFiwN1dls5stVQqeaUuV8sDpYQGFjnHyupOtsV0ih2SzXjtN/ygAkBQqqe0+MrH7u1aMQiW7VCqv2rxlKZiEWgGsu/61I98HHwTmUsGsH27s+XVGZiNSFgSLWr+3vg80+SLgQOqcJlKi9dYYwBRCpJxc3Pv2cKqdZC/GHS5kAi1aZUc8rcvpVAUnkbvMcQUKQqqkHSQcs76mVJfQe2jvURkEpSMfXlQF1/noYKcgjBEGqTo9POp4perBCCIdQmdyWdnGbmZ+PEGibBNJIh0y7mq7740AqxysrR6y/myFOKZUlnq7yi1VqxyEhTc0yZ+ybGgqXEppH0J1mgA7FgHMfLrk+FWFCGE2WWZ0QsKMMNSZ8pc1eaWHjEio9TKtZM+LnJJ4FYcXBG0tJeGx4hFpRlQdIPkm4qc7+18QQRKwznVcwkubZzt/e2glh2XJC0cVM3V+YuUSUAAE3gP+A0Ht6wIBpBAAAAAElFTkSuQmCC
 +    mediatype: image/png
    install:
      spec:
@@ -31,9 +89,20 @@
      type: AllNamespaces
    keywords:
    - pelorus-operator
++  - dora
++  - dora metrics
++  - pelorus
++  - metrics
++  - transformation
++  - devops
    links:
-   - name: Pelorus Operator
+-  - name: Pelorus Operator
 -    url: https://pelorus-operator.domain
++  - name: Pelorus Docs
++    url: https://pelorus.readthedocs.io/en/latest/
++  - name: Pelorus Configuration Docs
++    url: https://pelorus.readthedocs.io/en/latest/Configuration/
++  - name: Pelorus GIT repository
 +    url: https://github.com/konveyor/pelorus/
    maintainers:
 -  - email: your@email.com
@@ -44,6 +113,8 @@
 +    name: Wesley Hayutin
 +  - email: mpryc@redhat.com
 +    name: Michal Pryc
++  - email: msouzaol@redhat.com
++    name: Mateus Souza Oliveira
 +  - email: esauer@redhat.com
 +    name: Eric Sauer
    maturity: alpha

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -1,0 +1,89 @@
+--- config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml.original	2022-12-16 11:41:22.683297131 +0100
++++ config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml	2022-12-16 11:40:22.725983634 +0100
+@@ -15,29 +15,76 @@
+   - name: v1alpha1
+     schema:
+       openAPIV3Schema:
+-        description: Pelorus is the Schema for the pelorus API
++        description: >-
++          Configure a running instance of Pelorus
++        type: object
+         properties:
+           apiVersion:
+-            description: 'APIVersion defines the versioned schema of this representation
+-              of an object. Servers should convert recognized schemas to the latest
+-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
++            description: >-
++              APIVersion defines the versioned schema of this representation
++              of an object. Servers should convert recognized schemas to the
++              latest internal value, and may reject unrecognized values. More
++              info:
++              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+             type: string
+           kind:
+-            description: 'Kind is a string value representing the REST resource this
+-              object represents. Servers may infer this from the endpoint the client
+-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
++            description: >-
++              Kind is a string value representing the REST resource this
++
++              object represents. Servers may infer this from the endpoint the
++              client
++
++              submits requests to. Cannot be updated. In CamelCase. More info:
++              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+             type: string
+           metadata:
+             type: object
+           spec:
+-            description: Spec defines the desired state of Pelorus
++            description: >-
++              PelorusSpec defines state of the Pelorus application and allows
++              to configure for the desired workflow. More information about
++              Pelorus configuration that can be used in the Spec section is
++              available at:
++              https://pelorus.readthedocs.io/en/latest/Configuration/
+             type: object
+-            x-kubernetes-preserve-unknown-fields: true
++            properties:
++              exporters:
++                description: >-
++                  References configuration for the Pelorus exporters. More
++                  info about exporters configuration:
++                  https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters-details
++
++                    Example:
++                      instances:
++                        - app_name: < instance_name >
++                          enabled: < won't be created if set to false >
++                          exporter_type: < deploytime, committime, failure >
++                type: object
++              prometheus_retention:
++                description: >-
++                  Prometheus Retention time. More information:
++                  https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-retention
++                type: string
++              prometheus_retention_size:
++                description: >-
++                  Prometheus Retention Size. More information:
++                  https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-retention
++                type: string
++              prometheus_storage:
++                description: >-
++                  Use Prometheus Persistent Volume. More information:
++                  https://pelorus.readthedocs.io/en/latest/Install/#configure-prometheus-persistent-volume-recommended
++                type: boolean
++              prometheus_storage_pvc_capacity:
++                description: Prometheus Persistent Volume capacity.
++                type: string
++              prometheus_storage_pvc_storageclass:
++                description: Prometheus Persistent Volume storage class to be used.
++                type: string
+           status:
+             description: Status defines the observed state of Pelorus
+             type: object
+             x-kubernetes-preserve-unknown-fields: true
+-        type: object
+     served: true
+     storage: true
+     subresources:


### PR DESCRIPTION
A number of fixes in this revision:
 - Changed logo
 - Added descriptions and fields to the openAPIV3Schema
 - Updated example to include all 3 exporters
 - added "enabled:" field for the exporter to allow enabling or disabling exporter from the values.yaml or the openAPIV3Schema
 - Added metadata and categories for the Marketplace

Signed-off-by: Michal Pryc <mpryc@redhat.com>


## Testing Instructions

`operator-sdk run bundle quay.io/migtools/pelorus-operator-bundle:v0.0.38 --namespace pelorus`

@redhat-cop/mdt
