### PR TITLE
New release of Pelorus with new pelorus operator to fix #849

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.6
+version: 2.0.7

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.6
+version: 2.0.7
 
 dependencies:
   - name: exporters
-    version: "v2.0.6"
+    version: "v2.0.7"
     repository: file://./subcharts/exporters

--- a/charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.6
+version: 2.0.7

--- a/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.6" }}
+      ref: {{ .source_ref | default "v2.0.7" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,13 +20,13 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "2.0.6" }}
+      name: {{ .image_name }}:{{ .image_tag | default "2.0.7" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.6" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.7" }}
 # .image_name
 {{- end }}
-    name: {{ .image_tag | default "2.0.6" }}
+    name: {{ .image_tag | default "2.0.7" }}
     referencePolicy:
       type: Local
 # define

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -154,7 +154,7 @@ If not defined specifically, exporters are using pre-built container images with
 
 Each Pelorus GitHub pull request that is [merged](https://github.com/konveyor/pelorus/pulls?q=is%3Apr+is%3Amerged) results in a new set of images that are tagged with the GitHub commit hash, for example `d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31` for the following [Pull Request](https://github.com/konveyor/pelorus/commit/d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31). The newest merged commit results in additional image tag `latest`.
 
-Each new Pelorus [release](https://github.com/konveyor/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.6`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
+Each new Pelorus [release](https://github.com/konveyor/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.7`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
 
 During Pelorus Helm deployment or update time user have option to specify the image tag for each exporter instance individually. Example below shows two different tags for the commit time exporter and two tags for the failure exporter.
 
@@ -190,7 +190,7 @@ exporters:
 
   - app_name: jira-failure-exporter
     exporter_type: failure
-    image_tag: v2.0.6 # Specific release
+    image_tag: v2.0.7 # Specific release
     env_from_secrets:
     - jira-credentials
     env_from_configmaps:

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.3
+VERSION ?= 0.0.4
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -12,6 +12,7 @@ metadata:
           },
           "spec": {
             "exporters": {
+              "global": {},
               "instances": [
                 {
                   "app_name": "deploytime-exporter",
@@ -49,8 +50,8 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.3
-    createdAt: "2023-02-21T13:31:48Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.4
+    createdAt: "2023-03-02T13:39:53Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -58,7 +59,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/konveyor/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.3
+  name: pelorus-operator.v0.0.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -152,39 +153,62 @@ spec:
           - update
           - watch
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          - grafanadatasources
+          - grafanas
+          verbs:
+          - '*'
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheuses
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
           - ""
           resources:
-          - pods
-          - services
-          - services/finalizers
-          - endpoints
-          - persistentvolumeclaims
-          - events
           - configmaps
           - secrets
+          - serviceaccounts
+          - services
           verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
+          - '*'
         - apiGroups:
           - operators.coreos.com
           resources:
@@ -334,7 +358,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.3
+                image: quay.io/pelorus/pelorus-operator:0.0.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -436,8 +460,9 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.3
-  replaces: pelorus-operator.v0.0.2
+  version: 0.0.4
+  replaces: pelorus-operator.v0.0.3
   skips:
+    - pelorus-operator.v0.0.3
     - pelorus-operator.v0.0.2
     - pelorus-operator.v0.0.1

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.3
+  newTag: 0.0.4

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.3
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.4
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -45,39 +45,62 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
+- verbs:
+  - "*"
+  apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "clusterrolebindings"
+  - "clusterroles"
+- verbs:
+  - "*"
+  apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "rolebindings"
+  - "roles"
+- verbs:
+  - "*"
+  apiGroups:
+  - "apps.openshift.io"
+  resources:
+  - "deploymentconfigs"
+- verbs:
+  - "*"
+  apiGroups:
+  - "integreatly.org"
+  resources:
+  - "grafanadashboards"
+  - "grafanadatasources"
+  - "grafanas"
+- verbs:
+  - "*"
+  apiGroups:
+  - "image.openshift.io"
+  resources:
+  - "imagestreams"
+- verbs:
+  - "*"
+  apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - "prometheuses"
+  - "prometheusrules"
+  - "servicemonitors"
+- verbs:
+  - "*"
+  apiGroups:
+  - "route.openshift.io"
+  resources:
+  - "routes"
+- verbs:
+  - "*"
+  apiGroups:
   - ""
   resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
+++ b/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   # Default values copied from <project_dir>/helm-charts/pelorus/values.yaml
   exporters:
+    global: {}
     instances:
     - app_name: deploytime-exporter
       exporter_type: deploytime

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: 2.0.6
-digest: sha256:ffda57f2fffbfe9bffc6c184b3ca9d96f4d95a1c721dab6ea1fa7e44b66185df
-generated: "2023-02-21T14:31:44.600107749+01:00"
+  version: 2.0.7
+digest: sha256:f613fb665d4f9b0d17119698eada144f11dd85bf498197b5ad587bcbafaebdbe
+generated: "2023-03-02T14:39:47.359886943+01:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: v2.0.6
+  version: v2.0.7
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.6
+version: 2.0.7

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.6
+version: 2.0.7

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.6" }}
+      ref: {{ .source_ref | default "v2.0.7" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,13 +20,13 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "2.0.6" }}
+      name: {{ .image_name }}:{{ .image_tag | default "2.0.7" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.6" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.7" }}
 # .image_name
 {{- end }}
-    name: {{ .image_tag | default "2.0.6" }}
+    name: {{ .image_tag | default "2.0.7" }}
     referencePolicy:
       type: Local
 # define


### PR DESCRIPTION
Current version of pelorus-operator 0.0.3 is broken, we need to create new release 0.0.4 to fix the issue as in the #849.

Needed by #849 

Fix for the #849 requires creating new release in the openshift marketplace.

@redhat-cop/mdt
