### PR TITLE
Updated release of the Pelorus with it's pelorus-operator.

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.4
+version: 2.0.6

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.5
+version: 2.0.6
 
 dependencies:
   - name: exporters
-    version: "v2.0.5"
+    version: "v2.0.6"
     repository: file://./subcharts/exporters

--- a/charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.5
+version: 2.0.6

--- a/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.4" }}
+      ref: {{ .source_ref | default "v2.0.6" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,13 +20,13 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "stable" }}
+      name: {{ .image_name }}:{{ .image_tag | default "2.0.6" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "stable" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.6" }}
 # .image_name
 {{- end }}
-    name: {{ .image_tag | default "stable" }}
+    name: {{ .image_tag | default "2.0.6" }}
     referencePolicy:
       type: Local
 # define

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -154,7 +154,7 @@ If not defined specifically, exporters are using pre-built container images with
 
 Each Pelorus GitHub pull request that is [merged](https://github.com/konveyor/pelorus/pulls?q=is%3Apr+is%3Amerged) results in a new set of images that are tagged with the GitHub commit hash, for example `d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31` for the following [Pull Request](https://github.com/konveyor/pelorus/commit/d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31). The newest merged commit results in additional image tag `latest`.
 
-Each new Pelorus [release](https://github.com/konveyor/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v1.7.1`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
+Each new Pelorus [release](https://github.com/konveyor/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.6`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
 
 During Pelorus Helm deployment or update time user have option to specify the image tag for each exporter instance individually. Example below shows two different tags for the commit time exporter and two tags for the failure exporter.
 
@@ -190,7 +190,7 @@ exporters:
 
   - app_name: jira-failure-exporter
     exporter_type: failure
-    image_tag: v1.7.1 # Specific release
+    image_tag: v2.0.6 # Specific release
     env_from_secrets:
     - jira-credentials
     env_from_configmaps:

--- a/pelorus-operator/Dockerfile
+++ b/pelorus-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.26.0
+FROM quay.io/operator-framework/helm-operator:v1.26.1
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.2
+VERSION ?= 0.0.3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -146,7 +146,7 @@ ifeq (,$(shell which helm-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(HELM_OPERATOR)) ;\
-	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.26.0/helm-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.26.1/helm-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(HELM_OPERATOR) ;\
 	}
 else

--- a/pelorus-operator/bundle.Dockerfile
+++ b/pelorus-operator/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=pelorus-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.26.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.26.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
 

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -12,7 +12,6 @@ metadata:
           },
           "spec": {
             "exporters": {
-              "global": {},
               "instances": [
                 {
                   "app_name": "deploytime-exporter",
@@ -50,16 +49,16 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.2
-    createdAt: "2023-01-18T18:25:19Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.3
+    createdAt: "2023-02-21T13:31:48Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
-    operators.operatorframework.io/builder: operator-sdk-v1.26.0
+    operators.operatorframework.io/builder: operator-sdk-v1.26.1
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/konveyor/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.2
+  name: pelorus-operator.v0.0.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -153,62 +152,39 @@ spec:
           - update
           - watch
         - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          - clusterroles
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - '*'
-        - apiGroups:
-          - integreatly.org
-          resources:
-          - grafanadashboards
-          - grafanadatasources
-          - grafanas
-          verbs:
-          - '*'
-        - apiGroups:
-          - image.openshift.io
-          resources:
-          - imagestreams
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - prometheuses
-          - prometheusrules
-          - servicemonitors
-          verbs:
-          - '*'
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - '*'
-        - apiGroups:
           - ""
           resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
           - configmaps
           - secrets
-          - serviceaccounts
-          - services
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
-          - rbac.authorization.k8s.io
+          - apps
           resources:
-          - rolebindings
-          - roles
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - operators.coreos.com
           resources:
@@ -358,7 +334,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.2
+                image: quay.io/pelorus/pelorus-operator:0.0.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -460,7 +436,8 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.2
-  replaces: pelorus-operator.v0.0.1
+  version: 0.0.3
+  replaces: pelorus-operator.v0.0.2
   skips:
+    - pelorus-operator.v0.0.2
     - pelorus-operator.v0.0.1

--- a/pelorus-operator/bundle/metadata/annotations.yaml
+++ b/pelorus-operator/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: pelorus-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.26.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.26.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
 

--- a/pelorus-operator/bundle/tests/scorecard/config.yaml
+++ b/pelorus-operator/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.2
+  newTag: 0.0.3

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.2
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.3
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -45,62 +45,39 @@ rules:
   - patch
   - update
   - watch
-- verbs:
-  - "*"
-  apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  - "clusterrolebindings"
-  - "clusterroles"
-- verbs:
-  - "*"
-  apiGroups:
-  - "apps.openshift.io"
-  resources:
-  - "deploymentconfigs"
-- verbs:
-  - "*"
-  apiGroups:
-  - "integreatly.org"
-  resources:
-  - "grafanadashboards"
-  - "grafanadatasources"
-  - "grafanas"
-- verbs:
-  - "*"
-  apiGroups:
-  - "image.openshift.io"
-  resources:
-  - "imagestreams"
-- verbs:
-  - "*"
-  apiGroups:
-  - "monitoring.coreos.com"
-  resources:
-  - "prometheuses"
-  - "prometheusrules"
-  - "servicemonitors"
-- verbs:
-  - "*"
-  apiGroups:
-  - "route.openshift.io"
-  resources:
-  - "routes"
-- verbs:
-  - "*"
-  apiGroups:
+- apiGroups:
   - ""
   resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
-- verbs:
-  - "*"
-  apiGroups:
-  - "rbac.authorization.k8s.io"
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
   resources:
-  - "rolebindings"
-  - "roles"
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
+++ b/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   # Default values copied from <project_dir>/helm-charts/pelorus/values.yaml
   exporters:
-    global: {}
     instances:
     - app_name: deploytime-exporter
       exporter_type: deploytime

--- a/pelorus-operator/config/scorecard/patches/basic.config.yaml
+++ b/pelorus-operator/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/pelorus-operator/config/scorecard/patches/olm.config.yaml
+++ b/pelorus-operator/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    image: quay.io/operator-framework/scorecard-test:v1.26.1
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: 2.0.4
-digest: sha256:76d6f1ef53a7d8586a7d04dac9932b82460dcf135e48901741f510b401b906c3
-generated: "2023-01-18T19:25:13.200901467+01:00"
+  version: 2.0.6
+digest: sha256:ffda57f2fffbfe9bffc6c184b3ca9d96f4d95a1c721dab6ea1fa7e44b66185df
+generated: "2023-02-21T14:31:44.600107749+01:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: v2.0.4
+  version: v2.0.6
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.4
+version: 2.0.6

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.4
+version: 2.0.6

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.4" }}
+      ref: {{ .source_ref | default "v2.0.6" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,13 +20,13 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "stable" }}
+      name: {{ .image_name }}:{{ .image_tag | default "2.0.6" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "stable" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.6" }}
 # .image_name
 {{- end }}
-    name: {{ .image_tag | default "stable" }}
+    name: {{ .image_tag | default "2.0.6" }}
     referencePolicy:
       type: Local
 # define

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/default_configmaps.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/default_configmaps.yaml
@@ -1,7 +1,7 @@
 # These configmaps are not meant to be edited directly.
 # To configure pelorus, you can create your own copies of these.
 # See the documentation for details:
-# https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters
+# https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusExporters/#env_from_configmaps
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/scripts/create_release_pr
+++ b/scripts/create_release_pr
@@ -33,9 +33,11 @@
 # Required to get the latest released tag
 PELORUS_API_URL="https://api.github.com/repos/konveyor/pelorus/releases/latest"
 BUILDCONFIG_PATH="charts/pelorus/charts/exporters/templates/_buildconfig.yaml"
+IMAGESTREAM_PATH="charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml"
 PELORUS_CHART="charts/pelorus/Chart.yaml"
 PELORUS_EXPORTERS_CHART="charts/pelorus/subcharts/exporters/Chart.yaml"
 OPERATORS_CHART="charts/operators/Chart.yaml"
+CHART_LOCK_FILE="charts/pelorus/Chart.lock"
 
 INSTALL_DOC="docs/Development.md"
 
@@ -49,61 +51,69 @@ function print_help() {
     printf "\n\tOptions:\n"
     printf "\t  -m\tbump major version (minor and patch will start at 0)\n"
     printf "\t  -i\tbump minor version (patch will start at 0)\n"
-    printf "\nExample: %s -v 1.6.14\n\n" "$0"
+    printf "\t  -v\tuse exact version\n"
+    printf "\nExample: %s -v 2.0.5\n\n" "$0"
 
     exit 0
 }
 
 ### Options
 OPTIND=1
-while getopts "h?mi" option; do
+while getopts "h?miv:" option; do
     case "$option" in
     h|\?) print_help;;
     m) major="$TRUE";;
     i) minor="$TRUE";;
+    v) exact_ver=$OPTARG;;
     esac
 done
+
+UPDATE_CHART_VERSIONS="$FALSE"
 
 if [[ $minor && $major ]]; then
     echo "-m and -i flags can not be used together"
     exit 2
 fi
 
-UPDATE_CHART_VERSIONS="$FALSE"
-LAST_RELEASED_TAG=$(curl -s "$PELORUS_API_URL" | jq -r '.tag_name')
+if [ -z ${exact_ver+x} ]; then
+  LAST_RELEASED_TAG=$(curl -s "$PELORUS_API_URL" | jq -r '.tag_name')
+  # shellcheck disable=SC2207
+  V_RELEASED=( $(echo "$LAST_RELEASED_TAG" | sed 's/v//g'  | tr ' . '  '  ') )
+  V_MAJOR=${V_RELEASED[0]}
+  V_MINOR=${V_RELEASED[1]}
+  V_PATCH=${V_RELEASED[2]}
 
-# shellcheck disable=SC2207
-V_RELEASED=( $(echo "$LAST_RELEASED_TAG" | sed 's/v//g'  | tr ' . '  '  ') )
-V_MAJOR=${V_RELEASED[0]}
-V_MINOR=${V_RELEASED[1]}
-V_PATCH=${V_RELEASED[2]}
-
-echo "Current version: $LAST_RELEASED_TAG"
-if [[ $major ]]; then
-  V_MAJOR=$(( V_MAJOR +  1 ))
-  V_MINOR="0"
-  V_PATCH="0"
-  UPDATE_CHART_VERSIONS="$TRUE"
-elif [[ $minor ]]; then
-  V_MINOR=$(( V_MINOR +  1 ))
-  V_PATCH="0"
-  UPDATE_CHART_VERSIONS="$TRUE"
+  echo "Current version: $LAST_RELEASED_TAG"
+  if [[ $major ]]; then
+    V_MAJOR=$(( V_MAJOR +  1 ))
+    V_MINOR="0"
+    V_PATCH="0"
+    UPDATE_CHART_VERSIONS="$TRUE"
+  elif [[ $minor ]]; then
+    V_MINOR=$(( V_MINOR +  1 ))
+    V_PATCH="0"
+    UPDATE_CHART_VERSIONS="$TRUE"
+  else
+    V_PATCH=$(( V_PATCH +  1 ))
+  fi
+  SEMVER="$V_MAJOR.$V_MINOR.$V_PATCH"
 else
-  V_PATCH=$(( V_PATCH +  1 ))
+  UPDATE_CHART_VERSIONS="$TRUE"
+  SEMVER="$exact_ver"
 fi
-
-NEW_VER="v$V_MAJOR.$V_MINOR.$V_PATCH"
-echo "Version to be released: v$V_MAJOR.$V_MINOR.$V_PATCH"
+echo "Version to be released: v$SEMVER"
+NEW_VER="v$SEMVER"
 
 # Sed to inject version between the quotes in the line containing:
 # .source_ref | default=""
 sed -i "/.source_ref | default/s/\"[^\"][^\"]*\"/\"$NEW_VER\"/" "$BUILDCONFIG_PATH"
 
 if [[ $UPDATE_CHART_VERSIONS == "$TRUE" ]]; then
-  sed -i "s/^version:.*/version: $V_MAJOR.$V_MINOR.$V_PATCH/g" "$PELORUS_CHART"
-  sed -i "s/^    version:.*/    version: \"v$V_MAJOR.$V_MINOR.$V_PATCH\"/g" "$PELORUS_CHART"
-  sed -i "s/^version:.*/version: $V_MAJOR.$V_MINOR.$V_PATCH/g" "$OPERATORS_CHART"
-  sed -i "s/^version:.*/version: $V_MAJOR.$V_MINOR.$V_PATCH/g" "$PELORUS_EXPORTERS_CHART"
+  sed -i "s/^version:.*/version: $SEMVER/g" "$PELORUS_CHART"
+  sed -i "s/^    version:.*/    version: \"v$SEMVER\"/g" "$PELORUS_CHART"
+  sed -i "s/^version:.*/version: $SEMVER/g" "$OPERATORS_CHART"
+  sed -i "s/^version:.*/version: $SEMVER/g" "$PELORUS_EXPORTERS_CHART"
+  sed -i "s/\({{ \.image_tag \| default \)\"[^\"]*\"\( \)\?/\1\"$SEMVER\"\2/g" "$IMAGESTREAM_PATH"
 else
   # Bump the "Z" in the pelorus Chart.yaml
   CHART_VER=$( grep ^version: "$PELORUS_CHART"|awk -F' ' '{ print $2 }' )
@@ -112,12 +122,16 @@ else
 fi
 
 # Update branch in the Development documentation
-sed -i "s/\(release number, for example \`\).*\(\`\.\)/\1v$V_MAJOR.$V_MINOR.$V_PATCH\2/g" "$INSTALL_DOC"
-sed -i "s/\(image_tag: \).*\( # Specific release\)/\1v$V_MAJOR.$V_MINOR.$V_PATCH\2/g" "$INSTALL_DOC"
+sed -i "s/\(release number, for example \`\).*\(\`\.\)/\1v$SEMVER\2/g" "$INSTALL_DOC"
+sed -i "s/\(image_tag: \).*\( # Specific release\)/\1v$SEMVER\2/g" "$INSTALL_DOC"
 
+# Remove chart lock file
+rm -f "${CHART_LOCK_FILE}"
 
 if [[ $major ]]; then
   printf "\nIMPORTANT:\n\t Do include \"major release\" text in the first line of your commit message, or label your PR with: \"major\"\n\n"
 elif [[ $minor ]]; then
   printf "\nIMPORTANT:\n\t Do include \"minor release\" text in the first line of your commit message, or label your PR with: \"minor\"\n\n"
+else
+  printf "\nIMPORTANT:\n\t If it's minor or major version change do include \"minor release\" or \"major release\" text in the first line of your commit message, or label your PR with: \"minor\" or \"major\" \n\n"
 fi


### PR DESCRIPTION
This is a new release 2.0.6 of the Pelorus with it's corresponding pelorus-operator version 0.0.3.

## Describe the behavior changes introduced in this PR

This is just a source for the new release created using the following three calls:

```shell
$ ./scripts/create_release_pr -v 2.0.6
$ rm -rf pelorus-operator && mkdir pelorus-operator
$ ./scripts/create_pelorus_operator
```
This does not automatically create two container images required by the pelorus-operator:

```
quay.io/pelorus/pelorus-operator
quay.io/pelorus/pelorus-operator-bundle
```

To create those, log in to the quay.io account and then:

```shell
$ cd pelorus-operator/
$ make podman-build
$ make bundle-build
$ make podman-push
$ make bundle-push 
```


@redhat-cop/mdt
