### PR TITLE
Webhook exporter metrics route to be same as other exporters

### DIFF
--- a/docs/GettingStarted/configuration/ExporterWebhook.md
+++ b/docs/GettingStarted/configuration/ExporterWebhook.md
@@ -175,7 +175,7 @@ $ curl -X POST <Webhook route URI>/pelorus/webhook \
        -H "User-Agent: Pelorus-Webhook/test" \
        -H "X-Pelorus-Event: committime" \
        -H "Content-Type: application/json" \
-       -d ./mongo_committime.json
+       -d @./mongo_committime.json
 ```
 
 ```shell
@@ -183,7 +183,7 @@ $ curl -X POST <Webhook route URI>/pelorus/webhook \
        -H "User-Agent: Pelorus-Webhook/test" \
        -H "X-Pelorus-Event: deploytime" \
        -H "Content-Type: application/json" \
-       -d ./mongo_deploytime.json
+       -d @./mongo_deploytime.json
 ```
 
 ```shell
@@ -191,7 +191,7 @@ $ curl -X POST <Webhook route URI>/pelorus/webhook \
        -H "User-Agent: Pelorus-Webhook/test" \
        -H "X-Pelorus-Event: failure" \
        -H "Content-Type: application/json" \
-       -d ./mongo_production_failure.json
+       -d @./mongo_production_failure.json
 ```
 
 ```shell
@@ -199,5 +199,5 @@ $ curl -X POST <Webhook route URI>/pelorus/webhook \
        -H "User-Agent: Pelorus-Webhook/test" \
        -H "X-Pelorus-Event: failure" \
        -H "Content-Type: application/json" \
-       -d ./mongo_production_failure_resolved.json
+       -d @./mongo_production_failure_resolved.json
 ```

--- a/exporters/webhook/app.py
+++ b/exporters/webhook/app.py
@@ -163,7 +163,12 @@ async def get_handler(user_agent: str) -> Optional[Type[PelorusWebhookPlugin]]:
 
 
 # TODO App Module
-app = FastAPI(title="Pelorus Webhook receiver")
+app = FastAPI(
+    title="Pelorus Webhook receiver",
+    openapi_url=None,
+    docs_url=None,
+    redoc_url=None,
+)
 
 
 @app.post(
@@ -214,7 +219,7 @@ async def pelorus_webhook(
     )
 
 
-@app.get("/metrics", response_class=PlainTextResponse)
+@app.get("/{path:path}", response_class=PlainTextResponse)
 async def metrics():
     return generate_latest()
 


### PR DESCRIPTION
All other exporters can read the metrics from other endpoints in the URL route such as / or /metrics as well as /whatever

To make it consistent webhook exporter also presents the prometheus metrics on the GET event for all endpoints.

For the POST events only /pelorus/webhook can be used.

Disallow all other methods.

Fixes #889
Fixes #888 

## Testing Instructions

It's enough to run the exporter via python and test endpoints:

```
$ python exporters/webhook/app.py

# visit:
#  http://localhost:8080
#  http://localhost:8080/
#  http://localhost:8080/metrics
#  http://localhost:8080/othertarget
#  http://localhost:8080/pelorus/webhook

# Above should give the prometheus metrics

# Send the POST to the http://localhost:8080/pelorus/webhook using updated documentation in this PR and ensure the metrics are visible when visiting one of the above metric endpoints.
```

@redhat-cop/mdt
