### PR TITLE
Fix the webhook timestamp validator

### DIFF
--- a/exporters/tests/test_in_memory_metric.py
+++ b/exporters/tests/test_in_memory_metric.py
@@ -61,7 +61,7 @@ class TestInMemoryMetric:
         [
             (
                 "todolist",
-                "timestamp_str",
+                "1678269658",
                 "sha256:af4092ccbfa99a3ec1ea93058fe39b8ddfd8db1c7a18081db397c50a0b8ec77d",
                 "mynamespace",
                 "5379bad65a3f83853a75aabec9e0e43c75fd18fc",
@@ -105,7 +105,7 @@ class TestInMemoryMetric:
             labels=metric_labels,
         )
 
-        assert query_result == timestamp
+        assert str(query_result) == timestamp
 
 
 def test_all_models_have_prometheus_mappings():

--- a/exporters/tests/test_webhook_models.py
+++ b/exporters/tests/test_webhook_models.py
@@ -34,7 +34,7 @@ from webhook.models.pelorus_webhook import (
 
 test_payload = {
     "app": "todolist",
-    "timestamp": "timestamp_str",
+    "timestamp": "1678269658",
 }
 test_deploy = {
     **test_payload,
@@ -62,8 +62,8 @@ class FakePelorusPayload(BaseModel):
 @pytest.mark.parametrize(
     "app,timestamp",
     [
-        (123456, "timestamp_str"),
-        ("todolist", 123456),
+        (123456, 1678269658),
+        ("todolist", "1678269658"),
     ],
 )
 def test_pelorus_payload_success(app, timestamp):
@@ -77,6 +77,28 @@ def test_pelorus_payload_success(app, timestamp):
     """
     payload = PelorusPayload(app=app, timestamp=timestamp)
     assert payload.get_metric_model_name() == "PelorusPayload"
+
+
+@pytest.mark.parametrize(
+    "app,timestamp",
+    [
+        (123456, 123457890),
+        ("todolist", "123456789"),
+        ("todolist", "123456789"),
+        ("todolist", 12345678901),
+        ("todolist", "Mon Mar 6 15:31:32 2023 +0100"),
+        ("todolist", 1262307660),
+        ("todolist", 2840144462),
+    ],
+)
+def test_pelorus_wrong_timestamp(app, timestamp):
+    """
+    Test for the wrong timestamp of the PelorusPayload class.
+    The timestamp should be a valid EPOCH format, which is
+    10 digit number.
+    """
+    with pytest.raises(ValidationError):
+        PelorusPayload(app=app, timestamp=timestamp)
 
 
 @pytest.mark.parametrize(

--- a/exporters/webhook/models/pelorus_webhook.py
+++ b/exporters/webhook/models/pelorus_webhook.py
@@ -42,14 +42,16 @@ class PelorusPayload(BaseModel):
 
     Attributes:
         app (str): Application name.
-        timestamp (str): Timestamp of the event. This is different from the
-                         time when the webhook could have been received.
+        timestamp (int): 10 digit EPOCH timestamp of the event. This
+                         is different from the time when the webhook
+                         could have been received. The date value must
+                         be between 1.1.2010 and 1.1.2060
     """
 
     # Even if we consider git project name as app, it still should be below 100
     app: str = Field(max_length=200)
-    # ISO 8601 is 19 chars long, so don't expect any format can be longer then 50 chars
-    timestamp: str = Field(max_length=50)
+
+    timestamp: int = Field(None, ge=1262307661, le=2840144461)
 
     def get_metric_model_name(self) -> str:
         return type(self).__name__


### PR DESCRIPTION
We simplify the timestamp of the webhook pelorus plugin to accept only EPOCH timestamp.

It's up to the service sending POST data to ensure timestamp is a valid format and we do not have troubles converting them from unknown data format.

Fixes: #867 

## Testing Instructions

Added test to capture wrong data and modify other tests to cover positive test case.
$ make unit-tests

@redhat-cop/mdt
