### PR TITLE
docs: Use description lists instead of tabs

### DIFF
--- a/docs/GettingStarted/Installation.md
+++ b/docs/GettingStarted/Installation.md
@@ -120,7 +120,7 @@ Verify the pelorus-operator Subscription (sub) has been successfully created:
   NAME               PACKAGE            SOURCE                CHANNEL
   pelorus-operator   pelorus-operator   community-operators   alpha
   ```
-Verify the ClusterServiceVersion (csv) for Pelorus Operator together with Grafana and Prometheus were succesfully created:
+Verify the ClusterServiceVersion (csv) for Pelorus Operator together with Grafana and Prometheus were successfully created:
   ```shell
   $ oc get csv -n pelorus
   NAME                        DISPLAY               VERSION   REPLACES                    PHASE
@@ -184,7 +184,7 @@ Verify the pelorus-sample has been successfully created:
   pelorus-sample   31s
   ```
 
-Verbose command to list Pelorus objects with their statuses, presenting succesfull Deployment with the InstallationSuccessful status:
+Verbose command to list Pelorus objects with their statuses, presenting successful Deployment with the InstallationSuccessful status:
   ```
   $ oc get pelorus -n pelorus -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.conditions}{"\n"}{end}'
   pelorus-sample	[{"lastTransitionTime":"2023-01-10T14:12:56Z","status":"True","type":"Initialized"},{"lastTransitionTime":"2023-01-10T14:13:00Z","reason":"InstallSuccessful","status":"True","type":"Deployed"}]

--- a/docs/GettingStarted/QuickstartTutorial.md
+++ b/docs/GettingStarted/QuickstartTutorial.md
@@ -22,7 +22,7 @@ To do so, you will
 
 ### Tools and access
 
-To succesfully go through this demo you will need:
+To successfully go through this demo you will need:
 
 * [GitHub](https://github.com) account with a [Personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) generated.
 
@@ -54,9 +54,9 @@ Deployment of the running Pelorus Operator instance consists of two steps:
 
 #### Prepare Config file
 
-> **NOTE**: A comprehensive list of all configuration options is available in our [Pelorus Core](./configuration/PelorusCore.md) and [Pelorus Exportrs](./configuration/PelorusExporters.md) documentation.
+> **NOTE**: A comprehensive list of all configuration options is available in our [Pelorus Core](./configuration/PelorusCore.md) and [Pelorus Exporters](./configuration/PelorusExporters.md) documentation.
 
-For this demo we will need to prepare a configuration file that will be used in our deployment. For now it's enought to understand that our Pelorus Deployment will consist of:
+For this demo we will need to prepare a configuration file that will be used in our deployment. For now it's enough to understand that our Pelorus Deployment will consist of:
 
 * The pelorus instance:
     * is named **pelorus-quickstart**
@@ -131,12 +131,12 @@ prometheus-prometheus-pelorus-1                        3/3     Running     1 (2m
 
 #### Accessing Pelorus dashboard
 
-To view the Pelorus measurements we need to gain access to its' Grafana dasboard. To get the URL of the Grafana dashboard use the following command:
+To view the Pelorus measurements we need to gain access to its' Grafana dashboard. To get the URL of the Grafana dashboard use the following command:
 ```shell
 $ oc get route grafana-route --namespace pelorus -o=go-template='https://{{.spec.host | printf "%s\n" }}'
 ```
 
-In the Grafana dasboard navigate to **search** and select **"pelorus ➔ Software Delivery Performance - By App"**. An empty dashboard without any measurements should be presented. That is expected, because we did not deploy our sample application yet!
+In the Grafana dashboard navigate to **search** and select **"pelorus ➔ Software Delivery Performance - By App"**. An empty dashboard without any measurements should be presented. That is expected, because we did not deploy our sample application yet!
 
 ![pelorus_dashboard_no_data](../img/pelorus-dashboard-no-data.png)
 
@@ -144,10 +144,10 @@ In the Grafana dasboard navigate to **search** and select **"pelorus ➔ Softwar
 
 Pelorus is now configured to measure the sample application.
 
-It is time to deploy the sample application to view measurements from Pelorus' Grafana dashboard. Plase keep the Grafana page open.
+It is time to deploy the sample application to view measurements from Pelorus' Grafana dashboard. Please keep the Grafana page open.
 
 
-## Sample Aplication Demo
+## Sample Application Demo
 
 ### Lead Time for Change and Deployment Frequency
 
@@ -191,7 +191,7 @@ $ oc get buildconfig.build.openshift.io/todolist --namespace mongo-persistent -o
 
 #### View the Pelorus measurements
 
-After a couple of minutes you should see at least one measurement for **Lead Time for Change** and **Deployment Frequency** in the Grafana dasboard, like in the following image:
+After a couple of minutes you should see at least one measurement for **Lead Time for Change** and **Deployment Frequency** in the Grafana dashboard, like in the following image:
 
 > **Note:** If the time elapsed from your `mongo-persistent` deployment is higher then **5 minutes**, you may want to adjust different relative time range <span style="color:red">⓵</span> e.g. **Last 3 hours**s.
 
@@ -199,9 +199,9 @@ After a couple of minutes you should see at least one measurement for **Lead Tim
 
 #### Update application
 
-In this section we will observe application continous delivery and analyze it with Pelorus. Few steps will guide us through this process:
+In this section we will observe application continuous delivery and analyze it with Pelorus. Few steps will guide us through this process:
 
-- [Setting up GitHub Webhook](#github-webhook) that allows to automatically run new builds of your smaple applications when the commit to the source code happens
+- [Setting up GitHub Webhook](#github-webhook) that allows to automatically run new builds of your sample applications when the commit to the source code happens
 - Fixing an issue in the running application and [update the application source code](#update-the-application-source-code)
 - Committing changes to source control
 - Watching the application redeploy with the changes to be captured by Pelorus
@@ -237,7 +237,7 @@ To add the webhook to your forked GitHub repo:
 : For this quickstart tutorial consider **Disable**, as you may not have signed SSL Certificate in your testing OpenShift environment and the webhook will fail to deliver it's payload with the error: `We couldn’t deliver this payload: x509: certificate signed by unknown authority`.
 * <span style="color:red">⓺</span> Click **Add webhook**
 
-Now your webhook should be added and green success icon should appear left to your webhook's URL, which means it succesfully sent the first `ping` payload to your OpenShift URL endpoint:
+Now your webhook should be added and green success icon should appear left to your webhook's URL, which means it successfully sent the first `ping` payload to your OpenShift URL endpoint:
 
 ![github_webhook_3](../img/github_webhook_3.png)
 
@@ -330,7 +330,7 @@ Pelorus will utilize two labels to determine if a GitHub issue is associated wit
 
 > **Note:** Only those GitHub issues which have **both** labels are recognized by Pelorus as a critical bugs in our "production" environment.
 
-Ensure the above labels are present and create them in the event of their absence by navingating to the following URL, like in the following image:
+Ensure the above labels are present and create them in the event of their absence by navigating to the following URL, like in the following image:
 
 : **https://github.com/`<your_org>`/mig-demo-apps/labels**
 
@@ -359,7 +359,7 @@ You may also check the output from the failure exporter again, by running:
 $ curl $(oc get route failure-exporter --namespace pelorus -o=template='http://{{.spec.host | printf "%s\n"}}')
 ```
 
-At this time you should see lines startning with `failure_creation_timestamp` and `failure_resolution_timestamp`. They indicate the time the issue was created and when it was closed.
+At this time you should see lines starting with `failure_creation_timestamp` and `failure_resolution_timestamp`. They indicate the time the issue was created and when it was closed.
 
 #### Understand the changes to the Grafana Dashboard
 

--- a/docs/GettingStarted/configuration/ExporterCommittime.md
+++ b/docs/GettingStarted/configuration/ExporterCommittime.md
@@ -230,7 +230,7 @@ Those options are only applicable to the Commit Time Exporter when the [PROVIDER
 
 : Annotation name associated with the Image from which commit time is taken.
 : 
-> **NOTE:** The date and time found in the OpenShift object [COMMIT_DATE_ANNOTATION](#commit_date_annotation) annotation will be calculated by parsting it's value string in the following order:
+> **NOTE:** The date and time found in the OpenShift object [COMMIT_DATE_ANNOTATION](#commit_date_annotation) annotation will be calculated by parsing it's value string in the following order:
 > 
 - 10 digit EPOCH timestamp. Allowed EPOCH string format is one, where milliseconds are ignored.
 - The one from the [COMMIT_DATE_FORMAT](#commit_date_format)

--- a/docs/GettingStarted/configuration/PelorusCore.md
+++ b/docs/GettingStarted/configuration/PelorusCore.md
@@ -103,7 +103,7 @@ It is recommended to use Prometheus Persistent Volume **together** with [Thanos]
     - **Default Value:** false
 - **Type:** boolean
 
-: Controlls wether Prometheus should use persistent volume. If set to `true` [PersistentVolumeClaim](https://docs.openshift.com/container-platform/4.11/storage/understanding-persistent-storage.html#persistent-volume-claims_understanding-persistent-storage) will be created.
+: Controls wether Prometheus should use persistent volume. If set to `true` [PersistentVolumeClaim](https://docs.openshift.com/container-platform/4.11/storage/understanding-persistent-storage.html#persistent-volume-claims_understanding-persistent-storage) will be created.
 
 ###### prometheus_storage_pvc_capacity
 
@@ -142,7 +142,7 @@ $ htpasswd -nbs internal <my-secret-password>
 
 ### Multiple Prometheus
 
-By default Pelorus gathers the data from the Prometheus instance deployed in the same cluster in whcih it is running. To collect data across multiple OpenShift clusters additional Prometheus hosts have to be configured. To do this `extra_prometheus_hosts` configuration option is used.
+By default Pelorus gathers the data from the Prometheus instance deployed in the same cluster in which it is running. To collect data across multiple OpenShift clusters additional Prometheus hosts have to be configured. To do this `extra_prometheus_hosts` configuration option is used.
 
 ###### extra_prometheus_hosts
 

--- a/docs/GettingStarted/configuration/PelorusExporters.md
+++ b/docs/GettingStarted/configuration/PelorusExporters.md
@@ -102,7 +102,7 @@ env_from_secrets:
 - example-secret
 - other-secret
 ```
-[More examples](#secrets).
+**For more information, check [detailed Secrets examples](#secrets).**
 
 : Check the list of all available options per exporter type:
 : - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)
@@ -121,7 +121,7 @@ env_from_configmaps:
 - example-configmap
 - other-configmap
 ```
-[More examples](#configmaps).
+**For more information, check [detailed ConfigMaps examples](#configmaps).**
 
 : Check the list of all available options per exporter type:
 : - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)

--- a/docs/GettingStarted/configuration/PelorusExporters.md
+++ b/docs/GettingStarted/configuration/PelorusExporters.md
@@ -80,183 +80,72 @@ This is the list of options that can be applied to `exporters.instances` section
 - **Required:** yes
 - **Type:** string
 
-    Set the exporter name.
+: Set the exporter name.
 
 ###### exporter_type
 
 - **Required:** yes
 - **Type:** string
 
-    Set the exporter type. One of `deploytime`, `committime`, `failure`.
+: Set the exporter type. One of `deploytime`, `committime`, `failure`.
 
 ###### env_from_secrets
 
 - **Required:** no
 - **Type:** list
 
-    **Recommended for sensitive data**
+: **Recommended for sensitive data**
 
-    List of secrets, like in the following example.
-    ```yaml
-    env_from_secrets:
-    - example-secret
-    - other-secret
-    ```
+: List of secrets, like in the following example.
+```yaml
+env_from_secrets:
+- example-secret
+- other-secret
+```
+[More examples](#secrets).
 
-    Check the list of all available options per exporter type:
+: Check the list of all available options per exporter type:
+: - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)
+- [Commit time](ExporterCommittime.md#commit-time-exporter-configuration-options)
+- [Failure](ExporterFailure.md#failure-time-exporter-configuration-options)
 
-    - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)
-    - [Commit time](ExporterCommittime.md#commit-time-exporter-configuration-options)
-    - [Failure](ExporterFailure.md#failure-time-exporter-configuration-options)
-
-    **Secrets Examples**
-
-    1. To create a Secret named **example-secret** in **pelorus** namespace, with the option **TOKEN** with value **token_value**, using the file **secret.yaml**
-        ```yaml
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: example-secret
-          namespace: pelorus
-        type: Opaque
-        stringData:
-          TOKEN: "token_value"
-        ```
-        run
-        ```
-        oc apply -f secret.yaml
-        ```
-        Then, add
-        ```yaml
-        [...]
-                env_from_secrets:
-                - example-secret
-        [...]
-        ```
-        to the exporter configuration.
-
-        If no `metadata.namespace` is added to Secret file, you must run the command with the namespace you want to apply it. For example, `oc apply -f secret.yaml -n pelorus`.
-
-        More [examples Secret files](https://github.com/konveyor/pelorus/tree/master/charts/secrets).
-
-    1. To create a secret named **other-secret** in **pelorus** namespace, with the
-
-        - option **SERVER** with value **server_url**
-        - option **API_USER** with value **username**
-        - option **TOKEN** with value **token_value**
-
-        run
-        ```
-        oc create secret generic other-secret -n pelorus \
-        --from-literal=SERVER=server_url \
-        --from-literal=API_USER=username \
-        --from-literal=TOKEN=token_value
-        ```
-        Then, add
-        ```yaml
-        [...]
-                env_from_secrets:
-                - other-secret
-        [...]
-        ```
-        to the exporter configuration.
 
 ###### env_from_configmaps
 
 - **Required:** no
 - **Type:** list
 
-    List of ConfigMaps, like in the following example.
-    ```yaml
-    env_from_configmaps:
-    - example-configmap
-    - other-configmap
-    ```
+: List of ConfigMaps, like in the following example.
+```yaml
+env_from_configmaps:
+- example-configmap
+- other-configmap
+```
+[More examples](#configmaps).
 
-    Check the list of all available options per exporter type:
-
-    - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)
-    - [Commit time](ExporterCommittime.md#commit-time-exporter-configuration-options)
-    - [Failure](ExporterFailure.md#failure-time-exporter-configuration-options)
-
-    **ConfigMap Examples**
-
-    1. To create a ConfigMap named **example-config** in **pelorus** namespace, with the
-
-        - option **APP_LABEL** with value **example**
-        - option **NAMESPACES** with value **one,two**
-
-        using the file **config.yaml**
-        ```yaml
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: example-config
-          namespace: pelorus
-        data:
-          APP_LABEL: "example"
-          NAMESPACES: "one,two"
-        ```
-        run
-        ```
-        oc apply -f config.yaml
-        ```
-        Then, add
-        ```yaml
-        [...]
-                env_from_configmaps:
-                - example-config
-        [...]
-        ```
-        to the exporter configuration.
-
-        If no `metadata.namespace` is added to ConfigMap file, you must run the command with the namespace you want to apply it. For example, `oc apply -f config.yaml -n pelorus`.
-
-        More [examples ConfigMap files](https://github.com/konveyor/pelorus/tree/master/charts/configmaps).
-
-    1. To create a ConfigMap named **example-for-all** in **pelorus** namespace, that will be used by multiple exporters, with the option **LOG_LEVEL** with value **DEBUG**, using the file **config.yaml**
-        ```yaml
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: example-for-all
-          namespace: pelorus
-        data:
-          LOG_LEVEL: "DEBUG"
-        ```
-        run
-        ```
-        oc apply -f config.yaml
-        ```
-        Then, add
-        ```yaml
-        [...]
-                env_from_configmaps:
-                - example-for-all
-        [...]
-        ```
-        to each one of the exporters configuration.
+: Check the list of all available options per exporter type:
+: - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)
+- [Commit time](ExporterCommittime.md#commit-time-exporter-configuration-options)
+- [Failure](ExporterFailure.md#failure-time-exporter-configuration-options)
 
 ###### extraEnv
 
 - **Required:** no
 - **Type:** list
 
-    List of `name` and `value` pairs, like in the following example.
+: List of `name` and `value` pairs, like in the following example.
+```yaml
+extraEnv:
+  - name: OPTION1
+    value: value1
+  - name: OPTION2
+    value: value2
+```
 
-    ```yaml
-    extraEnv:
-      - name: OPTION1
-        value: value1
-      - name: OPTION2
-        value: value2
-    ```
-
-    Check the list of all available options per exporter type:
-
-    - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)
-    - [Commit time](ExporterCommittime.md#commit-time-exporter-configuration-options)
-    - [Failure](ExporterFailure.md#failure-time-exporter-configuration-options)
+: Check the list of all available options per exporter type:
+: - [Deploy time](ExporterDeploytime.md#deploy-time-exporter-configuration-options)
+- [Commit time](ExporterCommittime.md#commit-time-exporter-configuration-options)
+- [Failure](ExporterFailure.md#failure-time-exporter-configuration-options)
 
 ###### enabled
 
@@ -264,21 +153,20 @@ This is the list of options that can be applied to `exporters.instances` section
     - **Default Value:** true
 - **Type:** boolean
 
-    If set to `false`, the exporter is not deployed.
+: If set to `false`, the exporter is not deployed.
 
 ###### custom_certs
 
 - **Required:** no
 - **Type:** list
 
-    List of `map_name`s, like in the following example.
+: List of `map_name`s, like in the following example.
+```yaml
+custom_certs:
+  - map_name: name
+```
 
-    ```yaml
-    custom_certs:
-      - map_name: name
-    ```
-
-    Check [Custom Certificates](#custom-certificates) for more information.
+: Check [Custom Certificates](#custom-certificates) for more information.
 
 ###### image_tag
 
@@ -287,9 +175,9 @@ This is the list of options that can be applied to `exporters.instances` section
     - **Default Value:** stable
 - **Type:** string
 
-    Used to set exporter image tag (or custom image, if [image_name](#image_name) is set).
+: Used to set exporter image tag (or custom image, if [image_name](#image_name) is set).
 
-    Check [Development guide](../../Development.md) for more information.
+: Check [Development guide](../../Development.md) for more information.
 
 ###### image_name
 
@@ -297,9 +185,9 @@ This is the list of options that can be applied to `exporters.instances` section
     - Only applicable for development configuration, **do not use in production**
 - **Type:** string
 
-    Used to deploy exporter with the user built images or pre-built images hosted in non default container image registry. The container image URI may be with or without `:tag` suffix. If no tag suffix is specified in the URI, [image_tag](#image_tag) is used.
+: Used to deploy exporter with the user built images or pre-built images hosted in non default container image registry. The container image URI may be with or without `:tag` suffix. If no tag suffix is specified in the URI, [image_tag](#image_tag) is used.
 
-    Check [Development guide](../../Development.md) for more information.
+: Check [Development guide](../../Development.md) for more information.
 
 ###### source_url
 
@@ -307,9 +195,9 @@ This is the list of options that can be applied to `exporters.instances` section
     - Only applicable for development configuration, **do not use in production**
 - **Type:** string
 
-    Used to deploy exporter with the user Git source code.
+: Used to deploy exporter with the user Git source code.
 
-    Check [Development guide](../../Development.md) for more information.
+: Check [Development guide](../../Development.md) for more information.
 
 ###### source_ref
 
@@ -318,9 +206,111 @@ This is the list of options that can be applied to `exporters.instances` section
     - **Default Value:** points to the latest released Pelorus
 - **Type:** string
 
-    A Git reference or branch.
+: A Git reference or branch.
 
-    Check [Development guide](../../Development.md) for more information.
+: Check [Development guide](../../Development.md) for more information.
+
+## Examples
+
+### Secrets
+
+1. To create a Secret named **example-secret** in **pelorus** namespace, with the option **TOKEN** with value **token_value**, using the file **secret.yaml**
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+  namespace: pelorus
+type: Opaque
+stringData:
+  TOKEN: "token_value"
+```
+run
+```
+oc apply -f secret.yaml
+```
+Then, add
+```yaml
+[...]
+        env_from_secrets:
+        - example-secret
+[...]
+```
+to the exporter configuration. If no `metadata.namespace` is added to Secret file, you must run the command with the namespace you want to apply it. For example, `oc apply -f secret.yaml -n pelorus`. More [examples Secret files](https://github.com/konveyor/pelorus/tree/master/charts/secrets).
+
+1. To create a secret named **other-secret** in **pelorus** namespace, with the
+
+: - option **SERVER** with value **server_url**
+: - option **API_USER** with value **username**
+: - option **TOKEN** with value **token_value**
+
+: run
+```
+oc create secret generic other-secret -n pelorus \
+--from-literal=SERVER=server_url \
+--from-literal=API_USER=username \
+--from-literal=TOKEN=token_value
+```
+Then, add
+```yaml
+[...]
+        env_from_secrets:
+        - other-secret
+[...]
+```
+to the exporter configuration.
+
+### ConfigMaps
+
+1. To create a ConfigMap named **example-config** in **pelorus** namespace, with the
+: - option **APP_LABEL** with value **example**
+: - option **NAMESPACES** with value **one,two**
+: using the file **config.yaml**
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-config
+  namespace: pelorus
+data:
+  APP_LABEL: "example"
+  NAMESPACES: "one,two"
+```
+run
+```
+oc apply -f config.yaml
+```
+Then, add
+```yaml
+[...]
+        env_from_configmaps:
+        - example-config
+[...]
+```
+to the exporter configuration. If no `metadata.namespace` is added to ConfigMap file, you must run the command with the namespace you want to apply it. For example, `oc apply -f config.yaml -n pelorus`. More [examples ConfigMap files](https://github.com/konveyor/pelorus/tree/master/charts/configmaps).
+
+1. To create a ConfigMap named **example-for-all** in **pelorus** namespace, that will be used by multiple exporters, with the option **LOG_LEVEL** with value **DEBUG**, using the file **config.yaml**
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-for-all
+  namespace: pelorus
+data:
+  LOG_LEVEL: "DEBUG"
+```
+run
+```
+oc apply -f config.yaml
+```
+Then, add
+```yaml
+[...]
+        env_from_configmaps:
+        - example-for-all
+[...]
+```
+to each one of the exporters configuration.
 
 ## Authentication to Remote Services
 

--- a/docs/GettingStarted/configuration/ProductionBestPractice.md
+++ b/docs/GettingStarted/configuration/ProductionBestPractice.md
@@ -22,7 +22,7 @@ There are two configuration options that allows to modify those retention values
 - [prometheus_retention](./PelorusCore.md#prometheus_retention)
 - [prometheus_retention_size](./PelorusCore.md#prometheus_retention_size)
 
-Additionaly it is recommended to create Persistent Volumes to withstand prometheus container restarts. To enable that the [prometheus_storage](./PelorusCore.md#prometheus_storage) needs to be set to `true` and additionally PVC configuration options controls how it should be created. Relevant options are:
+Additionally it is recommended to create Persistent Volumes to withstand prometheus container restarts. To enable that the [prometheus_storage](./PelorusCore.md#prometheus_storage) needs to be set to `true` and additionally PVC configuration options controls how it should be created. Relevant options are:
 
 - [prometheus_storage](./PelorusCore.md#prometheus_storage)
 - [prometheus_storage_pvc_capacity](./PelorusCore.md#prometheus_storage_pvc_capacity)


### PR DESCRIPTION
Signed-off-by: Mateus Oliveira <msouzaol@redhat.com>

## Describe the behavior changes introduced in this PR

Use description list instead of tabs in our docs (and fix some typos).

## Linked Issues

resolves #803

## Testing Instructions

Check readthedocs CI job.
