### PR TITLE
feat: Add external Prometheus host config option

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.7-rc.1
+version: 2.0.8-rc.1
 
 dependencies:
   - name: exporters
-    version: "v2.0.7-rc.1"
+    version: "v2.0.8-rc.1"
     repository: file://./subcharts/exporters

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.7
+version: 2.0.7-rc.1
 
 dependencies:
   - name: exporters
-    version: "v2.0.7"
+    version: "v2.0.7-rc.1"
     repository: file://./subcharts/exporters

--- a/charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.7-rc.1
+version: 2.0.8-rc.1

--- a/charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.7
+version: 2.0.7-rc.1

--- a/charts/pelorus/templates/prometheus-cr.yaml
+++ b/charts/pelorus/templates/prometheus-cr.yaml
@@ -35,9 +35,9 @@ spec:
   ruleSelector: {}
   serviceAccountName: pelorus-prometheus
   serviceMonitorSelector: {}
-{{- if .Values.extra_prometheus_hosts}}
+{{- if or .Values.federated_prometheus_hosts .Values.external_prometheus_hosts }}
   additionalScrapeConfigs:
-    name: additional-scrape-configs
+    name: pelorus-prometheus-additional-scrape-configs
     key: prometheus-additional.yml
 {{- end }}
 {{- if .Values.custom_ca }}

--- a/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
+++ b/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
@@ -21,7 +21,6 @@
   {{- end }}
   {{- range .Values.external_prometheus_hosts }}
   - job_name: "external-prometheus-{{ .id }}"
-    # TODO any other config? I believe can be anything from here https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
     scrape_interval: 15s
     tls_config:
       insecure_skip_verify: true

--- a/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
+++ b/charts/pelorus/templates/prometheus-scrape-config-secret.yaml
@@ -1,5 +1,5 @@
 {{- define "prometheus_scrape_config"}}
-  {{- range .Values.extra_prometheus_hosts }}
+  {{- range .Values.federated_prometheus_hosts }}
   - job_name: "federated-prometheus-{{ .id }}"
     scrape_interval: 15s
     honor_labels: true
@@ -19,8 +19,20 @@
         labels:
           federated_job: "federated-prometheus-{{ .id }}"
   {{- end }}
+  {{- range .Values.external_prometheus_hosts }}
+  - job_name: "external-prometheus-{{ .id }}"
+    # TODO any other config? I believe can be anything from here https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
+    scrape_interval: 15s
+    tls_config:
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+          - "{{ .hostname }}"
+        labels:
+          external_job: "external-prometheus-{{ .id }}"
+  {{- end }}
 {{- end }}
-{{- if .Values.extra_prometheus_hosts}}
+{{- if or .Values.federated_prometheus_hosts .Values.external_prometheus_hosts }}
 ---
 apiVersion: v1
 data:
@@ -28,5 +40,5 @@ data:
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: additional-scrape-configs
+  name: pelorus-prometheus-additional-scrape-configs
 {{- end}}

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -5,7 +5,8 @@
 # to reset password: htpasswd -s -b -n internal changeme
 openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
 openshift_prometheus_basic_auth_pass: changeme
-extra_prometheus_hosts:
+federated_prometheus_hosts:
+external_prometheus_hosts:
 
 # Uncomment this if your cluster serves privately signed certificates
 # custom_ca: true

--- a/demo/tekton-demo-setup/operator_tekton_demo_values.yaml.sample
+++ b/demo/tekton-demo-setup/operator_tekton_demo_values.yaml.sample
@@ -43,7 +43,6 @@ spec:
           value: <your_git_org>/pelorus
         - name: APP_LABEL
           value: production_issue/name
-  extra_prometheus_hosts: null
   openshift_prometheus_basic_auth_pass: changeme
   openshift_prometheus_htpasswd_auth: 'internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM='
   prometheus_retention: 1y

--- a/docs/GettingStarted/Installation.md
+++ b/docs/GettingStarted/Installation.md
@@ -165,7 +165,6 @@ See the [Pelorus Exporters Configuration Guide](configuration/PelorusExporters.m
           exporter_type: failure
         - app_name: committime-exporter
           exporter_type: committime
-    extra_prometheus_hosts: null
     openshift_prometheus_basic_auth_pass: changeme
     openshift_prometheus_htpasswd_auth: 'internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM='
     prometheus_retention: 1y

--- a/docs/GettingStarted/configuration/PelorusCore.md
+++ b/docs/GettingStarted/configuration/PelorusCore.md
@@ -177,7 +177,6 @@ federated_prometheus_hosts:
 It is a list that consists of three configuration items per additional scrape host:
 : * id - a description of the scrape host
 : * hostname - the fully qualified domain name or ip address of the host
-: * password - TODO check if it needed!
 
 Prometheus will scrape data from `/metrics` endpoint.
 

--- a/docs/GettingStarted/configuration/PelorusCore.md
+++ b/docs/GettingStarted/configuration/PelorusCore.md
@@ -54,7 +54,8 @@ spec:
 | [prometheus_storage_pvc_storageclass](#prometheus_storage_pvc_storageclass) | no | `gp2` |
 | [openshift_prometheus_htpasswd_auth](#openshift_prometheus_htpasswd_auth)  | no | `internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=` |
 | [openshift_prometheus_basic_auth_pass](#openshift_prometheus_basic_auth_pass) | no | `changeme` |
-| [[extra_prometheus_hosts]](#extra_prometheus_hosts) | no | - |
+| [[federated_prometheus_hosts]](#federated_prometheus_hosts) | no | - |
+| [[external_prometheus_hosts]](#external_prometheus_hosts) | no | - |
 | [thanos_version](#thanos_version) | no | `v0.28.0` |
 | [bucket_access_point](#bucket_access_point) | no | - |
 | [bucket_access_key](#bucket_access_key) | no | - |
@@ -142,20 +143,23 @@ $ htpasswd -nbs internal <my-secret-password>
 
 ### Multiple Prometheus
 
-By default Pelorus gathers the data from the Prometheus instance deployed in the same cluster in which it is running. To collect data across multiple OpenShift clusters additional Prometheus hosts have to be configured. To do this `extra_prometheus_hosts` configuration option is used.
+By default, Pelorus gathers the data from the Prometheus instance deployed in the same cluster in which it is running. To collect data across multiple OpenShift clusters, additional Prometheus scrape hosts have to be configured. To do this `federated_prometheus_hosts` and `external_prometheus_hosts` configuration options are used.
 
-###### extra_prometheus_hosts
+###### federated_prometheus_hosts
 
 - **Required:** no
 - **Type:** list
 
-It is a list that consists of three configuration items per additional Prometheus host:
+It is a list that consists of three configuration items per additional [Federation](https://prometheus.io/docs/prometheus/latest/federation/) host:
 : * id - a description of the prometheus host (this will be used as a label to select metrics in the federated instance).
 : * hostname - the fully qualified domain name or ip address of the host with the extra Prometheus instance
 : * password - the password used for the `internal` basic auth account (this is provided by the k8s metrics prometheus instances in a secret).
+
+Prometheus will scrape data from `/federate` endpoint.
+
 : Example:
 ```yaml
-extra_prometheus_hosts:
+federated_prometheus_hosts:
 - id: "ci-1"
   hostname: "prometheus-k8s-openshift-monitoring.apps.ci-1.example.com"
   password: "<redacted>"
@@ -163,6 +167,28 @@ extra_prometheus_hosts:
 - id: "ci-2"
   hostname: "prometheus-k8s-openshift-monitoring.apps.ci-2.example.com"
   password: "<redacted>"
+```
+
+###### external_prometheus_hosts
+
+- **Required:** no
+- **Type:** list
+
+It is a list that consists of three configuration items per additional scrape host:
+: * id - a description of the scrape host
+: * hostname - the fully qualified domain name or ip address of the host
+: * password - TODO check if it needed!
+
+Prometheus will scrape data from `/metrics` endpoint.
+
+: Example:
+```yaml
+external_prometheus_hosts:
+- id: "prometheus-node"
+  hostname: "node.demo.do.prometheus.io"
+
+- id: "webhook"
+  hostname: "webhook.example.com"
 ```
 
 ## Grafana

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -1,6 +1,6 @@
 --- config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml.original	2022-12-16 20:39:18.630409481 +0100
 +++ config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml	2022-12-16 20:39:03.674340069 +0100
-@@ -15,29 +15,77 @@
+@@ -15,29 +42,104 @@
    - name: v1alpha1
      schema:
        openAPIV3Schema:
@@ -80,6 +80,33 @@
 +              prometheus_storage_pvc_storageclass:
 +                description: Prometheus Persistent Volume storage class to be used.
 +                type: string
++              federated_prometheus_hosts:
++                description: 'List of aditional Federation hosts'
++                type: array
++                items:
++                  type: object
++                  properties:
++                     id:
++                       description: 'Description of the Federation host (this will be used as a label to select metrics in the federated instance)'
++                       type: string
++                     hostname:
++                       description: 'the fully qualified domain name or ip address of the Federation host'
++                       type: string
++                     password:
++                       description: 'the password used for the `internal` basic auth account (this is provided by the k8s metrics prometheus instances in a secret)'
++                       type: string
++              external_prometheus_hosts:
++                description: 'List of aditional external scrape hosts'
++                type: array
++                items:
++                  type: object
++                  properties:
++                     id:
++                       description: 'Description of external scrape host'
++                       type: string
++                     hostname:
++                       description: 'the fully qualified domain name or ip address of the external scrape host'
++                       type: string
            status:
              description: Status defines the observed state of Pelorus
              type: object


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Add possibility of use scrape hosts from external cluster, or outside a cluster, with Pelorus.

## Linked Issues

https://github.com/orgs/konveyor/projects/51/views/2?pane=issue&itemId=20613515

## Testing Instructions

Create Pelorus operator from this branch, by changing line 19 of `scripts/create_pelorus_operator` to `YOUR_QUAY_USER` and running
```
podman login ...
oc login ...
rm -rf pelorus-operator && mkdir pelorus-operator && scripts/create_pelorus_operator
cd pelorus-operator
make podman-build
make bundle-build
make podman-push
make bundle-push
oc delete namespace pelorus
oc create namespace pelorus
operator-sdk run bundle quay.io/<YOUR_QUAY_USER>/pelorus-operator-bundle:v0.0.1 --namespace pelorus
```

Then, create an instance of Pelorus with `federated_prometheus_hosts` and/or  `external_prometheus_hosts` options, to test if it is working.

To clean it up, run
```
operator-sdk cleanup pelorus-operator --namespace pelorus
```
