### PR TITLE
Fix Demo link to work with the Konveyor demo

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.10"
   jobs:
     post_build:
-      - find _build/html
+      - find _readthedocs/html
       - find .cache
 
 python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,5 +83,6 @@ plugins:
            # Used by the Pelorus Operator v0.0.1
            'Configuration.md': 'GettingStarted/configuration/PelorusCore.md'
            'Install.md': 'GettingStarted/configuration/ProductionBestPractice.md'
+           'Demo.md': 'GettingStarted/QuickstartTutorial.md'
 watch:
 - overrides


### PR DESCRIPTION
Konveyor video available at:
  https://youtu.be/VPCOIfDcgso?t=212

Points to the:
  http://pelorus.readthedocs.io/en/latest/Demo/

This change allows the link to be redirected to our current Demo/Quickstart Tutorial.

Signed-off-by: Michal Pryc <mpryc@redhat.com>

@redhat-cop/mdt
