### PR TITLE
Fix for broken RBAC in the pelorus-operator 0.0.3

### DIFF
--- a/charts/pelorus/subcharts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "stable" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.7" }}
             {{- end }}
 
             {{- if .extraEnv }}
@@ -90,6 +90,8 @@ spec:
         {{- if or .source_ref .source_url }}
         name: {{ .app_name }}:latest
         {{- else }}
+        # default is an internal registry tag and must match the default from
+        # _imagestream_from_image.yaml
         name: {{ .app_name }}:{{ .image_tag | default "stable" }}
         {{- end }}
     type: ImageChange

--- a/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,13 +20,13 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "2.0.7" }}
+      name: {{ .image_name }}:{{ .image_tag | default "v2.0.7" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.7" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.7" }}
 # .image_name
 {{- end }}
-    name: {{ .image_tag | default "2.0.7" }}
+    name: {{ .image_tag | default "stable" }}
     referencePolicy:
       type: Local
 # define

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -51,7 +51,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.4
-    createdAt: "2023-03-02T13:39:53Z"
+    createdAt: "2023-03-02T21:50:29Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -160,6 +160,15 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - rolebindings
@@ -198,15 +207,6 @@ spec:
           - route.openshift.io
           resources:
           - routes
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - services
           verbs:
           - '*'
         - apiGroups:

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,15 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
+- verbs:
+  - "*"
+  apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - "rolebindings"
@@ -93,14 +102,5 @@ rules:
   - "route.openshift.io"
   resources:
   - "routes"
-- verbs:
-  - "*"
-  apiGroups:
-  - ""
-  resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./subcharts/exporters
   version: 2.0.7
 digest: sha256:f613fb665d4f9b0d17119698eada144f11dd85bf498197b5ad587bcbafaebdbe
-generated: "2023-03-02T14:39:47.359886943+01:00"
+generated: "2023-03-02T22:50:23.529649522+01:00"

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_deploymentconfig.yaml
@@ -60,7 +60,7 @@ spec:
 
             {{- if and (not .source_ref) (not .source_url) }}
             - name: PELORUS_IMAGE_TAG
-              value: {{ .app_name }}:{{ .image_tag | default "stable" }}
+              value: {{ .app_name }}:{{ .image_tag | default "v2.0.7" }}
             {{- end }}
 
             {{- if .extraEnv }}
@@ -90,6 +90,8 @@ spec:
         {{- if or .source_ref .source_url }}
         name: {{ .app_name }}:latest
         {{- else }}
+        # default is an internal registry tag and must match the default from
+        # _imagestream_from_image.yaml
         name: {{ .app_name }}:{{ .image_tag | default "stable" }}
         {{- end }}
     type: ImageChange

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,13 +20,13 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "2.0.7" }}
+      name: {{ .image_name }}:{{ .image_tag | default "v2.0.7" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "2.0.7" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.7" }}
 # .image_name
 {{- end }}
-    name: {{ .image_tag | default "2.0.7" }}
+    name: {{ .image_tag | default "stable" }}
     referencePolicy:
       type: Local
 # define


### PR DESCRIPTION
This fixes RBAC issues with the pelorus-operator 0.0.3.

There was another issue with the image tags within the image stream created for each individual exporter, which should be fixed by this PR.

No need to create new Release as the pelorus-operator and pelrus-bundle may be created without new github release.

## Testing Instructions

1. Create new pelorus namespace
2. make sure you activated venv of pelorus project (master should do)
3. Run `operator-sdk run bundle quay.io/pelorus/pelorus-operator-bundle:v0.0.4`
4. Create instance of the pelorus operator

@redhat-cop/mdt
