### PR TITLE
Commit time exporter should produce unique metric rows

### DIFF
--- a/exporters/committime/collector_base.py
+++ b/exporters/committime/collector_base.py
@@ -128,7 +128,7 @@ class AbstractCommitCollector(pelorus.AbstractPelorusExporter):
                 ],
                 my_metric.commit_timestamp,
             )
-            yield commit_metric
+        yield commit_metric
 
     def _get_watched_namespaces(self) -> set[str]:
         watched_namespaces = self.namespaces


### PR DESCRIPTION
Currently the commit time metric is yielding every commit row in a loop which results in duplicated rows in the Prometheus GaugeMetricFamily. This should be changed so the metrics are yielded at once and appearing in the /metrics of the exporter in a single place.

The current way causes number of rows to grow rapidly, let's say we have only `100` commits which should result in `100` rows, but in the current situation we would have `5050` rows, for `300` commits which isn't unusual instead of `300` rows we will get `45150` rows, so shortly we would cause entire commit time exporter to fail.
```
Cn - number of commits
Nseries = Cn/2 * (1 +Cn)
```

Current format, for each additional metric the commit_timestamp is duplicated, for just 4 commits:
```plain/text
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP commit_timestamp Commit timestamp
# TYPE commit_timestamp gauge
commit_timestamp{app="todolist",commit="731d5355550c41940807f42f9a0e7e9c366f7e60",image_sha="sha256:b2c0c50172ad0ff473d126a7e06778d437746c725fd26d5c6c19e58d1971d1c4",namespace="mongo-persistent"} 1.674407217e+09
# HELP commit_timestamp Commit timestamp
# TYPE commit_timestamp gauge
commit_timestamp{app="todolist",commit="731d5355550c41940807f42f9a0e7e9c366f7e60",image_sha="sha256:b2c0c50172ad0ff473d126a7e06778d437746c725fd26d5c6c19e58d1971d1c4",namespace="mongo-persistent"} 1.674407217e+09
commit_timestamp{app="todolist",commit="5379bad65a3f83853a75aabec9e0e43c75fd18fc",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.675101148e+09
# HELP commit_timestamp Commit timestamp
# TYPE commit_timestamp gauge
commit_timestamp{app="todolist",commit="731d5355550c41940807f42f9a0e7e9c366f7e60",image_sha="sha256:b2c0c50172ad0ff473d126a7e06778d437746c725fd26d5c6c19e58d1971d1c4",namespace="mongo-persistent"} 1.674407217e+09
commit_timestamp{app="todolist",commit="5379bad65a3f83853a75aabec9e0e43c75fd18fc",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.675101148e+09
commit_timestamp{app="todolist",commit="3d84d49bd5d93882890db1708eb118290ed0885e",image_sha="sha256:0a31659a81aed7038c832002c42c76a1f3e2a453a7c7b08775b575558b4d9320",namespace="mongo-persistent"} 1.675101239e+09
# HELP commit_timestamp Commit timestamp
# TYPE commit_timestamp gauge
commit_timestamp{app="todolist",commit="731d5355550c41940807f42f9a0e7e9c366f7e60",image_sha="sha256:b2c0c50172ad0ff473d126a7e06778d437746c725fd26d5c6c19e58d1971d1c4",namespace="mongo-persistent"} 1.674407217e+09
commit_timestamp{app="todolist",commit="5379bad65a3f83853a75aabec9e0e43c75fd18fc",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.675101148e+09
commit_timestamp{app="todolist",commit="3d84d49bd5d93882890db1708eb118290ed0885e",image_sha="sha256:0a31659a81aed7038c832002c42c76a1f3e2a453a7c7b08775b575558b4d9320",namespace="mongo-persistent"} 1.675101239e+09
commit_timestamp{app="todolist",commit="e6198ccbeaa917abd312ceeefe8930303de43e66",image_sha="sha256:05b2d889c6b989de805c632edc61aee2fce87f69b8650a65aab6e1a65ed19fe0",namespace="mongo-persistent"} 1.675101351e+09
```

After fix:
```plain/text
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP commit_timestamp Commit timestamp
# TYPE commit_timestamp gauge
commit_timestamp{app="todolist",commit="731d5355550c41940807f42f9a0e7e9c366f7e60",image_sha="sha256:b2c0c50172ad0ff473d126a7e06778d437746c725fd26d5c6c19e58d1971d1c4",namespace="mongo-persistent"} 1.674407217e+09
commit_timestamp{app="todolist",commit="5379bad65a3f83853a75aabec9e0e43c75fd18fc",image_sha="sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",namespace="mongo-persistent"} 1.675101148e+09
commit_timestamp{app="todolist",commit="3d84d49bd5d93882890db1708eb118290ed0885e",image_sha="sha256:0a31659a81aed7038c832002c42c76a1f3e2a453a7c7b08775b575558b4d9320",namespace="mongo-persistent"} 1.675101239e+09
commit_timestamp{app="todolist",commit="e6198ccbeaa917abd312ceeefe8930303de43e66",image_sha="sha256:05b2d889c6b989de805c632edc61aee2fce87f69b8650a65aab6e1a65ed19fe0",namespace="mongo-persistent"} 1.675101351e+09
```

The time to get the mertics is exactly the same as we are calling the underlying functions not in async (that could be improved).

There is another PR open that will resolve same issue, which is #720, but I really prefer to fix this one fast because the other PR is still in progress.

Signed-off-by: Michal Pryc <mpryc@redhat.com>
@redhat-cop/mdt
