### PR TITLE
fix: Tests config to run doctests and coverage right folders

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = exporters/tests/*

--- a/Makefile
+++ b/Makefile
@@ -148,12 +148,11 @@ e2e-tests-scenario-2: e2e-tests-dev-env
 	./scripts/run-pelorus-e2e-tests -f "periodic/different_deployment_methods.yaml"
 
 # Integration tests
-## integration-tests: pytest -rap -m integration
+## integration-tests: pytest everything marked as integration
 .PHONY: integration-tests
 integration-tests: $(PELORUS_VENV)
 	. ${PELORUS_VENV}/bin/activate && \
-	coverage run -m pytest -rap -m "integration" && \
-	coverage report
+	pytest -rap -m "integration"
 
 # Unit tests
 ## unit-tests: pytest everything minus integration and mockoon
@@ -163,8 +162,7 @@ unit-tests: $(PELORUS_VENV)
   # because using (A)ll includes stdout
   # -m filters out integration tests
 	. ${PELORUS_VENV}/bin/activate && \
-	coverage run -m pytest -rap -m "not integration and not mockoon" && \
-	coverage report
+	pytest -rap -m "not integration and not mockoon"
 
 # Prometheus ruels
 ## test-prometheusrules: test prometheus with data in _test/test_promethusrules
@@ -257,16 +255,6 @@ else
 shellcheck-optional:
 	$(warning 🐚 ⏭ Shellcheck not found, skipping)
 endif
-
-
-# Testing
-.PHONY: test
-
-# -r: show extra test summaRy: (a)ll except passed, (p)assed
-# because using (A)ll includes stdout
-# -m filters out integration tests
-test: $(PELORUS_VENV)
-	. ${PELORUS_VENV}/bin/activate && pytest -r ap -m "not integration"
 
 # Cleanup
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -446,11 +446,6 @@ Each PR runs exporter tests in the CI systems, however those changes can be test
         make help
 
 5. As an example run unit tests using `make unit-tests`.
-    1. You can also run coverage reports with the following:
-
-            coverage run -m pytest -rap -m "not integration and not mockoon"
-            coverage report
-
 
 5. Gather necessary [configuration information](../GettingStarted/configuration/PelorusExporters/).
 6. [Run exporter locally](#running-locally). You can do this either via the command line, or use the provided [VSCode debug confuration](#ide-setup-vscode) to run it in your IDE Debugger.

--- a/exporters/requirements-dev.txt
+++ b/exporters/requirements-dev.txt
@@ -1,9 +1,6 @@
 # Needed by exporters/tests
 pytest
-
-# Mentioned in the docs/Development.md
-# Also used by the github unittests.yml workflow
-coverage
+pytest-cov
 
 # Used by bats in the conftests
 yq

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ src_paths = ["exporters" ,"scripts"]
 known_first_party = ["pelorus"]
 
 [tool.pytest.ini_options]
-testpaths = ["exporters/tests"]
+testpaths = ["exporters"]
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "mockoon: tests that should be run with mockoon running"
@@ -12,6 +12,9 @@ markers = [
 log_cli = true
 addopts = [
     "--doctest-modules",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+    "--cov=exporters",
 ]
 
 [tool.pylama]


### PR DESCRIPTION
Signed-off-by: Mateus Oliveira <msouzaol@redhat.com>

## Describe the behavior changes introduced in this PR

Run doctests and coverage only Pelorus python source code (excluding its tests) when running pytest.

Example with `make unit-tests` on master branch
![Screenshot from 2023-01-28 13-19-34](https://user-images.githubusercontent.com/66965232/215277654-fb25c0f1-94a9-4470-ae72-412ccdf8d3f0.png)

Tests are considered part of the coverage, not all folders of exporters are present (like extra) in the coverage and doctests are not run.

Example with `make unit-tests` on this PR
![Screenshot from 2023-01-28 13-18-42](https://user-images.githubusercontent.com/66965232/215277686-f8a0700e-33d2-4634-a2fa-362061172cf3.png)

Tests are NOT considered part of the coverage, ALL folders of exporters are present in the coverage and doctest are run.

## Linked Issues

No.

## Testing Instructions

Check CI logs and run `make unit-tests`, `make mockoon-tests` and `make integration-tests` to check coverage information. All of them should have the same number of TOTAL Stmts (2183).
