### PR TITLE
Fix/operator form options

### DIFF
--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.8-rc.1
+version: 2.0.8-rc.2
 
 dependencies:
   - name: exporters
-    version: "v2.0.8-rc.1"
+    version: "v2.0.8-rc.2"
     repository: file://./subcharts/exporters

--- a/charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.8-rc.1
+version: 2.0.8-rc.2

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -35,36 +35,22 @@ prometheus_retention_size: 1GB
 
 exporters:
   instances:
-  - app_name: deploytime-exporter
-    exporter_type: deploytime
-    # env_from_configmaps:
-    # - pelorus-config
-    # - deploytime-config
+    - app_name: deploytime-exporter
+      exporter_type: deploytime
 
-  - app_name: failuretime-exporter
-    exporter_type: failure
-    enabled: false
-    env_from_configmaps:
-    - pelorus-config
-    - failuretime-config
-    env_from_secrets:
-    - jira-secret
+    - app_name: failuretime-exporter
+      exporter_type: failure
 
-  - app_name: committime-exporter
-    exporter_type: committime
-#    env_from_configmaps:
-#    - pelorus-config
-#    - committime-config
-#    env_from_secrets:
-#    - github-secret
+    - app_name: committime-exporter
+      exporter_type: committime
 
 # Experimental GitHub releasetime exporter
-#  - app_name: releasetime-exporter
-#    env_from_configmaps:
-#    - pelorus-config
-#    - releasetime-config
-#    env_from_secrets:
-#    - github-secret
-#    extraEnv:
-#    - name: APP_FILE
-#      value: extra/releasetime/app.py
+#     - app_name: releasetime-exporter
+#       env_from_configmaps:
+#         - pelorus-config
+#         - releasetime-config
+#       env_from_secrets:
+#         - github-secret
+#       extraEnv:
+#         - name: APP_FILE
+#           value: extra/releasetime/app.py

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -5,8 +5,8 @@
 # to reset password: htpasswd -s -b -n internal changeme
 openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
 openshift_prometheus_basic_auth_pass: changeme
-federated_prometheus_hosts:
-external_prometheus_hosts:
+# federated_prometheus_hosts:
+# external_prometheus_hosts:
 
 # Uncomment this if your cluster serves privately signed certificates
 # custom_ca: true

--- a/docs/GettingStarted/configuration/PelorusCore.md
+++ b/docs/GettingStarted/configuration/PelorusCore.md
@@ -250,9 +250,10 @@ The Pelorus chart supports deploying a [Thanos](https://thanos.io/) instance for
 ###### custom_ca
 
 - **Required:** no
-- **Type:** 'true' string or commented out for 'false'
+    - **Default Value:** false
+- **Type:** boolean
 
-: Whether or not the cluster serves custom signed certificates for ingress (e.g. router certs). If `true` we will load the custom via the [certificate injection method](https://docs.openshift.com/container-platform/4.11/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki).
+: Whether or not the cluster serves custom signed certificates for ingress (e.g. router certs). If `true`, we will load the custom via the [certificate injection method](https://docs.openshift.com/container-platform/4.11/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki).
 
 ## Deploying Across Multiple Clusters
 

--- a/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
+++ b/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
@@ -1,6 +1,6 @@
 --- config/manifests/bases/pelorus-operator.clusterserviceversion.yaml.original	2022-12-15 17:01:35.384242008 +0100
 +++ config/manifests/bases/pelorus-operator.clusterserviceversion.yaml	2022-12-15 17:01:46.425296201 +0100
-@@ -4,39 +4,111 @@
+@@ -4,39 +21,128 @@
    annotations:
      alm-examples: '[]'
      capabilities: Basic Install
@@ -25,6 +25,23 @@
 +      kind: Pelorus
 +      name: pelorus.charts.pelorus.konveyor.io
 +      version: v1alpha1
++      specDescriptors:
++      - path: exporters
++      - path: prometheus_retention
++      - path: prometheus_retention_size
++      - path: prometheus_storage
++      - path: prometheus_storage_pvc_capacity
++      - path: prometheus_storage_pvc_storageclass
++      - path: federated_prometheus_hosts
++      - path: external_prometheus_hosts
++      - path: openshift_prometheus_htpasswd_auth
++      - path: openshift_prometheus_basic_auth_pass
++      - path: thanos_version
++      - path: bucket_access_point
++      - path: bucket_access_key
++      - path: bucket_secret_access_key
++      - path: thanos_bucket_name
++      - path: custom_ca
 +  description: |
 +    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
 +

--- a/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
+++ b/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
@@ -1,6 +1,6 @@
 --- config/manifests/bases/pelorus-operator.clusterserviceversion.yaml.original	2022-12-15 17:01:35.384242008 +0100
 +++ config/manifests/bases/pelorus-operator.clusterserviceversion.yaml	2022-12-15 17:01:46.425296201 +0100
-@@ -4,39 +50,157 @@
+@@ -4,39 +56,163 @@
    annotations:
      alm-examples: '[]'
      capabilities: Basic Install
@@ -27,11 +27,13 @@
 +      version: v1alpha1
 +      specDescriptors:
 +      - path: exporters.instances.[0].app_name
++        displayName: Exporter Instance Name
 +      - path: exporters.instances.[0].exporter_type
 +      - path: exporters.instances.[0].env_from_secrets.[0]
 +        x-descriptors:
 +        - urn:alm:descriptor:io.kubernetes:Secret
 +      - path: exporters.instances.[0].env_from_configmaps.[0]
++        displayName: Env From ConfigMap
 +        x-descriptors:
 +        - urn:alm:descriptor:io.kubernetes:ConfigMap
 +      - path: exporters.instances.[0].extraEnv
@@ -45,6 +47,8 @@
 +      - path: exporters.instances.[0].source_ref
 +      - path: external_prometheus_hosts
 +        displayName: External Exporters
++      - path: external_prometheus_hosts[0].id
++        displayName: External Exporter name
 +      - path: prometheus_retention
 +      - path: prometheus_retention_size
 +      - path: prometheus_storage
@@ -55,10 +59,12 @@
 +        displayName: Prometheus PVC Storageclass
 +      - path: federated_prometheus_hosts
 +        displayName: Prometheus Federated Hosts
++      - path: federated_prometheus_hosts[0].id
++        displayName: Federated Exporter name
 +      - path: openshift_prometheus_htpasswd_auth
 +        displayName: Prometheus Internal Auth (htpasswd)
 +      - path: openshift_prometheus_basic_auth_pass
-+        displayName: Prometheus Internal Auth (basic auth)
++        displayName: Grafana Datasource Internal Auth (basic auth)
 +      - path: thanos_bucket_name
 +        displayName: Thanos S3 Bucket Name
 +      - path: bucket_access_point

--- a/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
+++ b/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
@@ -1,6 +1,6 @@
 --- config/manifests/bases/pelorus-operator.clusterserviceversion.yaml.original	2022-12-15 17:01:35.384242008 +0100
 +++ config/manifests/bases/pelorus-operator.clusterserviceversion.yaml	2022-12-15 17:01:46.425296201 +0100
-@@ -4,39 +21,128 @@
+@@ -4,39 +50,157 @@
    annotations:
      alm-examples: '[]'
      capabilities: Basic Install
@@ -26,22 +26,51 @@
 +      name: pelorus.charts.pelorus.konveyor.io
 +      version: v1alpha1
 +      specDescriptors:
-+      - path: exporters
++      - path: exporters.instances.[0].app_name
++      - path: exporters.instances.[0].exporter_type
++      - path: exporters.instances.[0].env_from_secrets.[0]
++        x-descriptors:
++        - urn:alm:descriptor:io.kubernetes:Secret
++      - path: exporters.instances.[0].env_from_configmaps.[0]
++        x-descriptors:
++        - urn:alm:descriptor:io.kubernetes:ConfigMap
++      - path: exporters.instances.[0].extraEnv
++      - path: exporters.instances.[0].enabled
++      - path: exporters.instances.[0].custom_certs.[0].map_name
++        x-descriptors:
++        - urn:alm:descriptor:io.kubernetes:ConfigMap
++      - path: exporters.instances.[0].image_tag
++      - path: exporters.instances.[0].image_name
++      - path: exporters.instances.[0].source_url
++      - path: exporters.instances.[0].source_ref
++      - path: external_prometheus_hosts
++        description: External Exporters
 +      - path: prometheus_retention
 +      - path: prometheus_retention_size
 +      - path: prometheus_storage
++        description: Prometheus Persistent Storage (PVC)
 +      - path: prometheus_storage_pvc_capacity
++        description: Prometheus PVC Capacity
 +      - path: prometheus_storage_pvc_storageclass
++        description: Prometheus PVC Storageclass
 +      - path: federated_prometheus_hosts
-+      - path: external_prometheus_hosts
++        description: Prometheus Federated Hosts
 +      - path: openshift_prometheus_htpasswd_auth
++        description: Prometheus Internal Auth (htpasswd)
 +      - path: openshift_prometheus_basic_auth_pass
-+      - path: thanos_version
-+      - path: bucket_access_point
-+      - path: bucket_access_key
-+      - path: bucket_secret_access_key
++        description: Prometheus Internal Auth (basic auth)
 +      - path: thanos_bucket_name
++        description: Thanos S3 Bucket Name
++      - path: bucket_access_point
++        description: Thanos S3 Access Point
++      - path: bucket_access_key
++        description: Thanos S3 Access Key
++      - path: bucket_secret_access_key
++        description: Thanos S3 Secret Access Key
++      - path: thanos_version
++        description: Thanos Quay Image Tag
 +      - path: custom_ca
++        description: CA Certificate Injection
 +  description: |
 +    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
 +

--- a/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
+++ b/scripts/pelorus-operator-patches/04_pelorus_cluster_service_versions.diff
@@ -44,33 +44,33 @@
 +      - path: exporters.instances.[0].source_url
 +      - path: exporters.instances.[0].source_ref
 +      - path: external_prometheus_hosts
-+        description: External Exporters
++        displayName: External Exporters
 +      - path: prometheus_retention
 +      - path: prometheus_retention_size
 +      - path: prometheus_storage
-+        description: Prometheus Persistent Storage (PVC)
++        displayName: Prometheus Persistent Storage (PVC)
 +      - path: prometheus_storage_pvc_capacity
-+        description: Prometheus PVC Capacity
++        displayName: Prometheus PVC Capacity
 +      - path: prometheus_storage_pvc_storageclass
-+        description: Prometheus PVC Storageclass
++        displayName: Prometheus PVC Storageclass
 +      - path: federated_prometheus_hosts
-+        description: Prometheus Federated Hosts
++        displayName: Prometheus Federated Hosts
 +      - path: openshift_prometheus_htpasswd_auth
-+        description: Prometheus Internal Auth (htpasswd)
++        displayName: Prometheus Internal Auth (htpasswd)
 +      - path: openshift_prometheus_basic_auth_pass
-+        description: Prometheus Internal Auth (basic auth)
++        displayName: Prometheus Internal Auth (basic auth)
 +      - path: thanos_bucket_name
-+        description: Thanos S3 Bucket Name
++        displayName: Thanos S3 Bucket Name
 +      - path: bucket_access_point
-+        description: Thanos S3 Access Point
++        displayName: Thanos S3 Access Point
 +      - path: bucket_access_key
-+        description: Thanos S3 Access Key
++        displayName: Thanos S3 Access Key
 +      - path: bucket_secret_access_key
-+        description: Thanos S3 Secret Access Key
++        displayName: Thanos S3 Secret Access Key
 +      - path: thanos_version
-+        description: Thanos Quay Image Tag
++        displayName: Thanos Quay Image Tag
 +      - path: custom_ca
-+        description: CA Certificate Injection
++        displayName: CA Certificate Injection
 +  description: |
 +    Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
 +

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -1,6 +1,6 @@
 --- config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml.original	2022-12-16 20:39:18.630409481 +0100
 +++ config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml	2022-12-16 20:39:03.674340069 +0100
-@@ -15,29 +142,204 @@
+@@ -15,29 +149,211 @@
    - name: v1alpha1
      schema:
        openAPIV3Schema:
@@ -112,6 +112,8 @@
 +                              map_name:
 +                                description: 'ConfigMap name created from Certificate file.'
 +                                type: string
++                            required:
++                              - map_name
 +                        image_tag:
 +                          description: >-
 +                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
@@ -171,6 +173,9 @@
 +                     password:
 +                       description: 'the password used for the `internal` basic auth account (this is provided by the k8s metrics prometheus instances in a secret)'
 +                       type: string
++                  required:
++                    - id
++                    - hostname
 +              external_prometheus_hosts:
 +                description: 'List of aditional external scrape hosts'
 +                type: array
@@ -183,6 +188,8 @@
 +                     hostname:
 +                       description: 'the fully qualified domain name or ip address of the external scrape host'
 +                       type: string
++                  required:
++                    - hostname
 +              openshift_prometheus_htpasswd_auth:
 +                description: Credentials for the internal user that are used by Grafana to communicate with the Prometheus instance deployed by Pelorus.
 +                type: string

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -132,9 +132,9 @@
 +                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
 +                            Exporter git reference or branch.
 +                          type: string
-+                required:
-+                  - app_name
-+                  - exporter_type
++                      required:
++                        - app_name
++                        - exporter_type
 +              prometheus_retention:
 +                description: >-
 +                  Prometheus Retention time. More information:

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -1,6 +1,6 @@
 --- config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml.original	2022-12-16 20:39:18.630409481 +0100
 +++ config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml	2022-12-16 20:39:03.674340069 +0100
-@@ -15,29 +149,211 @@
+@@ -15,29 +139,201 @@
    - name: v1alpha1
      schema:
        openAPIV3Schema:
@@ -47,22 +47,16 @@
 -            x-kubernetes-preserve-unknown-fields: true
 +            properties:
 +              exporters:
-+                description: >-
-+                  References configuration for the Pelorus exporters. More
-+                  info about exporters configuration:
-+                  https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusExporters/
++                description: Configure Pelorus exporters' References.
 +                type: object
 +                properties:
 +                  instances:
-+                    description: >-
-+                      Exporter instances configuration. More information:
-+                      https://pelorus.readthedocs.io/en/latest/Configuration/
 +                    type: array
 +                    items:
 +                      type: object
 +                      properties:
 +                        app_name:
-+                          description: 'Exporter name, must start with "- ".'
++                          description: Must consist of lower case alphanumeric characters or '-'.
 +                          type: string
 +                        exporter_type:
 +                          description: >-
@@ -71,21 +65,17 @@
 +                          type: string
 +                          enum: [deploytime, committime, failure, webhook]
 +                        env_from_secrets:
-+                          description: >-
-+                            Secret name(s) with secrets used by the exporter
-+                            instance.
++                          description: Secret name(s) with configuration used by the exporter instance.
 +                          type: array
 +                          items:
 +                            type: string
 +                        env_from_configmaps:
-+                          description: >-
-+                            ConfigMap name(s) with configuration used by the
-+                            exporter instance.
++                          description: ConfigMap name(s) with configuration used by the exporter instance.
 +                          type: array
 +                          items:
 +                            type: string
 +                        extraEnv:
-+                          description: 'List of name and value pairs.'
++                          description: List of Name and Value pairs used to configure the exporter instance.
 +                          type: array
 +                          items:
 +                            type: object
@@ -100,11 +90,11 @@
 +                              - name
 +                              - value
 +                        enabled:
-+                          description: 'If set to false, exporter won''t be provisioned.'
++                          description: If set to false, exporter instance won't be created.
 +                          type: boolean
 +                          default: true
 +                        custom_certs:
-+                          description: 'List of ConfigMaps.'
++                          description: ConfigMap name(s) with custom CA certificates.
 +                          type: array
 +                          items:
 +                            type: object
@@ -159,45 +149,45 @@
 +                description: Prometheus Persistent Volume storage class to be used.
 +                type: string
 +              federated_prometheus_hosts:
-+                description: 'List of aditional Federation hosts'
++                description: 'List of additional Federation hosts.'
 +                type: array
 +                items:
 +                  type: object
 +                  properties:
 +                     id:
-+                       description: 'Description of the Federation host (this will be used as a label to select metrics in the federated instance)'
++                       description: Must consist of lower case alphanumeric characters or '-'.
 +                       type: string
 +                     hostname:
-+                       description: 'the fully qualified domain name or ip address of the Federation host'
++                       description: 'The fully qualified domain name or IP Address of the Prometheus Federation host.'
 +                       type: string
 +                     password:
-+                       description: 'the password used for the `internal` basic auth account (this is provided by the k8s metrics prometheus instances in a secret)'
++                       description: 'The federated Prometheus "basic auth" password.'
 +                       type: string
 +                  required:
 +                    - id
 +                    - hostname
 +              external_prometheus_hosts:
-+                description: 'List of aditional external scrape hosts'
++                description: 'List of additional external scrape hosts.'
 +                type: array
 +                items:
 +                  type: object
 +                  properties:
 +                     id:
-+                       description: 'Description of external scrape host'
++                       description: Must consist of lower case alphanumeric characters or '-'.
 +                       type: string
 +                     hostname:
-+                       description: 'the fully qualified domain name or ip address of the external scrape host'
++                       description: 'The fully qualified domain name or IP Address of the external scrape host'
 +                       type: string
 +                  required:
 +                    - hostname
 +              openshift_prometheus_htpasswd_auth:
-+                description: Credentials for the internal user that are used by Grafana to communicate with the Prometheus instance deployed by Pelorus.
++                description: Credentials for the internal user that are used by Grafana to communicate with the Prometheus and Thanos deployed by Pelorus. Must match the "Grafana Datasource Internal Auth (basic auth)".
 +                type: string
 +              openshift_prometheus_basic_auth_pass:
-+                description: The password that grafana will use for its Prometheus datasource. Must match the openshift_prometheus_htpasswd_auth.
++                description: Password for Grafana to communicate with the Prometheus datasource. Must match the "Prometheus Internal Auth (htpasswd)".
 +                type: string
 +              thanos_version:
-+                description: Thanos version from the Official Thanos podman image.
++                description: DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION Thanos version from the Official Thanos podman image.
 +                type: string
 +              bucket_access_point:
 +                description: S3 named network endpoint that is used to perform S3 object operations.

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -1,6 +1,6 @@
 --- config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml.original	2022-12-16 20:39:18.630409481 +0100
 +++ config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml	2022-12-16 20:39:03.674340069 +0100
-@@ -15,29 +42,104 @@
+@@ -15,29 +142,204 @@
    - name: v1alpha1
      schema:
        openAPIV3Schema:
@@ -51,14 +51,90 @@
 +                  References configuration for the Pelorus exporters. More
 +                  info about exporters configuration:
 +                  https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusExporters/
-+
-+                    Example:
-+                      instances:
-+                        - app_name: < instance_name >
-+                          enabled: < won't be created if set to false >
-+                          exporter_type: < deploytime, committime, failure >
 +                type: object
-+                x-kubernetes-preserve-unknown-fields: true
++                properties:
++                  instances:
++                    description: >-
++                      Exporter instances configuration. More information:
++                      https://pelorus.readthedocs.io/en/latest/Configuration/
++                    type: array
++                    items:
++                      type: object
++                      properties:
++                        app_name:
++                          description: 'Exporter name, must start with "- ".'
++                          type: string
++                        exporter_type:
++                          description: >-
++                            Exporter type as in the:
++                            https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters-overview
++                          type: string
++                          enum: [deploytime, committime, failure]
++                        env_from_secrets:
++                          description: >-
++                            Secret name(s) with secrets used by the exporter
++                            instance.
++                          type: array
++                          items:
++                            type: string
++                        env_from_configmaps:
++                          description: >-
++                            ConfigMap name(s) with configuration used by the
++                            exporter instance.
++                          type: array
++                          items:
++                            type: string
++                        extraEnv:
++                          description: 'List of name and value pairs.'
++                          type: array
++                          items:
++                            type: object
++                            properties:
++                              name:
++                                description: 'Option name.'
++                                type: string
++                              value:
++                                description: 'Option value.'
++                                type: string
++                            required:
++                              - name
++                              - value
++                        enabled:
++                          description: 'If set to false, exporter won''t be provisioned.'
++                          type: boolean
++                          default: true
++                        custom_certs:
++                          description: 'List of ConfigMaps.'
++                          type: array
++                          items:
++                            type: object
++                            properties:
++                              map_name:
++                                description: 'ConfigMap name created from Certificate file.'
++                                type: string
++                        image_tag:
++                          description: >-
++                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
++                            Exporter image tag.
++                          type: string
++                        image_name:
++                          description: >-
++                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
++                            Exporter image name, with registry.
++                          type: string
++                        source_url:
++                          description: >-
++                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
++                            Exporter git source code.
++                          type: string
++                        source_ref:
++                          description: >-
++                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
++                            Exporter git reference or branch.
++                          type: string
++                required:
++                  - app_name
++                  - exporter_type
 +              prometheus_retention:
 +                description: >-
 +                  Prometheus Retention time. More information:
@@ -107,6 +183,30 @@
 +                     hostname:
 +                       description: 'the fully qualified domain name or ip address of the external scrape host'
 +                       type: string
++              openshift_prometheus_htpasswd_auth:
++                description: Credentials for the internal user that are used by Grafana to communicate with the Prometheus instance deployed by Pelorus.
++                type: string
++              openshift_prometheus_basic_auth_pass:
++                description: The password that grafana will use for its Prometheus datasource. Must match the openshift_prometheus_htpasswd_auth.
++                type: string
++              thanos_version:
++                description: Thanos version from the Official Thanos podman image.
++                type: string
++              bucket_access_point:
++                description: S3 named network endpoint that is used to perform S3 object operations.
++                type: string
++              bucket_access_key:
++                description: S3 Access Key ID.
++                type: string
++              bucket_secret_access_key:
++                description: S3 Secret Access Key.
++                type: string
++              thanos_bucket_name:
++                description: S3 bucket name.
++                type: string
++              custom_ca:
++                description: Whether or not the cluster serves custom signed certificates for ingress (e.g. router certs).
++                type: boolean
            status:
              description: Status defines the observed state of Pelorus
              type: object

--- a/scripts/pelorus-operator-patches/07_spec_description.diff
+++ b/scripts/pelorus-operator-patches/07_spec_description.diff
@@ -69,7 +69,7 @@
 +                            Exporter type as in the:
 +                            https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters-overview
 +                          type: string
-+                          enum: [deploytime, committime, failure]
++                          enum: [deploytime, committime, failure, webhook]
 +                        env_from_secrets:
 +                          description: >-
 +                            Secret name(s) with secrets used by the exporter


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Allow form view to gave all fields user can have, when creating instance from Pelorus Operator.

## Linked Issues

Resolves https://github.com/konveyor/pelorus/issues/860

## Testing Instructions

Use Pelorus operator from mine quay repository
```
oc login ...
oc delete namespace pelorus
oc create namespace pelorus
operator-sdk run bundle quay.io/msouzaol/pelorus-operator-bundle:v0.0.6 --namespace pelorus
```

Then, create an instance of Pelorus using form or yaml view, to test if it is working. It should warn of wrong usage or lack of required fields.

To clean it up, run
```
operator-sdk cleanup pelorus-operator --namespace pelorus
```
