### PR TITLE
Add GitHub Actions to build the webhook exporter

### DIFF
--- a/.github/workflows/build-pelorus.yml
+++ b/.github/workflows/build-pelorus.yml
@@ -131,3 +131,32 @@ jobs:
           registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
+
+  build-webhook:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup S2i and Build container image
+      - name: Setup and Build
+        id: build-exporter
+        uses: redhat-actions/s2i-build@v2
+        with:
+          image: 'pelorus-webhook-exporter'
+          path_context: 'exporters'
+          builder_image: ${{ env.builder_image }}
+          tags: ${{ env.latesttag }} ${{ github.sha }}
+          log_level: ${{ env.s2i_log_level }}
+
+
+      # Push Image to Quay registry
+      - name: Push To Quay Action
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-exporter.outputs.image }}
+          tags: ${{ steps.build-exporter.outputs.tags }}
+          registry: ${{ env.imageregistry }}/${{ env.imagenamespace }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -48,10 +48,20 @@ jobs:
           registry_username: ${{ secrets.QUAY_USERNAME }}
           registry_password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Tag failure with (pre)released version
+      - name: Tag releasetime with (pre)released version
         uses: tinact/docker.image-retag@1.0.3
         with:
           image_name: ${{ env.imagenamespace }}/pelorus-releasetime-exporter
+          image_old_tag: ${{ github.sha }}
+          image_new_tag: ${{ github.event.release.tag_name }}
+          registry: ${{ env.imageregistry }}
+          registry_username: ${{ secrets.QUAY_USERNAME }}
+          registry_password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Tag webhook with (pre)released version
+        uses: tinact/docker.image-retag@1.0.3
+        with:
+          image_name: ${{ env.imagenamespace }}/pelorus-webhook-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ github.event.release.tag_name }}
           registry: ${{ env.imageregistry }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,20 @@ jobs:
           registry_username: ${{ secrets.QUAY_USERNAME }}
           registry_password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Tag failure with released version
+      - name: Tag releasetime with released version
         uses: tinact/docker.image-retag@1.0.3
         with:
           image_name: ${{ env.imagenamespace }}/pelorus-releasetime-exporter
+          image_old_tag: ${{ github.sha }}
+          image_new_tag: ${{ env.releasetag }}
+          registry: ${{ env.imageregistry }}
+          registry_username: ${{ secrets.QUAY_USERNAME }}
+          registry_password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Tag webhook with released version
+        uses: tinact/docker.image-retag@1.0.3
+        with:
+          image_name: ${{ env.imagenamespace }}/pelorus-webhook-exporter
           image_old_tag: ${{ github.sha }}
           image_new_tag: ${{ env.releasetag }}
           registry: ${{ env.imageregistry }}

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -149,6 +149,8 @@ If not defined specifically, exporters are using pre-built container images with
   * Quay repository for the [committime-exporter](https://quay.io/repository/pelorus/pelorus-committime-exporter)
   * Quay repository for the [failure-exporter](https://quay.io/repository/pelorus/pelorus-failure-exporter)
   * Quay repository for the [deploytime-exporter](https://quay.io/repository/pelorus/pelorus-deploytime-exporter)
+  * Quay repository for the [releasetime-exporter](https://quay.io/repository/pelorus/pelorus-releasetime-exporter)
+  * Quay repository for the [webhook-exporter](https://quay.io/repository/pelorus/pelorus-webhook-exporter)
 
 #### Pre-built Quay images
 


### PR DESCRIPTION
Covers building webhook exporter and pushing it to the quay.io repository for the commit, pre-release and release events.

Documentation will be covered as part of the #857, however here one link was added as it's directly pointing to the quay image which will be built by those actions.

Depends on: #836

@redhat-cop/mdt
