### PR TITLE
release: Pelorus Operator version 0.0.5

### DIFF
--- a/charts/operators/Chart.yaml
+++ b/charts/operators/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.7
+version: 2.0.8

--- a/charts/pelorus/Chart.yaml
+++ b/charts/pelorus/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.8-rc.2
+version: 2.0.8
 
 dependencies:
   - name: exporters
-    version: "v2.0.8-rc.2"
+    version: 2.0.8
     repository: file://./subcharts/exporters

--- a/charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.8-rc.2
+version: 2.0.8

--- a/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.7" }}
+      ref: {{ .source_ref | default "v2.0.8" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,10 +20,10 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "v2.0.7" }}
+      name: {{ .image_name }}:{{ .image_tag | default "v2.0.8" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.7" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.8" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -40,9 +40,13 @@ exporters:
 
     - app_name: failuretime-exporter
       exporter_type: failure
+      enabled: false
 
     - app_name: committime-exporter
       exporter_type: committime
+
+    - app_name: webhook-exporter
+      exporter_type: webhook
 
 # Experimental GitHub releasetime exporter
 #     - app_name: releasetime-exporter

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -218,7 +218,7 @@ If not defined specifically, exporters are using pre-built container images with
 
 Each Pelorus GitHub pull request that is [merged](https://github.com/konveyor/pelorus/pulls?q=is%3Apr+is%3Amerged) results in a new set of images that are tagged with the GitHub commit hash, for example `d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31` for the following [Pull Request](https://github.com/konveyor/pelorus/commit/d6f6e6fa1c9d48ca1deeaf1c72585b94964cbf31). The newest merged commit results in additional image tag `latest`.
 
-Each new Pelorus [release](https://github.com/konveyor/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.7`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
+Each new Pelorus [release](https://github.com/konveyor/pelorus/releases) results in a new set of images that are tagged with the release number, for example `v2.0.8`. At the same time when release is made a `stable` tag is updated to point to the latest released version of the images.
 
 During Pelorus Helm deployment or update time user have option to specify the image tag for each exporter instance individually. Example below shows two different tags for the commit time exporter and two tags for the failure exporter.
 
@@ -258,7 +258,7 @@ exporters:
 
   - app_name: jira-failure-exporter
     exporter_type: failure
-    image_tag: v2.0.7 # Specific release
+    image_tag: v2.0.8 # Specific release
     env_from_secrets:
     - jira-credentials
     env_from_configmaps:

--- a/pelorus-operator/Dockerfile
+++ b/pelorus-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.26.1
+FROM quay.io/operator-framework/helm-operator:v1.27.0
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml

--- a/pelorus-operator/Makefile
+++ b/pelorus-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.4
+VERSION ?= 0.0.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -146,7 +146,7 @@ ifeq (,$(shell which helm-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(HELM_OPERATOR)) ;\
-	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.26.1/helm-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(HELM_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.27.0/helm-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(HELM_OPERATOR) ;\
 	}
 else

--- a/pelorus-operator/bundle.Dockerfile
+++ b/pelorus-operator/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=pelorus-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.26.1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.27.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
 

--- a/pelorus-operator/bundle/manifests/charts.pelorus.konveyor.io_pelorus.yaml
+++ b/pelorus-operator/bundle/manifests/charts.pelorus.konveyor.io_pelorus.yaml
@@ -36,18 +36,150 @@ spec:
               Pelorus configuration that can be used in the Spec section is available
               at: https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusCore/'
             properties:
+              bucket_access_key:
+                description: S3 Access Key ID.
+                type: string
+              bucket_access_point:
+                description: S3 named network endpoint that is used to perform S3
+                  object operations.
+                type: string
+              bucket_secret_access_key:
+                description: S3 Secret Access Key.
+                type: string
+              custom_ca:
+                description: Whether or not the cluster serves custom signed certificates
+                  for ingress (e.g. router certs).
+                type: boolean
               exporters:
-                description: |-
-                  References configuration for the Pelorus exporters. More info about exporters configuration: https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusExporters/
-
-
-                    Example:
-                      instances:
-                        - app_name: < instance_name >
-                          enabled: < won't be created if set to false >
-                          exporter_type: < deploytime, committime, failure >
+                description: Configure Pelorus exporters' References.
+                properties:
+                  instances:
+                    items:
+                      properties:
+                        app_name:
+                          description: Must consist of lower case alphanumeric characters
+                            or '-'.
+                          type: string
+                        custom_certs:
+                          description: ConfigMap name(s) with custom CA certificates.
+                          items:
+                            properties:
+                              map_name:
+                                description: ConfigMap name created from Certificate
+                                  file.
+                                type: string
+                            required:
+                            - map_name
+                            type: object
+                          type: array
+                        enabled:
+                          default: true
+                          description: If set to false, exporter instance won't be
+                            created.
+                          type: boolean
+                        env_from_configmaps:
+                          description: ConfigMap name(s) with configuration used by
+                            the exporter instance.
+                          items:
+                            type: string
+                          type: array
+                        env_from_secrets:
+                          description: Secret name(s) with configuration used by the
+                            exporter instance.
+                          items:
+                            type: string
+                          type: array
+                        exporter_type:
+                          description: 'Exporter type as in the: https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters-overview'
+                          enum:
+                          - deploytime
+                          - committime
+                          - failure
+                          - webhook
+                          type: string
+                        extraEnv:
+                          description: List of Name and Value pairs used to configure
+                            the exporter instance.
+                          items:
+                            properties:
+                              name:
+                                description: Option name.
+                                type: string
+                              value:
+                                description: Option value.
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        image_name:
+                          description: DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter image name, with registry.
+                          type: string
+                        image_tag:
+                          description: DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter image tag.
+                          type: string
+                        source_ref:
+                          description: DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter git reference or branch.
+                          type: string
+                        source_url:
+                          description: DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter git source code.
+                          type: string
+                      required:
+                      - app_name
+                      - exporter_type
+                      type: object
+                    type: array
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
+              external_prometheus_hosts:
+                description: List of additional external scrape hosts.
+                items:
+                  properties:
+                    hostname:
+                      description: The fully qualified domain name or IP Address of
+                        the external scrape host
+                      type: string
+                    id:
+                      description: Must consist of lower case alphanumeric characters
+                        or '-'.
+                      type: string
+                  required:
+                  - hostname
+                  type: object
+                type: array
+              federated_prometheus_hosts:
+                description: List of additional Federation hosts.
+                items:
+                  properties:
+                    hostname:
+                      description: The fully qualified domain name or IP Address of
+                        the Prometheus Federation host.
+                      type: string
+                    id:
+                      description: Must consist of lower case alphanumeric characters
+                        or '-'.
+                      type: string
+                    password:
+                      description: The federated Prometheus "basic auth" password.
+                      type: string
+                  required:
+                  - id
+                  - hostname
+                  type: object
+                type: array
+              openshift_prometheus_basic_auth_pass:
+                description: Password for Grafana to communicate with the Prometheus
+                  datasource. Must match the "Prometheus Internal Auth (htpasswd)".
+                type: string
+              openshift_prometheus_htpasswd_auth:
+                description: Credentials for the internal user that are used by Grafana
+                  to communicate with the Prometheus and Thanos deployed by Pelorus.
+                  Must match the "Grafana Datasource Internal Auth (basic auth)".
+                type: string
               prometheus_retention:
                 description: 'Prometheus Retention time. More information: https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusCore/#prometheus_retention'
                 type: string
@@ -63,6 +195,13 @@ spec:
                 type: string
               prometheus_storage_pvc_storageclass:
                 description: Prometheus Persistent Volume storage class to be used.
+                type: string
+              thanos_bucket_name:
+                description: S3 bucket name.
+                type: string
+              thanos_version:
+                description: DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION Thanos version
+                  from the Official Thanos podman image.
                 type: string
             type: object
           status:

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -20,11 +20,16 @@ metadata:
                 },
                 {
                   "app_name": "failuretime-exporter",
+                  "enabled": false,
                   "exporter_type": "failure"
                 },
                 {
                   "app_name": "committime-exporter",
                   "exporter_type": "committime"
+                },
+                {
+                  "app_name": "webhook-exporter",
+                  "exporter_type": "webhook"
                 }
               ]
             },
@@ -42,7 +47,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.5
-    createdAt: "2023-03-10T12:28:30Z"
+    createdAt: "2023-03-10T15:45:43Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -203,6 +208,12 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - '*'
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - prometheuses
@@ -244,12 +255,6 @@ spec:
           - grafanadashboards
           - grafanadatasources
           - grafanas
-          verbs:
-          - '*'
-        - apiGroups:
-          - image.openshift.io
-          resources:
-          - imagestreams
           verbs:
           - '*'
         - apiGroups:

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -20,14 +20,6 @@ metadata:
                 },
                 {
                   "app_name": "failuretime-exporter",
-                  "enabled": false,
-                  "env_from_configmaps": [
-                    "pelorus-config",
-                    "failuretime-config"
-                  ],
-                  "env_from_secrets": [
-                    "jira-secret"
-                  ],
                   "exporter_type": "failure"
                 },
                 {
@@ -36,7 +28,6 @@ metadata:
                 }
               ]
             },
-            "extra_prometheus_hosts": null,
             "openshift_prometheus_basic_auth_pass": "changeme",
             "openshift_prometheus_htpasswd_auth": "internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=",
             "prometheus_retention": "1y",
@@ -50,16 +41,16 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.4
-    createdAt: "2023-03-02T21:50:29Z"
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.5
+    createdAt: "2023-03-10T12:28:30Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
-    operators.operatorframework.io/builder: operator-sdk-v1.26.1
+    operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/konveyor/pelorus/
     support: Pelorus Community
-  name: pelorus-operator.v0.0.4
+  name: pelorus-operator.v0.0.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -70,6 +61,58 @@ spec:
       displayName: Pelorus
       kind: Pelorus
       name: pelorus.charts.pelorus.konveyor.io
+      specDescriptors:
+      - displayName: Exporter Instance Name
+        path: exporters.instances.[0].app_name
+      - path: exporters.instances.[0].exporter_type
+      - path: exporters.instances.[0].env_from_secrets.[0]
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Env From ConfigMap
+        path: exporters.instances.[0].env_from_configmaps.[0]
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMap
+      - path: exporters.instances.[0].extraEnv
+      - path: exporters.instances.[0].enabled
+      - path: exporters.instances.[0].custom_certs.[0].map_name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMap
+      - path: exporters.instances.[0].image_tag
+      - path: exporters.instances.[0].image_name
+      - path: exporters.instances.[0].source_url
+      - path: exporters.instances.[0].source_ref
+      - displayName: External Exporters
+        path: external_prometheus_hosts
+      - displayName: External Exporter name
+        path: external_prometheus_hosts[0].id
+      - path: prometheus_retention
+      - path: prometheus_retention_size
+      - displayName: Prometheus Persistent Storage (PVC)
+        path: prometheus_storage
+      - displayName: Prometheus PVC Capacity
+        path: prometheus_storage_pvc_capacity
+      - displayName: Prometheus PVC Storageclass
+        path: prometheus_storage_pvc_storageclass
+      - displayName: Prometheus Federated Hosts
+        path: federated_prometheus_hosts
+      - displayName: Federated Exporter name
+        path: federated_prometheus_hosts[0].id
+      - displayName: Prometheus Internal Auth (htpasswd)
+        path: openshift_prometheus_htpasswd_auth
+      - displayName: Grafana Datasource Internal Auth (basic auth)
+        path: openshift_prometheus_basic_auth_pass
+      - displayName: Thanos S3 Bucket Name
+        path: thanos_bucket_name
+      - displayName: Thanos S3 Access Point
+        path: bucket_access_point
+      - displayName: Thanos S3 Access Key
+        path: bucket_access_key
+      - displayName: Thanos S3 Secret Access Key
+        path: bucket_secret_access_key
+      - displayName: Thanos Quay Image Tag
+        path: thanos_version
+      - displayName: CA Certificate Injection
+        path: custom_ca
       version: v1alpha1
   description: |
     Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:
@@ -160,6 +203,20 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheuses
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
           - ""
           resources:
           - configmaps
@@ -193,20 +250,6 @@ spec:
           - image.openshift.io
           resources:
           - imagestreams
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - prometheuses
-          - prometheusrules
-          - servicemonitors
-          verbs:
-          - '*'
-        - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
           verbs:
           - '*'
         - apiGroups:
@@ -358,7 +401,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=pelorus-operator
-                image: quay.io/pelorus/pelorus-operator:0.0.4
+                image: quay.io/pelorus/pelorus-operator:0.0.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -460,9 +503,10 @@ spec:
   provider:
     name: Red Hat
     url: https://redhat.com
-  version: 0.0.4
-  replaces: pelorus-operator.v0.0.3
+  version: 0.0.5
+  replaces: pelorus-operator.v0.0.4
   skips:
+    - pelorus-operator.v0.0.4
     - pelorus-operator.v0.0.3
     - pelorus-operator.v0.0.2
     - pelorus-operator.v0.0.1

--- a/pelorus-operator/bundle/metadata/annotations.yaml
+++ b/pelorus-operator/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: pelorus-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.26.1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.27.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
 

--- a/pelorus-operator/bundle/tests/scorecard/config.yaml
+++ b/pelorus-operator/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/pelorus-operator/config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml
+++ b/pelorus-operator/config/crd/bases/charts.pelorus.konveyor.io_pelorus.yaml
@@ -49,18 +49,86 @@ spec:
             type: object
             properties:
               exporters:
-                description: >-
-                  References configuration for the Pelorus exporters. More
-                  info about exporters configuration:
-                  https://pelorus.readthedocs.io/en/latest/GettingStarted/configuration/PelorusExporters/
-
-                    Example:
-                      instances:
-                        - app_name: < instance_name >
-                          enabled: < won't be created if set to false >
-                          exporter_type: < deploytime, committime, failure >
+                description: Configure Pelorus exporters' References.
                 type: object
-                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  instances:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        app_name:
+                          description: Must consist of lower case alphanumeric characters or '-'.
+                          type: string
+                        exporter_type:
+                          description: >-
+                            Exporter type as in the:
+                            https://pelorus.readthedocs.io/en/latest/Configuration/#configuring-exporters-overview
+                          type: string
+                          enum: [deploytime, committime, failure, webhook]
+                        env_from_secrets:
+                          description: Secret name(s) with configuration used by the exporter instance.
+                          type: array
+                          items:
+                            type: string
+                        env_from_configmaps:
+                          description: ConfigMap name(s) with configuration used by the exporter instance.
+                          type: array
+                          items:
+                            type: string
+                        extraEnv:
+                          description: List of Name and Value pairs used to configure the exporter instance.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                description: 'Option name.'
+                                type: string
+                              value:
+                                description: 'Option value.'
+                                type: string
+                            required:
+                              - name
+                              - value
+                        enabled:
+                          description: If set to false, exporter instance won't be created.
+                          type: boolean
+                          default: true
+                        custom_certs:
+                          description: ConfigMap name(s) with custom CA certificates.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              map_name:
+                                description: 'ConfigMap name created from Certificate file.'
+                                type: string
+                            required:
+                              - map_name
+                        image_tag:
+                          description: >-
+                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter image tag.
+                          type: string
+                        image_name:
+                          description: >-
+                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter image name, with registry.
+                          type: string
+                        source_url:
+                          description: >-
+                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter git source code.
+                          type: string
+                        source_ref:
+                          description: >-
+                            DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION
+                            Exporter git reference or branch.
+                          type: string
+                      required:
+                        - app_name
+                        - exporter_type
               prometheus_retention:
                 description: >-
                   Prometheus Retention time. More information:
@@ -82,6 +150,62 @@ spec:
               prometheus_storage_pvc_storageclass:
                 description: Prometheus Persistent Volume storage class to be used.
                 type: string
+              federated_prometheus_hosts:
+                description: 'List of additional Federation hosts.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                     id:
+                       description: Must consist of lower case alphanumeric characters or '-'.
+                       type: string
+                     hostname:
+                       description: 'The fully qualified domain name or IP Address of the Prometheus Federation host.'
+                       type: string
+                     password:
+                       description: 'The federated Prometheus "basic auth" password.'
+                       type: string
+                  required:
+                    - id
+                    - hostname
+              external_prometheus_hosts:
+                description: 'List of additional external scrape hosts.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                     id:
+                       description: Must consist of lower case alphanumeric characters or '-'.
+                       type: string
+                     hostname:
+                       description: 'The fully qualified domain name or IP Address of the external scrape host'
+                       type: string
+                  required:
+                    - hostname
+              openshift_prometheus_htpasswd_auth:
+                description: Credentials for the internal user that are used by Grafana to communicate with the Prometheus and Thanos deployed by Pelorus. Must match the "Grafana Datasource Internal Auth (basic auth)".
+                type: string
+              openshift_prometheus_basic_auth_pass:
+                description: Password for Grafana to communicate with the Prometheus datasource. Must match the "Prometheus Internal Auth (htpasswd)".
+                type: string
+              thanos_version:
+                description: DEVELOPMENT OPTION, DO NOT USE IN PRODUCTION Thanos version from the Official Thanos podman image.
+                type: string
+              bucket_access_point:
+                description: S3 named network endpoint that is used to perform S3 object operations.
+                type: string
+              bucket_access_key:
+                description: S3 Access Key ID.
+                type: string
+              bucket_secret_access_key:
+                description: S3 Secret Access Key.
+                type: string
+              thanos_bucket_name:
+                description: S3 bucket name.
+                type: string
+              custom_ca:
+                description: Whether or not the cluster serves custom signed certificates for ingress (e.g. router certs).
+                type: boolean
           status:
             description: Status defines the observed state of Pelorus
             type: object

--- a/pelorus-operator/config/manager/kustomization.yaml
+++ b/pelorus-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/pelorus/pelorus-operator
-  newTag: 0.0.4
+  newTag: 0.0.5

--- a/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/config/manifests/bases/pelorus-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
-    containerImage: quay.io/pelorus/pelorus-operator:0.0.4
+    containerImage: quay.io/pelorus/pelorus-operator:0.0.5
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -23,6 +23,58 @@ spec:
       displayName: Pelorus
       kind: Pelorus
       name: pelorus.charts.pelorus.konveyor.io
+      specDescriptors:
+      - displayName: Exporter Instance Name
+        path: exporters.instances.[0].app_name
+      - path: exporters.instances.[0].exporter_type
+      - path: exporters.instances.[0].env_from_secrets.[0]
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Env From ConfigMap
+        path: exporters.instances.[0].env_from_configmaps.[0]
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMap
+      - path: exporters.instances.[0].extraEnv
+      - path: exporters.instances.[0].enabled
+      - path: exporters.instances.[0].custom_certs.[0].map_name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMap
+      - path: exporters.instances.[0].image_tag
+      - path: exporters.instances.[0].image_name
+      - path: exporters.instances.[0].source_url
+      - path: exporters.instances.[0].source_ref
+      - displayName: External Exporters
+        path: external_prometheus_hosts
+      - displayName: External Exporter name
+        path: external_prometheus_hosts[0].id
+      - path: prometheus_retention
+      - path: prometheus_retention_size
+      - displayName: Prometheus Persistent Storage (PVC)
+        path: prometheus_storage
+      - displayName: Prometheus PVC Capacity
+        path: prometheus_storage_pvc_capacity
+      - displayName: Prometheus PVC Storageclass
+        path: prometheus_storage_pvc_storageclass
+      - displayName: Prometheus Federated Hosts
+        path: federated_prometheus_hosts
+      - displayName: Federated Exporter name
+        path: federated_prometheus_hosts[0].id
+      - displayName: Prometheus Internal Auth (htpasswd)
+        path: openshift_prometheus_htpasswd_auth
+      - displayName: Grafana Datasource Internal Auth (basic auth)
+        path: openshift_prometheus_basic_auth_pass
+      - displayName: Thanos S3 Bucket Name
+        path: thanos_bucket_name
+      - displayName: Thanos S3 Access Point
+        path: bucket_access_point
+      - displayName: Thanos S3 Access Key
+        path: bucket_access_key
+      - displayName: Thanos S3 Secret Access Key
+        path: bucket_secret_access_key
+      - displayName: Thanos Quay Image Tag
+        path: thanos_version
+      - displayName: CA Certificate Injection
+        path: custom_ca
       version: v1alpha1
   description: |
     Pelorus is a tool that helps IT organizations measure their impact on the overall performance of their organization. It does this by gathering metrics about team and organizational behaviors over time in some key areas of IT that have been shown to impact the value they deliver to the organization as a whole. Some of the key outcomes Pelorus can focus on are:

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,20 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - "prometheuses"
+  - "prometheusrules"
+  - "servicemonitors"
+- verbs:
+  - "*"
+  apiGroups:
+  - "route.openshift.io"
+  resources:
+  - "routes"
+- verbs:
+  - "*"
+  apiGroups:
   - ""
   resources:
   - "configmaps"
@@ -88,19 +102,5 @@ rules:
   - "image.openshift.io"
   resources:
   - "imagestreams"
-- verbs:
-  - "*"
-  apiGroups:
-  - "monitoring.coreos.com"
-  resources:
-  - "prometheuses"
-  - "prometheusrules"
-  - "servicemonitors"
-- verbs:
-  - "*"
-  apiGroups:
-  - "route.openshift.io"
-  resources:
-  - "routes"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,6 +55,12 @@ rules:
 - verbs:
   - "*"
   apiGroups:
+  - "image.openshift.io"
+  resources:
+  - "imagestreams"
+- verbs:
+  - "*"
+  apiGroups:
   - "monitoring.coreos.com"
   resources:
   - "prometheuses"
@@ -96,11 +102,5 @@ rules:
   - "grafanadashboards"
   - "grafanadatasources"
   - "grafanas"
-- verbs:
-  - "*"
-  apiGroups:
-  - "image.openshift.io"
-  resources:
-  - "imagestreams"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
+++ b/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
@@ -10,16 +10,9 @@ spec:
     - app_name: deploytime-exporter
       exporter_type: deploytime
     - app_name: failuretime-exporter
-      enabled: false
-      env_from_configmaps:
-      - pelorus-config
-      - failuretime-config
-      env_from_secrets:
-      - jira-secret
       exporter_type: failure
     - app_name: committime-exporter
       exporter_type: committime
-  extra_prometheus_hosts: null
   openshift_prometheus_basic_auth_pass: changeme
   openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
   prometheus_retention: 1y

--- a/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
+++ b/pelorus-operator/config/samples/charts_v1alpha1_pelorus.yaml
@@ -10,9 +10,12 @@ spec:
     - app_name: deploytime-exporter
       exporter_type: deploytime
     - app_name: failuretime-exporter
+      enabled: false
       exporter_type: failure
     - app_name: committime-exporter
       exporter_type: committime
+    - app_name: webhook-exporter
+      exporter_type: webhook
   openshift_prometheus_basic_auth_pass: changeme
   openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
   prometheus_retention: 1y

--- a/pelorus-operator/config/scorecard/patches/basic.config.yaml
+++ b/pelorus-operator/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/pelorus-operator/config/scorecard/patches/olm.config.yaml
+++ b/pelorus-operator/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.26.1
+    image: quay.io/operator-framework/scorecard-test:v1.27.0
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./subcharts/exporters
   version: 2.0.8
 digest: sha256:e85d32a997154187035655535a048c186de9e2fd4df332b7178e4f23abd92ff5
-generated: "2023-03-10T09:28:24.624063792-03:00"
+generated: "2023-03-10T12:45:37.338975782-03:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: 2.0.7
-digest: sha256:f613fb665d4f9b0d17119698eada144f11dd85bf498197b5ad587bcbafaebdbe
-generated: "2023-03-02T22:50:23.529649522+01:00"
+  version: 2.0.8
+digest: sha256:e85d32a997154187035655535a048c186de9e2fd4df332b7178e4f23abd92ff5
+generated: "2023-03-10T09:28:24.624063792-03:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 dependencies:
 - name: exporters
   repository: file://./subcharts/exporters
-  version: v2.0.7
+  version: 2.0.8
 description: A Helm chart for Kubernetes
 name: pelorus
 type: application
-version: 2.0.7
+version: 2.0.8

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.7
+version: 2.0.8

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_buildconfig.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     contextDir: {{ .source_context_dir | default "exporters/" }}
     git:
-      ref: {{ .source_ref | default "v2.0.7" }}
+      ref: {{ .source_ref | default "v2.0.8" }}
       uri: {{ .source_url | default "https://github.com/konveyor/pelorus.git"}}
     type: Git
   strategy:

--- a/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
+++ b/pelorus-operator/helm-charts/pelorus/subcharts/exporters/templates/_imagestream_from_image.yaml
@@ -20,10 +20,10 @@ spec:
       name: {{ .image_name }}
     # .image_name is provided without tag
     {{- else }}
-      name: {{ .image_name }}:{{ .image_tag | default "v2.0.7" }}
+      name: {{ .image_name }}:{{ .image_tag | default "v2.0.8" }}
     {{- end }}
 {{- else }}
-      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.7" }}
+      name: quay.io/pelorus/pelorus-{{ .exporter_type }}-exporter:{{ .image_tag | default "v2.0.8" }}
 # .image_name
 {{- end }}
     name: {{ .image_tag | default "stable" }}

--- a/pelorus-operator/helm-charts/pelorus/templates/prometheus-cr.yaml
+++ b/pelorus-operator/helm-charts/pelorus/templates/prometheus-cr.yaml
@@ -35,9 +35,9 @@ spec:
   ruleSelector: {}
   serviceAccountName: pelorus-prometheus
   serviceMonitorSelector: {}
-{{- if .Values.extra_prometheus_hosts}}
+{{- if or .Values.federated_prometheus_hosts .Values.external_prometheus_hosts }}
   additionalScrapeConfigs:
-    name: additional-scrape-configs
+    name: pelorus-prometheus-additional-scrape-configs
     key: prometheus-additional.yml
 {{- end }}
 {{- if .Values.custom_ca }}

--- a/pelorus-operator/helm-charts/pelorus/templates/prometheus-scrape-config-secret.yaml
+++ b/pelorus-operator/helm-charts/pelorus/templates/prometheus-scrape-config-secret.yaml
@@ -1,5 +1,5 @@
 {{- define "prometheus_scrape_config"}}
-  {{- range .Values.extra_prometheus_hosts }}
+  {{- range .Values.federated_prometheus_hosts }}
   - job_name: "federated-prometheus-{{ .id }}"
     scrape_interval: 15s
     honor_labels: true
@@ -19,8 +19,19 @@
         labels:
           federated_job: "federated-prometheus-{{ .id }}"
   {{- end }}
+  {{- range .Values.external_prometheus_hosts }}
+  - job_name: "external-prometheus-{{ .id }}"
+    scrape_interval: 15s
+    tls_config:
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+          - "{{ .hostname }}"
+        labels:
+          external_job: "external-prometheus-{{ .id }}"
+  {{- end }}
 {{- end }}
-{{- if .Values.extra_prometheus_hosts}}
+{{- if or .Values.federated_prometheus_hosts .Values.external_prometheus_hosts }}
 ---
 apiVersion: v1
 data:
@@ -28,5 +39,5 @@ data:
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: additional-scrape-configs
+  name: pelorus-prometheus-additional-scrape-configs
 {{- end}}

--- a/pelorus-operator/helm-charts/pelorus/values.yaml
+++ b/pelorus-operator/helm-charts/pelorus/values.yaml
@@ -40,9 +40,13 @@ exporters:
 
     - app_name: failuretime-exporter
       exporter_type: failure
+      enabled: false
 
     - app_name: committime-exporter
       exporter_type: committime
+
+    - app_name: webhook-exporter
+      exporter_type: webhook
 
 # Experimental GitHub releasetime exporter
 #     - app_name: releasetime-exporter

--- a/pelorus-operator/helm-charts/pelorus/values.yaml
+++ b/pelorus-operator/helm-charts/pelorus/values.yaml
@@ -5,7 +5,8 @@
 # to reset password: htpasswd -s -b -n internal changeme
 openshift_prometheus_htpasswd_auth: internal:{SHA}+pvrmeQCmtWmYVOZ57uuITVghrM=
 openshift_prometheus_basic_auth_pass: changeme
-extra_prometheus_hosts:
+# federated_prometheus_hosts:
+# external_prometheus_hosts:
 
 # Uncomment this if your cluster serves privately signed certificates
 # custom_ca: true
@@ -34,36 +35,22 @@ prometheus_retention_size: 1GB
 
 exporters:
   instances:
-  - app_name: deploytime-exporter
-    exporter_type: deploytime
-    # env_from_configmaps:
-    # - pelorus-config
-    # - deploytime-config
+    - app_name: deploytime-exporter
+      exporter_type: deploytime
 
-  - app_name: failuretime-exporter
-    exporter_type: failure
-    enabled: false
-    env_from_configmaps:
-    - pelorus-config
-    - failuretime-config
-    env_from_secrets:
-    - jira-secret
+    - app_name: failuretime-exporter
+      exporter_type: failure
 
-  - app_name: committime-exporter
-    exporter_type: committime
-#    env_from_configmaps:
-#    - pelorus-config
-#    - committime-config
-#    env_from_secrets:
-#    - github-secret
+    - app_name: committime-exporter
+      exporter_type: committime
 
 # Experimental GitHub releasetime exporter
-#  - app_name: releasetime-exporter
-#    env_from_configmaps:
-#    - pelorus-config
-#    - releasetime-config
-#    env_from_secrets:
-#    - github-secret
-#    extraEnv:
-#    - name: APP_FILE
-#      value: extra/releasetime/app.py
+#     - app_name: releasetime-exporter
+#       env_from_configmaps:
+#         - pelorus-config
+#         - releasetime-config
+#       env_from_secrets:
+#         - github-secret
+#       extraEnv:
+#         - name: APP_FILE
+#           value: extra/releasetime/app.py

--- a/scripts/create_pelorus_operator
+++ b/scripts/create_pelorus_operator
@@ -40,20 +40,37 @@ function print_help() {
     printf "\t  -d\tpath to EMPTY destination folder, default: %s\n" "${DEFAULT_PELORUS_OPERATOR_DIR}"
     printf "\t  -p\tpath to DIR with operator patches to be applied, default: %s\n" "${DEFAULT_PELORUS_OPERATOR_PATCHES_DIR}"
     printf "\t  -v\toperator version to be used in a format x.y.z. If not set z+1 is used.\n"
+    printf "\t  -o\tQuay user/org name, default to pelorus, which is the production storage.\n"
     exit 0
 }
 
 ### Options
 OPTIND=1
-while getopts "s:d:p:h?v:" option; do
+while getopts "s:d:p:h?v:o:" option; do
     case "$option" in
     h|\?) print_help;;
     s)    source_dir=$OPTARG;;
     d)    destination_dir=$OPTARG;;
     p)    patches_dir=$OPTARG;;
     v)    operator_ver=$OPTARG;;
+    o)    quay_user=$OPTARG;;
     esac
 done
+
+# Check preconditions
+if ! oc auth can-i '*' '*' --all-namespaces &> /dev/null; then
+    echo "You must be logged in to a OpenShift cluster as a user with cluster-admin permissions to run this script."
+    echo "This avoids RBAC problems. More info: https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/#prerequisites"
+    exit 1
+fi
+if ! oc get crd grafanas.integreatly.org &> /dev/null; then
+    echo "Grafana CRD not found."
+    exit 1
+fi
+if ! oc get crd prometheuses.monitoring.coreos.com &> /dev/null; then
+    echo "Prometheus CRD not found."
+    exit 1
+fi
 
 if [ -z ${source_dir+x} ]; then
     source_dir="${DEFAULT_PELORUS_CHARTS_DIR}"
@@ -63,6 +80,9 @@ if [ -z ${destination_dir+x} ]; then
 fi
 if [ -z ${patches_dir+x} ]; then
     patches_dir="${DEFAULT_PELORUS_OPERATOR_PATCHES_DIR}"
+fi
+if [ -n "${quay_user}" ]; then
+    OPERATOR_ORG_NAME="${quay_user}"
 fi
 
 echo "INFO: Source directory: ${source_dir}"


### PR DESCRIPTION
## Describe the behavior changes introduced in this PR

Release for version `0.0.5` of Pelorus Operator.

## Linked Issues

related to #864 (It will be resolved once it is merged in community operator repository)

## Testing Instructions

For changing helm verion (removing `v` from it), we ran
```
helm install operators charts/operators --namespace pelorus
helm install pelorus charts/pelorus --namespace pelorus --values charts/pelorus/values.yaml
```

Manually changed some versions of helm and ran `scripts/create_release_pr -v 2.0.8`.

We ran the usual commands to create Pelorus Operator files
```
podman login ...
oc login ...
rm -rf pelorus-operator && mkdir pelorus-operator && scripts/create_pelorus_operator
cd pelorus-operator
make podman-build
make bundle-build
make podman-push
make bundle-push
```
(Note: sent the images to my personal account to test them before sending to production, but checked if they were the same with `diff -ruN pelorus-operator pelorus-operator-test-release`, excluding podman user/org and versions)

To test the release candidate, run (must be logged in to your Openshift cluster)
```
operator-sdk run bundle quay.io/msouzaol/pelorus-operator-bundle:v0.0.8 --namespace pelorus 
```
and when creating Pelorus instance, **you must add `image_tag: latest`** to each exporter instance (because the new version, `v2.0.8`, will just be available after this PR closes with the GitHub release).
