### PR TITLE
feat: Add PagerDuty Failure Exporter

### DIFF
--- a/docs/GettingStarted/Overview.md
+++ b/docs/GettingStarted/Overview.md
@@ -58,6 +58,7 @@ Open an [issue](https://github.com/konveyor/pelorus/issues/new) or a pull reques
 
 - Jira :simple-jirasoftware:
 - GitHub :simple-github:
-- Service Now
+- ServiceNow
+- PagerDuty :simple-pagerduty:
 
 </font>

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -62,6 +62,8 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 | [JIRA_JQL_SEARCH_QUERY](#jira_jql_search_query) | no | - |
 | [JIRA_RESOLVED_STATUS](#jira_resolved_status) | no | - |
 | [GITHUB_ISSUE_LABEL](#github_issue_label) | no | bug |
+| [PAGERDUTY_URGENCY](#pagerduty_urgency) | no | - |
+| [PAGERDUTY_PRIORITY](#pagerduty_priority) | no | - |
 
 ###### PROVIDER
 
@@ -69,7 +71,7 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
     - **Default Value:** jira
 - **Type:** string
 
-: Set the Issue Tracker provider for the failure exporter. One of `jira`, `github`, `servicenow`.
+: Set the Issue Tracker provider for the failure exporter. One of `jira`, `github`, `servicenow`, `pagerduty`.
 
 ###### LOG_LEVEL
 
@@ -162,6 +164,22 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
 - **Type:** string
 
 : Defines a custom label to be used in GitHub issues to identify the ones to be monitored.
+
+###### PAGERDUTY_URGENCY
+
+- **Required:** no
+    - Only applicable for [PROVIDER](#provider) set to `pagerduty`
+- **Type:** string
+
+: Defines incidents urgencies (comma separated) to be monitored. By default, monitors all urgencies.
+
+###### PAGERDUTY_PRIORITY
+
+- **Required:** no
+    - Only applicable for [PROVIDER](#provider) set to `pagerduty`
+- **Type:** string
+
+: Defines incidents priorities (comma separated) to be monitored. By default, monitors all urgencies. To monitor incidents without priority, add **null** to this value.
 
 ## Configuring Jira
 

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -392,9 +392,9 @@ A custom field can be configure with the following steps:
 
 By default, Failure Time Exporter(s) configured to work with PagerDuty will:
 
-* Monitor all incidents in the domain of the token used to access it (PagerDuty's token handles all the information about credentials, including their URL, without using `SERVER`).
+* Monitor all incidents in the domain of the token used to access it (PagerDuty's API Access Key manages both the API URL endpoint and the credentials information).
 
-* The application(s) monitored must have the same name of the service linked to the incident (PagerDuty does not have labels, this is how Pelorus links the incidents to each application without using `APP_LABEL`).
+* Incidents' service name must match the monitored application(s) name (PagerDuty does not have labels or tags, so this is not as flexible as it is for other providers).
 
 * Incidents will be considered resolved when their statuses change to `Resolved` (Pelorus will not monitor alerts, but resolving all alerts of an incident, will resolve it. Suppressing alerts do not resolve them).
 

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -179,7 +179,7 @@ This is the list of options that can be applied to `env_from_secrets`, `env_from
     - Only applicable for [PROVIDER](#provider) set to `pagerduty`
 - **Type:** string
 
-: Defines incidents priorities (comma separated) to be monitored. By default, monitors all urgencies. To monitor incidents without priority, add **null** to this value.
+: Defines incidents priorities (comma separated) to be monitored. By default, monitors all priorities. To monitor incidents without priority, add **null** to this value.
 
 ## Configuring Jira
 
@@ -385,3 +385,23 @@ A custom field can be configure with the following steps:
 - Navigate to an existing Incident.
 - Use the upper left Menu and select Configure -> Form Layout.
 - Create a new field (String, Table or reference a List).
+
+## Configuring PagerDuty
+
+### Default workflow
+
+By default, Failure Time Exporter(s) configured to work with PagerDuty will:
+
+* Monitor all incidents in the domain of the token used to access it.
+
+* The application(s) monitored must have the same name of the service linked to the incident.
+
+* Incidents will be considered resolved when their statuses change to `Resolved`.
+
+### Custom workflow
+
+Failure Time Exporter(s) configured to work with PagerDuty can be easily adjusted to adapt to custom workflow(s), like:
+
+* Monitor issues of only specific urgencies, using [PAGERDUTY_URGENCY](#pagerduty_urgency).
+
+* Monitor issues of only specific priorities, using [PAGERDUTY_PRIORITY](#pagerduty_priority).

--- a/docs/GettingStarted/configuration/ExporterFailure.md
+++ b/docs/GettingStarted/configuration/ExporterFailure.md
@@ -392,11 +392,11 @@ A custom field can be configure with the following steps:
 
 By default, Failure Time Exporter(s) configured to work with PagerDuty will:
 
-* Monitor all incidents in the domain of the token used to access it.
+* Monitor all incidents in the domain of the token used to access it (PagerDuty's token handles all the information about credentials, including their URL, without using `SERVER`).
 
-* The application(s) monitored must have the same name of the service linked to the incident.
+* The application(s) monitored must have the same name of the service linked to the incident (PagerDuty does not have labels, this is how Pelorus links the incidents to each application without using `APP_LABEL`).
 
-* Incidents will be considered resolved when their statuses change to `Resolved`.
+* Incidents will be considered resolved when their statuses change to `Resolved` (Pelorus will not monitor alerts, but resolving all alerts of an incident, will resolve it. Suppressing alerts do not resolve them).
 
 ### Custom workflow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ Some of the key outcomes we would like Pelorus help us measure are:
   -   # :simple-gitlab:
   -   # :simple-azuredevops:
   -   # :simple-jirasoftware:
+  -   # :simple-pagerduty:
 
   </div>
 </div>

--- a/exporters/failure/app.py
+++ b/exporters/failure/app.py
@@ -25,10 +25,11 @@ from prometheus_client.core import REGISTRY
 import pelorus
 from failure.collector_github import GithubFailureCollector
 from failure.collector_jira import JiraFailureCollector
+from failure.collector_pagerduty import PagerdutyFailureCollector
 from failure.collector_servicenow import ServiceNowFailureCollector
 from pelorus.config import env_vars, load_and_log
 
-PROVIDER_TYPES = {"jira", "github", "servicenow"}
+PROVIDER_TYPES = {"jira", "github", "pagerduty", "servicenow"}
 
 
 @frozen
@@ -46,6 +47,8 @@ class FailureCollectorConfig:
             return load_and_log(ServiceNowFailureCollector)
         elif self.tracker_provider == "github":
             return load_and_log(GithubFailureCollector)
+        elif self.tracker_provider == "pagerduty":
+            return load_and_log(PagerdutyFailureCollector)
         else:
             raise ValueError(
                 "unknown tracker {self.tracker_provider}, but should be unreachable because of attrs"

--- a/exporters/failure/collector_github.py
+++ b/exporters/failure/collector_github.py
@@ -25,6 +25,7 @@ from failure.collector_base import AbstractFailureCollector, TrackerIssue
 from pelorus.config import env_var_names, env_vars
 from pelorus.config.converters import comma_or_whitespace_separated
 from pelorus.config.log import REDACT, log
+from pelorus.errors import FailureProviderAuthenticationError
 from pelorus.utils import TokenAuth, set_up_requests_session
 from provider_common.github import parse_datetime
 
@@ -35,17 +36,6 @@ from provider_common.github import parse_datetime
 # TODO Paginate results
 
 DEFAULT_GITHUB_ISSUE_LABEL = "bug"
-
-
-class GithubAuthenticationError(Exception):
-    """
-    Exception raised for authentication issues
-    """
-
-    auth_message = "Check the TOKEN: not authorized, invalid credentials"
-
-    def __init__(self, message=auth_message):
-        super().__init__(message)
 
 
 @define(kw_only=True)
@@ -112,7 +102,7 @@ class GithubFailureCollector(AbstractFailureCollector):
             return resp.json()
         except requests.HTTPError as e:
             if resp.status_code == requests.codes.unauthorized:
-                raise GithubAuthenticationError from e
+                raise FailureProviderAuthenticationError from e
             else:
                 raise
 

--- a/exporters/failure/collector_pagerduty.py
+++ b/exporters/failure/collector_pagerduty.py
@@ -83,7 +83,9 @@ class PagerdutyFailureCollector(AbstractFailureCollector):
             return resp.json()["incidents"]
         except requests.HTTPError as error:
             if resp.status_code == requests.codes.unauthorized:
+                logging.error(FailureProviderAuthenticationError.auth_message)
                 raise FailureProviderAuthenticationError from error
+            logging.error(error)  # pragma: no cover
             raise  # pragma: no cover
 
     def filter_by_urgency(self, urgency: str) -> bool:

--- a/exporters/failure/collector_pagerduty.py
+++ b/exporters/failure/collector_pagerduty.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import logging
+
+import requests
+from attrs import define, field
+
+from failure.collector_base import AbstractFailureCollector, TrackerIssue
+from pelorus.config import env_var_names, env_vars
+from pelorus.config.log import REDACT, log
+from pelorus.errors import FailureProviderAuthenticationError
+from pelorus.timeutil import parse_tz_aware, second_precision
+from pelorus.utils import TokenAuth, set_up_requests_session
+
+DEFAULT_PAGERDUTY_URGENCY = "high"
+DEFAULT_PAGERDUTY_PRIORITY = None  # equivalent to null
+
+_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+@define(kw_only=True)
+class PagerdutyFailureCollector(AbstractFailureCollector):
+    """
+    PagerDuty implementation of a FailureCollector
+    """
+
+    token: str = field(
+        default="",
+        metadata=env_vars(*env_var_names.TOKEN) | log(REDACT),
+        repr=False,
+    )
+
+    tls_verify: bool = field(default=True)
+
+    session: requests.Session = field(factory=requests.Session, init=False)
+
+    incident_urgency: str = field(
+        default=DEFAULT_PAGERDUTY_URGENCY, metadata=env_vars("PAGERDUTY_URGENCY")
+    )
+
+    incident_priority: str = field(
+        default=DEFAULT_PAGERDUTY_PRIORITY, metadata=env_vars("PAGERDUTY_PRIORITY")
+    )
+
+    def __attrs_post_init__(self):
+        # disable .netrc
+        self.session.trust_env = False
+
+        if self.token:
+            set_up_requests_session(
+                self.session,
+                self.tls_verify,
+                auth=TokenAuth(self.token, is_pagerduty=True),
+            )
+
+    def get_incidents(self) -> list[dict]:
+        logging.info("Getting incidents")
+        url = "https://api.pagerduty.com/incidents"
+        headers = {
+            "Accept": "application/vnd.pagerduty+json;version=2",
+        }
+
+        resp = self.session.get(url, headers=headers)
+        try:
+            resp.raise_for_status()
+            # TODO too much noise?
+            logging.debug("PagerDuty successfully returned %s", resp.text)
+            return resp.json()["incidents"]
+        except requests.HTTPError as error:
+            if resp.status_code == requests.codes.unauthorized:
+                raise FailureProviderAuthenticationError from error
+            raise
+
+    def search_issues(self) -> list[TrackerIssue]:
+        """
+        To maintain consistency, we are call this function `search_issues`,
+        but an `issue` in PagerDuty is called `incident`.
+        """
+        production_incidents = []
+        all_incidents = self.get_incidents()
+        if not all_incidents:
+            logging.debug("No issues were found")
+            return production_incidents
+        for incident in all_incidents:
+            is_production_bug = (
+                incident["urgency"] == self.incident_urgency
+                and incident["priority"] == self.incident_priority
+            )
+
+            if is_production_bug:
+                created_at = incident["created_at"]
+                resolved_at = incident["last_status_change_at"]
+                incident_id = incident["incident_number"]
+                title = incident["title"]
+
+                created_tz = parse_tz_aware(created_at, _DATETIME_FORMAT)
+                created_ts = second_precision(created_tz).timestamp()
+
+                resolution_tz = parse_tz_aware(resolved_at, _DATETIME_FORMAT)
+                resolution_ts = second_precision(resolution_tz).timestamp()
+
+                if resolution_ts > created_ts:
+                    logging.debug(
+                        "Found production incident closed: {}, {}: {}".format(
+                            resolved_at,
+                            incident_id,
+                            title,
+                        )
+                    )
+                else:
+                    logging.debug(
+                        "Found production incident opened: {}, {}: {}".format(
+                            created_at,
+                            incident_id,
+                            title,
+                        )
+                    )
+                    resolution_ts = None
+
+                tracker_issue = TrackerIssue(
+                    str(incident_id),
+                    created_ts,
+                    resolution_ts,
+                    incident["service"]["summary"],
+                )
+                production_incidents.append(tracker_issue)
+        return production_incidents

--- a/exporters/failure/collector_pagerduty.py
+++ b/exporters/failure/collector_pagerduty.py
@@ -72,7 +72,7 @@ class PagerdutyFailureCollector(AbstractFailureCollector):
 
     def get_incidents(self) -> list[dict]:
         logging.info("Getting incidents")
-        url = "https://api.pagerduty.com/incidents?date_range=all"
+        url = "https://api.pagerduty.com/incidents?date_range=all&limit=10000"
         headers = {
             "Accept": "application/vnd.pagerduty+json;version=2",
         }

--- a/exporters/failure/collector_pagerduty.py
+++ b/exporters/failure/collector_pagerduty.py
@@ -72,7 +72,7 @@ class PagerdutyFailureCollector(AbstractFailureCollector):
 
     def get_incidents(self) -> list[dict]:
         logging.info("Getting incidents")
-        url = "https://api.pagerduty.com/incidents"
+        url = "https://api.pagerduty.com/incidents?date_range=all"
         headers = {
             "Accept": "application/vnd.pagerduty+json;version=2",
         }
@@ -147,6 +147,13 @@ class PagerdutyFailureCollector(AbstractFailureCollector):
                     created_ts,
                     resolution_ts,
                     incident["service"]["summary"],
+                    # TODO another thing I thought: we could filter services
+                    # (did not think about a good use case for this) or have a
+                    # map like user inputs pairs of key values, like
+                    #    key1=value1,key2=value2
+                    # and then pelorus will put the app here as the value. Ex.:
+                    # the service is named "Incidents of production" but the app
+                    # is called "todolist", then we could map the incidents to the right app
                 )
                 production_incidents.append(tracker_issue)
         if not production_incidents:

--- a/exporters/failure/collector_pagerduty.py
+++ b/exporters/failure/collector_pagerduty.py
@@ -25,10 +25,10 @@ from pelorus.config import env_var_names, env_vars
 from pelorus.config.converters import comma_or_whitespace_separated
 from pelorus.config.log import REDACT, log
 from pelorus.errors import FailureProviderAuthenticationError
-from pelorus.timeutil import parse_tz_aware, second_precision
+from pelorus.timeutil import parse_assuming_utc, second_precision
 from pelorus.utils import TokenAuth, set_up_requests_session
 
-_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 @define(kw_only=True)
@@ -118,10 +118,10 @@ class PagerdutyFailureCollector(AbstractFailureCollector):
                 incident_id = incident["incident_number"]
                 title = incident["title"]
 
-                created_tz = parse_tz_aware(created_at, _DATETIME_FORMAT)
+                created_tz = parse_assuming_utc(created_at, _DATETIME_FORMAT)
                 created_ts = second_precision(created_tz).timestamp()
 
-                resolution_tz = parse_tz_aware(resolved_at, _DATETIME_FORMAT)
+                resolution_tz = parse_assuming_utc(resolved_at, _DATETIME_FORMAT)
                 resolution_ts = second_precision(resolution_tz).timestamp()
 
                 if resolution_ts > created_ts:

--- a/exporters/pelorus/errors.py
+++ b/exporters/pelorus/errors.py
@@ -1,3 +1,4 @@
+# TODO this can be more generic, used by all exporters
 class FailureProviderAuthenticationError(Exception):
     """
     Exception raised for authentication issues

--- a/exporters/pelorus/errors.py
+++ b/exporters/pelorus/errors.py
@@ -1,0 +1,9 @@
+class FailureProviderAuthenticationError(Exception):
+    """
+    Exception raised for authentication issues
+    """
+
+    auth_message = "Check the TOKEN: not authorized, invalid credentials"
+
+    def __init__(self, message=auth_message):
+        super().__init__(message)

--- a/exporters/pelorus/utils/__init__.py
+++ b/exporters/pelorus/utils/__init__.py
@@ -140,8 +140,8 @@ class TokenAuth(requests.auth.AuthBase):
     Add token authentication to a requests Request or Session.
     """
 
-    def __init__(self, token: str):
-        self.auth_str = f"token {token}"
+    def __init__(self, token: str, is_pagerduty: bool = False):
+        self.auth_str = f"Token token={token}" if is_pagerduty else f"token {token}"
 
     def __call__(self, r: requests.PreparedRequest):
         r.headers["Authorization"] = self.auth_str

--- a/exporters/tests/__init__.py
+++ b/exporters/tests/__init__.py
@@ -1,0 +1,10 @@
+from prometheus_client.core import REGISTRY
+
+from pelorus import AbstractPelorusExporter
+
+
+def run_prometheus_register(collector: AbstractPelorusExporter) -> None:
+    try:
+        REGISTRY.register(collector)
+    finally:
+        REGISTRY.unregister(collector)

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright Red Hat
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -24,13 +22,13 @@ from unittest import mock  # NOQA
 import pytest
 from jira.exceptions import JIRAError
 from jira.resources import Issue
-from prometheus_client.core import REGISTRY
 
 from failure import collector_jira
 from failure.collector_github import GithubFailureCollector
 from failure.collector_jira import DEFAULT_JQL_SEARCH_QUERY, JiraFailureCollector
 from pelorus.config import load_and_log
 from pelorus.errors import FailureProviderAuthenticationError
+from tests import run_prometheus_register
 
 JIRA_SERVER = "https://pelorustest.atlassian.net"
 JIRA_USERNAME = os.environ.get("JIRA_USERNAME")
@@ -198,7 +196,10 @@ def test_jira_prometheus_register(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(JiraFailureCollector, "search_issues", mock_search_issues)
     collector = setup_jira_collector()
 
-    REGISTRY.register(collector)  # type: ignore
+    with nullcontext() as context:
+        run_prometheus_register(collector)
+
+    assert context is None
 
 
 def test_jira_exception_is_not_raised(monkeypatch: pytest.MonkeyPatch):
@@ -263,7 +264,11 @@ def test_github_prometheus_register(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(GithubFailureCollector, "search_issues", mock_search_issues)
     collector = setup_github_collector(monkeypatch)
-    REGISTRY.register(collector)  # type: ignore
+
+    with nullcontext() as context:
+        run_prometheus_register(collector)
+
+    assert context is None
 
 
 # has label bug and app_label

--- a/exporters/tests/test_failure_exporter.py
+++ b/exporters/tests/test_failure_exporter.py
@@ -27,9 +27,10 @@ from jira.resources import Issue
 from prometheus_client.core import REGISTRY
 
 from failure import collector_jira
-from failure.collector_github import GithubAuthenticationError, GithubFailureCollector
+from failure.collector_github import GithubFailureCollector
 from failure.collector_jira import DEFAULT_JQL_SEARCH_QUERY, JiraFailureCollector
 from pelorus.config import load_and_log
+from pelorus.errors import FailureProviderAuthenticationError
 
 JIRA_SERVER = "https://pelorustest.atlassian.net"
 JIRA_USERNAME = os.environ.get("JIRA_USERNAME")
@@ -249,7 +250,7 @@ def get_test_data(file="/exporters/tests/data/github_issue.json"):
 
 @pytest.mark.integration
 def test_github_connection():
-    with pytest.raises(GithubAuthenticationError) as context_ex:
+    with pytest.raises(FailureProviderAuthenticationError) as context_ex:
         setup_github_collector()
     assert "Check the TOKEN: not authorized, invalid credentials" in str(
         context_ex.value

--- a/exporters/tests/test_failure_exporter_app.py
+++ b/exporters/tests/test_failure_exporter_app.py
@@ -1,0 +1,72 @@
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import os
+from pathlib import Path
+from runpy import run_path
+from typing import Dict
+
+from failure.app import __file__ as app_file
+
+# import pytest
+
+
+# from pelorus.errors import FailureProviderAuthenticationError
+
+APP = Path(app_file).resolve().as_posix()
+PAGER_DUTY_TOKEN = os.environ.get("PAGER_DUTY_TOKEN")
+
+
+# TODO fix this end 2 end tests
+def run_app(arguments: Dict[str, str]) -> None:
+    """Run failure app object with desired enviroment variables."""
+    try:
+        for key, value in arguments.items():
+            os.environ[key] = value
+        run_path(APP, run_name="__main__")
+    finally:
+        for key in arguments:
+            del os.environ[key]
+
+
+# @pytest.mark.parametrize("provider", ["wrong", "git_hub", "GITHUB", "GitHub"])
+# @pytest.mark.integration
+# def test_app_invalid_provider(provider: str):
+#     with pytest.raises(ValueError) as error:
+#         run_app({"PROVIDER": provider})
+
+#     assert "'tracker_provider' must be in dict_keys" in str(error.value)
+
+
+# @pytest.mark.integration
+# def test_app_pagerduty_error():
+#     with pytest.raises(FailureProviderAuthenticationError) as auth_error:
+#         run_app({"PROVIDER": "pagerduty"})
+
+#     assert "Check the TOKEN: not authorized, invalid credentials" in str(
+#         auth_error.value
+#     )
+
+
+# @pytest.mark.integration
+# @pytest.mark.skipif(
+#     not PAGER_DUTY_TOKEN,
+#     reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+# )
+# def test_app_pagerduty_success():
+#     with nullcontext() as context:
+#         run_app({"PROVIDER": "pagerduty", "TOKEN": PAGER_DUTY_TOKEN})
+
+#     assert context is None

--- a/exporters/tests/test_failure_exporter_pager_duty.py
+++ b/exporters/tests/test_failure_exporter_pager_duty.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+#
+# Copyright Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+import os
+from contextlib import nullcontext
+from typing import Optional
+
+import pytest
+from prometheus_client.core import REGISTRY
+
+from failure.collector_pagerduty import PagerdutyFailureCollector
+from pelorus.errors import FailureProviderAuthenticationError
+
+PAGER_DUTY_TOKEN = os.environ.get("PAGER_DUTY_TOKEN")
+
+
+def setup_pager_duty_collector(
+    token: str = "fake_token",
+    incident_urgency: Optional[str] = None,
+    incident_priority: Optional[str] = None,
+) -> PagerdutyFailureCollector:
+    return PagerdutyFailureCollector(
+        token=token,
+        incident_urgency=incident_urgency,
+        incident_priority=incident_priority,
+    )
+
+
+@pytest.mark.integration
+def test_pager_duty_connection():
+    collector = setup_pager_duty_collector()
+    with pytest.raises(FailureProviderAuthenticationError) as auth_error:
+        collector.search_issues()
+    assert "Check the TOKEN: not authorized, invalid credentials" in str(
+        auth_error.value
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search():
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 7
+    assert len([issue for issue in issues if issue.resolutiondate is None]) == 2
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_multiple_filters():
+    collector = setup_pager_duty_collector(
+        PAGER_DUTY_TOKEN, incident_urgency="low,high", incident_priority="null,P3"
+    )
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 6
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_priority_null():
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN, incident_priority="null")
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 6
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_priority_p1():
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN, incident_priority="P1")
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 1
+
+
+@pytest.mark.parametrize("priority", ["P2", "P3", "P4", "P5"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_priority(priority: str):
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN, incident_priority=priority)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 0
+
+
+@pytest.mark.parametrize("priority", ["wrong", "not_available"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_wrong_priority(priority: str):
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN, incident_priority=priority)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 0
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_urgency_low():
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN, incident_urgency="low")
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_urgency_high():
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN, incident_urgency="high")
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 6
+
+
+@pytest.mark.parametrize("urgency", ["wrong", "not_available"])
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not PAGER_DUTY_TOKEN,
+    reason="No PagerDuty token set, run export PAGER_DUTY_TOKEN=token",
+)
+def test_pager_duty_search_with_wrong_urgency(urgency: str):
+    collector = setup_pager_duty_collector(PAGER_DUTY_TOKEN, incident_urgency=urgency)
+
+    with nullcontext() as context:
+        issues = collector.search_issues()
+
+    assert context is None
+    assert len(issues) == 0
+
+
+def test_pager_duty_prometheus_register(monkeypatch: pytest.MonkeyPatch):
+    def mock_search_issues(self):
+        return []
+
+    monkeypatch.setattr(PagerdutyFailureCollector, "search_issues", mock_search_issues)
+    collector = setup_pager_duty_collector()
+
+    REGISTRY.register(collector)

--- a/exporters/tests/test_failure_exporter_pager_duty.py
+++ b/exporters/tests/test_failure_exporter_pager_duty.py
@@ -62,8 +62,9 @@ def test_pager_duty_search():
         issues = collector.search_issues()
 
     assert context is None
-    assert len(issues) == 7
-    assert len([issue for issue in issues if issue.resolutiondate is None]) == 2
+    assert len(issues) == 57
+    assert len([issue for issue in issues if issue.resolutiondate is None]) == 52
+    assert len([issue for issue in issues if issue.resolutiondate]) == 5
 
 
 @pytest.mark.integration
@@ -73,14 +74,14 @@ def test_pager_duty_search():
 )
 def test_pager_duty_search_with_multiple_filters():
     collector = setup_pager_duty_collector(
-        PAGER_DUTY_TOKEN, incident_urgency="low,high", incident_priority="null,P3"
+        PAGER_DUTY_TOKEN, incident_urgency="low,high", incident_priority="P1,P3"
     )
 
     with nullcontext() as context:
         issues = collector.search_issues()
 
     assert context is None
-    assert len(issues) == 6
+    assert len(issues) == 16
 
 
 @pytest.mark.integration
@@ -95,7 +96,7 @@ def test_pager_duty_search_with_priority_null():
         issues = collector.search_issues()
 
     assert context is None
-    assert len(issues) == 6
+    assert len(issues) == 41
 
 
 @pytest.mark.integration
@@ -110,7 +111,7 @@ def test_pager_duty_search_with_priority_p1():
         issues = collector.search_issues()
 
     assert context is None
-    assert len(issues) == 1
+    assert len(issues) == 16
 
 
 @pytest.mark.parametrize("priority", ["P2", "P3", "P4", "P5"])
@@ -157,7 +158,7 @@ def test_pager_duty_search_with_urgency_low():
         issues = collector.search_issues()
 
     assert context is None
-    assert len(issues) == 1
+    assert len(issues) == 11
 
 
 @pytest.mark.integration
@@ -172,7 +173,7 @@ def test_pager_duty_search_with_urgency_high():
         issues = collector.search_issues()
 
     assert context is None
-    assert len(issues) == 6
+    assert len(issues) == 46
 
 
 @pytest.mark.parametrize("urgency", ["wrong", "not_available"])


### PR DESCRIPTION
Signed-off-by: Mateus Oliveira <msouzaol@redhat.com>

## Describe the behavior changes introduced in this PR

Add PagerDuty Failure Exporter to Pelorus.

| Variable | Required | Default Value |
|----------|----------|---------------|
| PROVIDER | yes | `pagerduty` |
| LOG_LEVEL | no | `INFO` |
| SERVER (tracker_api) | NOT USED | - |
| API_USER | NOT USED | - |
| TOKEN | yes | get it at `https://your_subdomain.pagerduty.com/api_keys` (Integration -> API Access Keys) |
| APP_LABEL | NOT USED | `app.kubernetes.io/name` |
| PROJECTS | NOT USED | - |
| PELORUS_DEFAULT_KEYWORD | no | `default` |
| PAGERDUTY_URGENCY | no | - |
| PAGERDUTY_PRIORITY | no | - |

**TODO write tests and docs:**
- [x] create PagerDuty account and subdomains for Pelorus tests (and add maintainers there)
- [x] think about use cases: is there some similar to projects in PagerDuty? (accessing 2 or more subdomains, for example) ANSWER: NO
- [x] write/update documentation for failure exporter in docs folder (add configuring PagerDuty section)
- [x] add PagerDuty logo to docs index and to the list of supported providers

## Linked Issues

Ensure the requirements items in here were fulfilled https://github.com/orgs/konveyor/projects/51/views/2?pane=issue&itemId=20613492

Resolves #848 

## Testing Instructions

To test PagerDuty API, run
```
curl --request GET \
--url https://api.pagerduty.com/incidents \
--header 'Accept: application/vnd.pagerduty+json;version=2' \
--header 'Authorization: Token token=your_token' \
--header 'Content-Type: application/json' | jq
```
[More details about the response](https://developer.pagerduty.com/api-reference/9d0b4b12e36f9-list-incidents).

we care about the following data
```yaml
"created_at": "2023-02-08T16:57:09Z", # Used for creation timestamp
"status": "triggered", # triggered, acknowledged, resolved;  used to check if it is resolved
"last_status_change_at": "2023-02-08T17:29:24Z", # Used for resolution timestamp
"priority": null, # null, P1, P2, P3, P4, P5 (objects {}); used as filter
"urgency": "high", # high, low; used as filter
"service": {"summary": "string"} # Used as label, to match which app the issue is related to
```

To test the python code, add this code to the end of `exporters/failure/collector_pagerduty.py` file
```python
if __name__ == "__main__":
    logging.getLogger().setLevel(logging.DEBUG)
    pager_duty = PagerdutyFailureCollector(token="your_token")
    pager_duty.search_issues()
```
and run
```
python exporters/failure/collector_pagerduty.py
```
