### PR TITLE
fix: Documentation typos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,16 @@
 ## Describe the behavior changes introduced in this PR
 
-## Linked Issues?
+<!-- Write this section if Pull Request has linked issues -->
+## Linked Issues
 
-resolves #<issue number>
+<!-- Use this if merging should auto-close an issue, one issue per line -->
+resolves #<!-- issue number -->
 
-related to #<issue number>
+<!-- Use this if merging should NOT auto-close an issue, one issue per line -->
+related to #<!-- issue number -->
 
 ## Testing Instructions
 
-Please include any additional commands or pointers in addition to our [standard PR testing process](/docs/Development.md#testing-pull-requests).
+Please include any additional commands or pointers in addition to our [standard PR testing process](https://pelorus.readthedocs.io/en/latest/Development/#testing-pull-requests).
 
 @redhat-cop/mdt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing to Pelorus
 
-//Table of Content goes here
-
 ## Types of contributions we’re looking for
 
 * Resolving issues
@@ -26,7 +24,7 @@ created as others will do so if they appreciate it.
 
 ## Getting set up for local development
 
-Check out our [Pelorus development guide](/docs/Development.md) to get started developing Pelorus.
+Check out our [Pelorus development guide](https://pelorus.readthedocs.io/en/latest/Development/) to get started developing Pelorus.
 
 ## Contributing Content
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -5,19 +5,19 @@ The following diagram shows the various components and traffic flows in the Pelo
 ## Terminology
 
 _Exporter_
-: Exporters enable Pelorus to customize data points to capture metrics from various providers.  
+: Exporters enable Pelorus to customize data points to capture metrics from various providers.
 e.g. Deploy time exporter, Commit time exporter, Failure exporter
 
 _Provider_
-: The source from which exporters automate collection of data points (metrics).  
+: The source from which exporters automate collection of data points (metrics).
 e.g. OpenShift, Git providers (GitHub, GitLab, Bitbucket), Issue trackers (JIRA, ServiceNow)
 
 _Metrics_
-: The data points that are collected from the providers.  
+: The data points that are collected from the providers.
 e.g. deploy_time, commit_time, failure_creation, failure_resolution
 
 _Measures_
-: Metrics calculated to represent an [outcome](philosophy/outcomes/index.md). Each outcome is made measurable by a set of representative measures.  
+: Metrics calculated to represent an [outcome](philosophy/outcomes/index.md). Each outcome is made measurable by a set of representative measures.
 e.g. Lead Time for Change, Deployment Frequency, Mean Time to Restore, Change Failure Rate
 
 ## Basic Architecture and Components
@@ -38,7 +38,7 @@ Pelorus is composed of the following open source components.
 
 ### Prometheus and Grafana
 
-Pelorus is built on top of [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/), an industry standard open source metrics gathering and dashboarding stack. This allows for us to focus on the core differntiators for Pelorus - the metrics we care about, methods of gathering then, and building information radiators from those metrics.
+Pelorus is built on top of [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/), an industry standard open source metrics gathering and dashboarding stack. This allows for us to focus on the core differentiators for Pelorus - the metrics we care about, methods of gathering then, and building information radiators from those metrics.
 
 [Thanos](https://thanos.io/) is a set of Prometheus components that provide high availability and long term storage of Prometheus data. We use Thanos in Pelorus to give our dashboards the ability to look back over months or years of organizational data.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2,7 +2,7 @@
 
 ## Configuring The Pelorus Stack
 
-The Pelorus stack (Prometheus, Grafana, Thanos, etc.) can be configured by changing the `values.yaml` file that is passed to helm. The recommended practice is to make a copy of the one [values.yaml](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/values.yaml) file and [charts/pelorus/configmaps/](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/configmaps) directory, and store in in your own configuration repo for safe keeping, and updating. Once established, you can make configuration changes by updating your `charts/pelorus/configmaps` files with `values.yaml` and applying the changes like so:
+The Pelorus stack (Prometheus, Grafana, Thanos, etc.) can be configured by changing the `values.yaml` file that is passed to helm. The recommended practice is to make a copy of the one [values.yaml](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/values.yaml) file and [charts/pelorus/configmaps/](https://github.com/konveyor/pelorus/blob/master/charts/pelorus/configmaps) directory, and store in your own configuration repo for safe keeping, and updating. Once established, you can make configuration changes by updating your `charts/pelorus/configmaps` files with `values.yaml` and applying the changes like so:
 
 ```
 oc apply -f `myclusterconfigs/pelorus/configmaps
@@ -178,7 +178,7 @@ exporters:
 
 #### Source-to-image (S2I)
 
-By specyfing `source_url` and optionally `source_ref` Pelorus exporters will use installation method that performs incremental builds of the exporter images using source from the GIT repository. Images are being stored in an OpenShift Container Platform registry and used during Pelorus Helm deployment or update. Each instance that uses this method results in a new build. This method is recommended for development or unmerged bug-fixes as it may point to any GIT and any branch or GIT reference. By default `source_ref` points to the latest [released](https://github.com/konveyor/pelorus/releases) Pelorus.
+By specifying `source_url` and optionally `source_ref` Pelorus exporters will use installation method that performs incremental builds of the exporter images using source from the GIT repository. Images are being stored in an OpenShift Container Platform registry and used during Pelorus Helm deployment or update. Each instance that uses this method results in a new build. This method is recommended for development or unmerged bug-fixes as it may point to any GIT and any branch or GIT reference. By default `source_ref` points to the latest [released](https://github.com/konveyor/pelorus/releases) Pelorus.
 
 Example of such exporter instances are below:
 
@@ -208,11 +208,12 @@ exporters:
 
 ### Authentication to Remote Services
 
-Pelorus exporters make use of `personal access tokens` when authentication is 
-required.  It is recommended to configure the Pelorus exporters with authenticaion
+Pelorus exporters make use of `personal access tokens` when authentication is
+required.  It is recommended to configure the Pelorus exporters with authentication
 via the `TOKEN` key to avoid connection rate limiting and access restrictions.
 
 More information about personal access tokens:
+
 * [Github Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 
 * [Jira / Bitbucket Personal Access Tokens](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
@@ -325,12 +326,12 @@ When it starts up, you should see information about custom certificate usage, de
 
 Labels are key/value pairs that are attached to objects, such as pods. Labels are intended to be used to specify identifying attributes of objects that are meaningful and relevant to users and Pelorus.
 
-The commit time, deploy time, and failure exporters all rely on labels to indentify the application that is associated with an object.  The object can
+The commit time, deploy time, and failure exporters all rely on labels to identify the application that is associated with an object.  The object can
 include a build, build configuration, deployment or issue.
 
-In Pelorus the default label is: `app.kubernetes.io/name=<app_name>` where 
+In Pelorus the default label is: `app.kubernetes.io/name=<app_name>` where
 app_name is the name of the application(s) being monitored. The label can
-be customized by setting the `APP_LABEL` variable to your custom value. 
+be customized by setting the `APP_LABEL` variable to your custom value.
 
 An example may be to override the APP_LABEL for the failure exporter to indicate a production bug or issue.
 The `APP_LABEL` with the value `production_issue/name` may give more context than `app.kubernetes.io/name`
@@ -353,7 +354,7 @@ Example Failure exporter config:
     value: production_issue/name
 ```
 
-> **Warning** 
+> **Warning**
 > If the application label is not properly configured, Pelorus will not collect data for that object.
 
 In the following examples an application named [todolist](https://github.com/konveyor/mig-demo-apps/blob/master/apps/todolist-mongo-go/mongo-persistent.yaml) is being monitored.
@@ -434,7 +435,7 @@ Note: The requirement to label the build with `app.kubernetes.io/name=<app_name>
 * Sample Application
 
 ```
-cat app.py 
+cat app.py
 #!/usr/bin/env python3
 print("Hello World")
 ```
@@ -569,7 +570,7 @@ data:
 
 #### Custom JIRA workflow
 
-The Failure Time Exporter(s) can be easilly adjusted to adapt custom JIRA workflow(s), this includes:
+The Failure Time Exporter(s) can be easily adjusted to adapt custom JIRA workflow(s), this includes:
 
 1. Custom JIRA JQL query to find all matching issues to be tracked. *NOTE* in such case `PROJECTS` value is ignored, because user may or may not include `project` as part of the custom JQL query. More information is available at [Advanced Jira Query Language (JQL) site](https://support.atlassian.com/jira-service-management-cloud/docs/use-advanced-search-with-jira-query-language-jql/).
 
@@ -739,7 +740,7 @@ This exporter provides several configuration options, passed via `pelorus-config
 
 The job of the failure time exporter is to capture the timestamp at which a failure occurs in a production environment and when it is resolved.
 
-Failure Time Exporter may be deployed with one of three backends, such as JIRA, GithHub Issues and ServiceNow. In one clusters' namespace there may be multiple instances of the Failure Time Exporter for each of the backends or/and watched projects.
+Failure Time Exporter may be deployed with one of three backends, such as JIRA, GitHub Issues and ServiceNow. In one clusters' namespace there may be multiple instances of the Failure Time Exporter for each of the backends or/and watched projects.
 
 Each of the backend requires specific [configuration](#failureconfigmap), that may be used via ConfigMap associated with the exporter instance.
 
@@ -807,14 +808,14 @@ metadata:
   namespace: pelorus
 data:
   PROVIDER: "github"     # jira  |  jira, github, servicenow
-  SERVER:                #       |  URL to the Jira or ServiceNowServer, can be overriden by env_from_secrets
-  API_USER:                  #       |  Tracker Username, can be overriden by env_from_secrets
-  TOKEN:                 #       |  User's API Token, can be overriden by env_from_secrets
+  SERVER:                #       |  URL to the Jira or ServiceNowServer, can be overridden by env_from_secrets
+  API_USER:                  #       |  Tracker Username, can be overridden by env_from_secrets
+  TOKEN:                 #       |  User's API Token, can be overridden by env_from_secrets
   PROJECTS: "konveyor/todolist-mongo-go,konveyor/todolist-mariadb-go"
   APP_FIELD: "todolist"  #       |  This is optional for the Github failure exporter
 ```
 
-The `PROJECTS` key is comma deliniated and formated at "Github_organization/Github_repository"
+The `PROJECTS` key is comma delimited and formatted at "Github_organization/Github_repository"
 The `APP_FIELD` key may be used to associate the Github repository with a particular application
 
 Any Github issue must be labeled as a "bug".  Any issue optionally can be labeled with a label associated

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -4,11 +4,11 @@ We appreciate your interest in contributing to Pelorus! Use this guide to help y
 
 There are three main tracks of Pelorus development to consider.
 
-1. [Deployment Automation](#contributing-to-deployment-automation)  
+1. [Deployment Automation](#contributing-to-deployment-automation)
 This track mostly involves testing, fixing, and updating our Helm chart(s) to streamline the installation and configuration experience. Knowledge of Helm, OpenShift, Operators and Prometheus configuration is assumed for this work.
-2. [Dashboard Development](#dashboard-development)  
+2. [Dashboard Development](#dashboard-development)
 This is where we take the raw data we've collected and turn it into actionable visual representations that will help IT organizations make important decisions. Knowledge of Grafana and PromQL is required for contribution here.
-3. [Exporter Development](#exporter-development)  
+3. [Exporter Development](#exporter-development)
 This track is focused around the development of custom [Prometheus exporters](https://prometheus.io/docs/instrumenting/writing_exporters/) to gather the information we need in order to calculate our core metrics. Python development experience is assumed.
 
 ## Contributing to Deployment Automation
@@ -63,7 +63,7 @@ The following outlines a workflow for working on a dashboard:
         $ oc get route grafana-route -n pelorus
 
 1. Once signed in, sign as an administrator
-    1. Click the signin button in the bottom right corner:  
+    1. Click the signin button in the bottom right corner:
     ![Signin button](img/signin.png)
     1. The admin credentials can be pulled from the following commands:
 
@@ -364,7 +364,7 @@ We are in the process of refactoring our helm charts such that they can be teste
 The following is a walkthrough of the process we follow to create and manage versioned releases of Pelorus.
 Pelorus release versions follow SemVer versioning conventions. Change of the version is managed via Makefile.
 
-1. Create Pelorus Pull Request with the release you're about to make.  
+1. Create Pelorus Pull Request with the release you're about to make.
 
     For PATCH version bump use:
 
@@ -385,10 +385,18 @@ Pelorus release versions follow SemVer versioning conventions. Change of the ver
 
 ## Testing the Docs
 
-Our documentation gets published via [readthedocs](https://readthedocs.org/), via the [mkdocs](https://www.mkdocs.org/) framework. Mkdocs can be run locally for testing the rendering of the markdown files. If you followed the [local setup](#running-locally) instructions above, you should already have mkdocs installed.
+Our documentation gets published via [readthedocs](https://readthedocs.org/), via the [mkdocs](https://www.mkdocs.org/) framework. Mkdocs can be run locally for testing the rendering of the markdown files. If you followed the [local setup](#running-locally) instructions above, you should already have `mkdocs` installed.
 
-Stand up the local server by running:
+Stand up the local server by running
+```
+mkdocs serve
+```
 
-    mkdocs serve
+If an error with `KeyError: 'Regular'` appears when testing the the documentation, run
+```
+rm -rf .cache && mkdocs serve
+```
+to fix it.
 
-The mkdocs config is controlled by the mkdocs.yml file in the root of this project. All of the documents that will be served are in the [/docs](/docs) folder.
+
+The mkdocs config is controlled by the `mkdocs.yml` file in the root of this project. All of the documents that will be served are in the [/docs](/docs) folder.

--- a/docs/Noobaa.md
+++ b/docs/Noobaa.md
@@ -45,7 +45,7 @@ They will be used later in the [Update Pelorus Configuration](#update-pelorus-co
 #------------------#
 
 AWS_ACCESS_KEY_ID     : <s3 access key>
-AWS_SECRET_ACCESS_KEY : <s3 secred access key>
+AWS_SECRET_ACCESS_KEY : <s3 secret access key>
 ```
 
 After running `noobaa install --namespace pelorus` step, you may confirm that installation went fine by checking the System Status output and ensuring that ll the services are marked with ✅:
@@ -97,7 +97,7 @@ To create `thanos` NooBaa bucket:
 noobaa bucket create thanos --namespace pelorus
 ```
 
-At any time to check if the bucket was created succesfully and it's healthy run the command:
+At any time to check if the bucket was created successfully and it's healthy run the command:
 
 ```
 noobaa bucket status thanos --namespace pelorus
@@ -107,7 +107,7 @@ noobaa bucket status thanos --namespace pelorus
 
 To update our Pelorus stack, follow the instructions provided in the [Long Term Storage](Install.md#configure-long-term-storage-recommended).
 
-Ensure that `<s3 access key>`, `<s3 secred access key>` and the `<bucket name>` are used from the [Deploy NooBaa
+Ensure that `<s3 access key>`, `<s3 secret access key>` and the `<bucket name>` are used from the [Deploy NooBaa
 ](#deploy-noobaa) step and `s3.pelorus.svc:443`, which is an `S3 InternalDNS Address` from the `noobaa status --namespace pelorus` command, as bucket access point as in example:
 
 ```yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,8 @@ template: home.html
 ![](https://github.com/redhat-cop/pelorus/workflows/Chart%20Lint/badge.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-![Python versions](https://img.shields.io/badge/Python-3.9%20|%203.10-success)
 
-Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. 
+Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole.
 
 Some of the key outcomes we'd like Pelorus help us measure are:
 

--- a/docs/philosophy/outcomes/SoftwareDeliveryPerformance.md
+++ b/docs/philosophy/outcomes/SoftwareDeliveryPerformance.md
@@ -1,6 +1,6 @@
 # Outcome: Software Delivery Performance
 
-_Software Delivery Performance_ is a measure of an organization's ability to effectively deliver software-based products they have built to their customers. It is comprised of 4 _measures_ that provide a balanced perspective, taking both speed to market and stability measures into account. Tracking _Software Delivery Performance_ over time provides IT organizations with data they can use to make smarter investments in their internal tools and processes to optimize their delivery processes based on the types of products they are delivering. This outcomes provides a bridge between development, operations and leadership, allowing them to better communicate about whether proposed work on infrastructure imrovements or process developments are in line with the overall vision and financial goals of the organization at large.
+_Software Delivery Performance_ is a measure of an organization's ability to effectively deliver software-based products they have built to their customers. It is comprised of 4 _measures_ that provide a balanced perspective, taking both speed to market and stability measures into account. Tracking _Software Delivery Performance_ over time provides IT organizations with data they can use to make smarter investments in their internal tools and processes to optimize their delivery processes based on the types of products they are delivering. This outcomes provides a bridge between development, operations and leadership, allowing them to better communicate about whether proposed work on infrastructure improvements or process developments are in line with the overall vision and financial goals of the organization at large.
 
 ![Software Delivery Performance dashboard](../../img/sdp-dashboard.png)
 
@@ -19,7 +19,7 @@ The Pelorus _Software Delivery Performance_ dashboard tracks the four primary me
 
 ## Measures
 
-![Exporter relaionship diagram](../../img/exporter-relationship-diagram.png)
+![Exporter relationship diagram](../../img/exporter-relationship-diagram.png)
 
 ### :material-clock-fast: Lead Time for Change
 
@@ -81,7 +81,7 @@ For an organizational-level measurement, average MTTR data across products.
 
 The following exporters are required to calculate _Mean Time to Restore_:
 
-* The [failure exporter](https://github.com/konveyor/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` and `failure_resolution_timestamp` metrics, which attempt to capture the beginning and end of individual failure or degredation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
+* The [failure exporter](https://github.com/konveyor/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` and `failure_resolution_timestamp` metrics, which attempt to capture the beginning and end of individual failure or degradation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
 
 The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/konveyor/pelorus/blob/master/charts/deploy/templates/prometheus-rules.yaml). This converts individual `failure_creation_timestamp` and `failure_resolution_timestamp` data points into the following metrics:
 
@@ -106,7 +106,7 @@ For an organizational-level measurement, expand the scope of the failures captur
 
 The following exporters are require to calculate _Change Failure Rate_:
 
-* The [failure exporter](https://github.com/konveyor/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` metrics, which attempt to capture the beginning of individual failure or degredation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
+* The [failure exporter](https://github.com/konveyor/pelorus/blob/master/exporters/failure) provides the `failure_creation_timestamp` metrics, which attempt to capture the beginning of individual failure or degradation events in customer-facing systems. This data is typically collected from a ticketing system, though automated approaches of failure detection and tracking could be added in the future.
 * The [deploy time exporter](https://github.com/konveyor/pelorus/blob/master/exporters/deploytime) provides the `deploy_time` metric, which is a timestamp that a production deployment was rolled out.
 
 The exporters are only responsible for gathering data about individual events. Before the dashboard consumes them, we perform some aggregation calculations in a set of [PrometheusRules](https://github.com/konveyor/pelorus/blob/master/charts/deploy/templates/prometheus-rules.yaml). This converts individual `failure_creation_timestamp` and `deploy_time` data points into the following metric:


### PR DESCRIPTION
Signed-off-by: Mateus Oliveira <msouzaol@redhat.com>

## Describe the behavior changes introduced in this PR

Fix some typos in documentation.

## Linked Issues?

No.

## Testing Instructions

Run the documentation locally, with
```
make dev-env
source .venv/bin/activate
mkdocs serve
```
