### PR TITLE
feat: Automatically add replaces/skips to operator csv file

### DIFF
--- a/scripts/create_pelorus_operator
+++ b/scripts/create_pelorus_operator
@@ -100,7 +100,8 @@ pushd "${destination_dir}" || exit 2
     operator-sdk create api --helm-chart="${source_dir}" || exit 2
 
     # Correct operator version, to be latest +1
-    OPERATOR_VERSION=$(curl -H "Authorization: Bearer XYZ" -X GET "https://quay.io/api/v1/repository/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}/tag/" | jq .tags[].name | head -1 | sed -e 's|\"||g')
+    OPERATOR_VERSIONS=$(curl -H "Authorization: Bearer XYZ" -X GET "https://quay.io/api/v1/repository/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}/tag/" | jq ".tags[] | select(.end_ts == null) | .name" | sed -e 's|\"||g' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' -o | sort --reverse)
+    OPERATOR_VERSION=$(echo "$OPERATOR_VERSIONS" | head -1 )
     echo "INFO: Current operator version: ${OPERATOR_VERSION}"
 
     if [ -z ${operator_ver+x} ]; then
@@ -119,7 +120,7 @@ pushd "${destination_dir}" || exit 2
     IMAGE_TAG_BASE="quay.io/${OPERATOR_ORG_NAME}/${OPERATOR_PROJECT_NAME}"
     echo "INFO: Setting IMAGE_TAG_BASE to ${IMAGE_TAG_BASE}"
     sed -i "s#IMAGE_TAG_BASE ?=.*#IMAGE_TAG_BASE ?= ${IMAGE_TAG_BASE}#g" Makefile || exit 2
-    
+
     # Generate kustomize files. This is similar to the first command from
     # Make bundle, except we do want to have non-interactive version
     echo "INFO: Generating kustomize manifests files"
@@ -163,7 +164,10 @@ elif [ "$(ls -A "${patches_dir}/bundle-patches"/*.diff 2>/dev/null)" ]; then
         done
 fi
 
-# Print operator versions
+echo "INFO: Adding replaces and skips entries to ${source_dir}${destination_dir}/bundle/manifests/charts.pelorus.konveyor.io_pelorus.yaml"
+set -e
+$SCRIPT_DIR/specify_operator_update.py $NEW_OPERATOR_VERSION $destination_dir $OPERATOR_VERSIONS
+
 echo "INFO: Current operator version: ${OPERATOR_VERSION}"
 echo "INFO: New operator version: ${NEW_OPERATOR_VERSION}"
 

--- a/scripts/specify_operator_update.py
+++ b/scripts/specify_operator_update.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Script to add replaces and skips sections to Pelorus Operator
+ClusterServiceVersion file, located in
+
+../pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+
+More info: https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List
+
+YAML_TAB = "  "
+
+
+def path_type(file_path: str) -> Path:
+    _file_path = Path(file_path).resolve()
+    if _file_path.exists():
+        return _file_path
+    raise argparse.ArgumentTypeError(f"Folder {_file_path} does not exist.")
+
+
+def exit_error(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main(
+    new_version: str, cluster_service_version_file: Path, versions: List[str]
+) -> None:
+    if new_version in versions:
+        exit_error(f"version {new_version} already exists in Pelorus Operator tags.")
+
+    with open(cluster_service_version_file, encoding="utf-8") as file_content:
+        cluster_service_version_file_content = file_content.readlines()
+
+    cluster_service_version_file_content.append(
+        f"{YAML_TAB}replaces: pelorus-operator.v{versions[0]}\n"
+    )
+    cluster_service_version_file_content.append(f"{YAML_TAB}skips:\n")
+    for version in versions:
+        cluster_service_version_file_content.append(
+            f"{YAML_TAB*2}- pelorus-operator.v{version}\n"
+        )
+
+    with open(cluster_service_version_file, mode="w", encoding="utf-8") as file_content:
+        file_content.writelines(cluster_service_version_file_content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Updates ClusterServiceVersion of new Pelorus Operator."
+    )
+    parser.add_argument(
+        "new_version", type=str, help="New version of Pelorus Operator."
+    )
+    parser.add_argument(
+        "destination_path", type=path_type, help="Folder of Pelorus Operator."
+    )
+    parser.add_argument(
+        "versions", nargs="*", help="Pelorus Operator versions, filtered and sorted."
+    )
+
+    cluster_service_version_file = (
+        Path(parser.parse_args().destination_path).resolve()
+        / "bundle/manifests/pelorus-operator.clusterserviceversion.yaml"
+    )
+    if not cluster_service_version_file.exists():
+        exit_error(f"{cluster_service_version_file} does not exist.")
+
+    main(
+        parser.parse_args().new_version,
+        cluster_service_version_file,
+        parser.parse_args().versions,
+    )


### PR DESCRIPTION
Signed-off-by: Mateus Oliveira <msouzaol@redhat.com>

## Describe the behavior changes introduced in this PR

Automatically add replaces/skips sections to Pelorus Operator ClusterServiceVersion file when updating/creating the  Operator.

## Linked Issues

resolves #788 

## Testing Instructions

run `rm -rf test_folder && mkdir test_folder && scripts/create_pelorus_operator -d test_folder` and check if the `test_folder/bundle/manifests/pelorus-operator.clusterserviceversion.yaml` has the desired sections from pelorus operator tags.