### PR TITLE
Add the ability to configure exporters system ca bundle

### DIFF
--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.1
 digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-11T19:08:27.806745358Z"
+generated: "2024-07-09T14:27:25.533200716+02:00"

--- a/charts/pelorus/Chart.lock
+++ b/charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.1
 digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-09T14:27:25.533200716+02:00"
+generated: "2024-07-11T19:08:27.806745358Z"

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -36,7 +36,9 @@ spec:
         - name: configmap-cluster-ca-bundle
           configMap:
             name: {{ .custom_ca_configmap }}
-            defaultMode: 420
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
         {{- end }}
       containers:
         - name: {{ .app_name }}
@@ -50,7 +52,7 @@ spec:
             {{- if .custom_ca_configmap }}
             - name: configmap-cluster-ca-bundle
               readOnly: true
-              mountPath: /etc/pki/tls/certs
+              mountPath: /etc/pki/ca-trust/extracted/pem
             {{- end }}
 
           envFrom:

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -32,6 +32,12 @@ spec:
           configMap:
             name: {{ $config.map_name }}
         {{- end }}
+        {{- if .custom_ca }}
+        - name: configmap-cluster-ca-bundle
+          configMap:
+            name: {{ .custom_ca.map_name }}
+            defaultMode: 420
+        {{- end }}
       containers:
         - name: {{ .app_name }}
           imagePullPolicy: Always
@@ -40,6 +46,11 @@ spec:
             {{- range $config := .custom_certs }}
             - name: custom-cert-volume-{{$config.map_name}}
               mountPath: /etc/pelorus/custom_certs/{{$config.map_name}}
+            {{- end }}
+            {{- if .custom_ca }}
+            - name: configmap-cluster-ca-bundle
+              readOnly: true
+              mountPath: /etc/pki/tls/certs
             {{- end }}
 
           envFrom:

--- a/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -32,10 +32,10 @@ spec:
           configMap:
             name: {{ $config.map_name }}
         {{- end }}
-        {{- if .custom_ca }}
+        {{- if .custom_ca_configmap }}
         - name: configmap-cluster-ca-bundle
           configMap:
-            name: {{ .custom_ca.map_name }}
+            name: {{ .custom_ca_configmap }}
             defaultMode: 420
         {{- end }}
       containers:
@@ -47,7 +47,7 @@ spec:
             - name: custom-cert-volume-{{$config.map_name}}
               mountPath: /etc/pelorus/custom_certs/{{$config.map_name}}
             {{- end }}
-            {{- if .custom_ca }}
+            {{- if .custom_ca_configmap }}
             - name: configmap-cluster-ca-bundle
               readOnly: true
               mountPath: /etc/pki/tls/certs

--- a/charts/pelorus/values.yaml
+++ b/charts/pelorus/values.yaml
@@ -50,6 +50,8 @@ exporters:
 
     - app_name: committime-exporter
       exporter_type: committime
+      # Override the exporter system CA bundle. The ConfigMap must be present and must contain the ca-bundle.crt key with PEM formatted certs.
+      # custom_ca_configmap: <configmap name>
 
     - app_name: webhook-exporter
       exporter_type: webhook

--- a/docs/GettingStarted/configuration/PelorusExporters.md
+++ b/docs/GettingStarted/configuration/PelorusExporters.md
@@ -71,6 +71,7 @@ This is the list of options that can be applied to `exporters.instances` section
 | [extraEnv](#extraenv) | no | - |
 | [enabled](#enabled) | no | `true` |
 | [custom_certs](#custom_certs) | no | - |
+| [custom_ca_configmap](#custom_ca_configmap) | no | - |
 | [image_tag](#image_tag) | no | - |
 | [image_name](#image_name) | no | - |
 | [source_url](#source_url) | no | - |
@@ -168,6 +169,13 @@ custom_certs:
 ```
 
 : Check [Custom Certificates](#custom-certificates) for more information.
+
+###### custom_ca_configmap
+
+- **Required:** no
+- **Type:** String
+
+: Used to override the exporter system ca bundle. The value must be the ConfigMap name holding the `ca-bundle.crt` key with PEM formatted certificates.
 
 ###### image_tag
 

--- a/pelorus-operator/bundle/manifests/charts.pelorus.dora-metrics.io_peloruses.yaml
+++ b/pelorus-operator/bundle/manifests/charts.pelorus.dora-metrics.io_peloruses.yaml
@@ -60,6 +60,10 @@ spec:
                           description: Must consist of lower case alphanumeric characters
                             or '-'.
                           type: string
+                        custom_ca_configmap:
+                          description: ConfigMap name with ca-bundle.crt key mounted
+                            over the exporter image system CA bundle.
+                          type: string
                         custom_certs:
                           description: ConfigMap name(s) with custom CA certificates.
                           items:

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
-    createdAt: "2024-07-11T19:08:34Z"
+    createdAt: "2024-07-09T12:27:27Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -211,20 +211,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - image.openshift.io
-          resources:
-          - imagestreams
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - prometheuses
-          - prometheusrules
-          - servicemonitors
-          verbs:
-          - '*'
-        - apiGroups:
           - route.openshift.io
           resources:
           - routes
@@ -258,6 +244,20 @@ spec:
           - grafanadashboards
           - grafanadatasources
           - grafanas
+          verbs:
+          - '*'
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheuses
+          - prometheusrules
+          - servicemonitors
           verbs:
           - '*'
         - apiGroups:

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
-    createdAt: "2024-07-09T12:27:27Z"
+    createdAt: "2024-07-09T12:46:49Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -211,28 +211,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - services
-          verbs:
-          - '*'
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - '*'
-        - apiGroups:
           - apps.openshift.io
           resources:
           - deploymentconfigs
@@ -258,6 +236,28 @@ spec:
           - prometheuses
           - prometheusrules
           - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
           verbs:
           - '*'
         - apiGroups:

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
-    createdAt: "2024-07-12T10:48:55Z"
+    createdAt: "2024-07-11T19:08:34Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus
@@ -211,20 +211,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - '*'
-        - apiGroups:
-          - integreatly.org
-          resources:
-          - grafanadashboards
-          - grafanadatasources
-          - grafanas
-          verbs:
-          - '*'
-        - apiGroups:
           - image.openshift.io
           resources:
           - imagestreams
@@ -258,6 +244,20 @@ spec:
           resources:
           - rolebindings
           - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          - grafanadatasources
+          - grafanas
           verbs:
           - '*'
         - apiGroups:

--- a/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
+++ b/pelorus-operator/bundle/manifests/pelorus-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: |
       Modernization & Migration,Developer Tools,Monitoring,Integration & Delivery
     containerImage: quay.io/pelorus/pelorus-operator:0.0.10-rc.1
-    createdAt: "2024-07-09T12:46:49Z"
+    createdAt: "2024-07-12T10:48:55Z"
     description: |
       Tool that helps IT organizations measure their impact on the overall performance of their organization
     operatorframework.io/suggested-namespace: pelorus

--- a/pelorus-operator/config/crd/bases/charts.pelorus.dora-metrics.io_peloruses.yaml
+++ b/pelorus-operator/config/crd/bases/charts.pelorus.dora-metrics.io_peloruses.yaml
@@ -95,6 +95,10 @@ spec:
                           description: If set to false, exporter instance won't be created.
                           type: boolean
                           default: true
+                        custom_ca_configmap:
+                          description: >-
+                            ConfigMap name with ca-bundle.crt key mounted over the exporter image system CA bundle.
+                          type: string
                         custom_certs:
                           description: ConfigMap name(s) with custom CA certificates.
                           type: array

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,20 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "image.openshift.io"
-  resources:
-  - "imagestreams"
-- verbs:
-  - "*"
-  apiGroups:
-  - "monitoring.coreos.com"
-  resources:
-  - "prometheuses"
-  - "prometheusrules"
-  - "servicemonitors"
-- verbs:
-  - "*"
-  apiGroups:
   - "route.openshift.io"
   resources:
   - "routes"
@@ -102,5 +88,19 @@ rules:
   - "grafanadashboards"
   - "grafanadatasources"
   - "grafanas"
+- verbs:
+  - "*"
+  apiGroups:
+  - "image.openshift.io"
+  resources:
+  - "imagestreams"
+- verbs:
+  - "*"
+  apiGroups:
+  - "monitoring.coreos.com"
+  resources:
+  - "prometheuses"
+  - "prometheusrules"
+  - "servicemonitors"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,20 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "apps.openshift.io"
-  resources:
-  - "deploymentconfigs"
-- verbs:
-  - "*"
-  apiGroups:
-  - "integreatly.org"
-  resources:
-  - "grafanadashboards"
-  - "grafanadatasources"
-  - "grafanas"
-- verbs:
-  - "*"
-  apiGroups:
   - "image.openshift.io"
   resources:
   - "imagestreams"
@@ -102,5 +88,19 @@ rules:
   resources:
   - "rolebindings"
   - "roles"
+- verbs:
+  - "*"
+  apiGroups:
+  - "apps.openshift.io"
+  resources:
+  - "deploymentconfigs"
+- verbs:
+  - "*"
+  apiGroups:
+  - "integreatly.org"
+  resources:
+  - "grafanadashboards"
+  - "grafanadatasources"
+  - "grafanas"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/config/rbac/role.yaml
+++ b/pelorus-operator/config/rbac/role.yaml
@@ -55,28 +55,6 @@ rules:
 - verbs:
   - "*"
   apiGroups:
-  - "route.openshift.io"
-  resources:
-  - "routes"
-- verbs:
-  - "*"
-  apiGroups:
-  - ""
-  resources:
-  - "configmaps"
-  - "secrets"
-  - "serviceaccounts"
-  - "services"
-- verbs:
-  - "*"
-  apiGroups:
-  - "rbac.authorization.k8s.io"
-  resources:
-  - "rolebindings"
-  - "roles"
-- verbs:
-  - "*"
-  apiGroups:
   - "apps.openshift.io"
   resources:
   - "deploymentconfigs"
@@ -102,5 +80,27 @@ rules:
   - "prometheuses"
   - "prometheusrules"
   - "servicemonitors"
+- verbs:
+  - "*"
+  apiGroups:
+  - "route.openshift.io"
+  resources:
+  - "routes"
+- verbs:
+  - "*"
+  apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "secrets"
+  - "serviceaccounts"
+  - "services"
+- verbs:
+  - "*"
+  apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "rolebindings"
+  - "roles"
 
 #+kubebuilder:scaffold:rules

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.1
 digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-11T19:08:28.036277921Z"
+generated: "2024-07-09T14:27:25.844344357+02:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.1
 digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-12T12:48:53.977217732+02:00"
+generated: "2024-07-11T19:08:28.036277921Z"

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.1
 digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-09T14:27:25.844344357+02:00"
+generated: "2024-07-09T14:46:48.176903577+02:00"

--- a/pelorus-operator/helm-charts/pelorus/Chart.lock
+++ b/pelorus-operator/helm-charts/pelorus/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://./charts/exporters
   version: 2.0.13-rc.1
 digest: sha256:7509215040089f3aafebaf275ac38485546d900b1bddb5849daf35d412745871
-generated: "2024-07-09T14:46:48.176903577+02:00"
+generated: "2024-07-12T12:48:53.977217732+02:00"

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -32,6 +32,12 @@ spec:
           configMap:
             name: {{ $config.map_name }}
         {{- end }}
+        {{- if .custom_ca_configmap }}
+        - name: configmap-cluster-ca-bundle
+          configMap:
+            name: {{ .custom_ca_configmap }}
+            defaultMode: 420
+        {{- end }}
       containers:
         - name: {{ .app_name }}
           imagePullPolicy: Always
@@ -40,6 +46,11 @@ spec:
             {{- range $config := .custom_certs }}
             - name: custom-cert-volume-{{$config.map_name}}
               mountPath: /etc/pelorus/custom_certs/{{$config.map_name}}
+            {{- end }}
+            {{- if .custom_ca_configmap }}
+            - name: configmap-cluster-ca-bundle
+              readOnly: true
+              mountPath: /etc/pki/tls/certs
             {{- end }}
 
           envFrom:

--- a/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
+++ b/pelorus-operator/helm-charts/pelorus/charts/exporters/templates/_deploymentconfig.yaml
@@ -36,7 +36,9 @@ spec:
         - name: configmap-cluster-ca-bundle
           configMap:
             name: {{ .custom_ca_configmap }}
-            defaultMode: 420
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
         {{- end }}
       containers:
         - name: {{ .app_name }}
@@ -50,7 +52,7 @@ spec:
             {{- if .custom_ca_configmap }}
             - name: configmap-cluster-ca-bundle
               readOnly: true
-              mountPath: /etc/pki/tls/certs
+              mountPath: /etc/pki/ca-trust/extracted/pem
             {{- end }}
 
           envFrom:

--- a/pelorus-operator/helm-charts/pelorus/values.yaml
+++ b/pelorus-operator/helm-charts/pelorus/values.yaml
@@ -50,6 +50,8 @@ exporters:
 
     - app_name: committime-exporter
       exporter_type: committime
+      # Override the exporter system CA bundle. The ConfigMap must be present and must contain the ca-bundle.crt key with PEM formatted certs.
+      # custom_ca_configmap: <configmap name>
 
     - app_name: webhook-exporter
       exporter_type: webhook

--- a/scripts/pelorus-operator-patches/09_custom_ca_configmap_param.diff
+++ b/scripts/pelorus-operator-patches/09_custom_ca_configmap_param.diff
@@ -1,0 +1,13 @@
+--- config/crd/bases/charts.pelorus.dora-metrics.io_peloruses.yaml.original
++++ config/crd/bases/charts.pelorus.dora-metrics.io_peloruses.yaml
+@@ -95,6 +95,10 @@ spec:
+                           description: If set to false, exporter instance won't be created.
+                           type: boolean
+                           default: true
++                        custom_ca_configmap:
++                          description: >-
++                            ConfigMap name with ca-bundle.crt key mounted over the exporter image system CA bundle.
++                          type: string
+                         custom_certs:
+                           description: ConfigMap name(s) with custom CA certificates.
+                           type: array


### PR DESCRIPTION
- [x] I have read [Pelorus Contributing guidelines](https://github.com/dora-metrics/pelorus/blob/master/CONTRIBUTING.md)

## Linked Issues
N/A

## Description

Some people need to trust internal CAs emitting TLS certificates for internal only services.

Adding the internal CAs to the container system CA bundle avoids certificate validation errors in the exporters.

This PR adds the ability to override the exporters system CA bundle with a ConfigMap.
The ConfigMap must contain the `ca-bundle.crt` key populated with PEM formatted certificates to be trusted.

The ConfigMap will be mounted into the exporter pods updating the system CA bundle located in `/etc/pki/tls/certs/ca-bundle.crt`.

## Testing Instructions

1. Create the ConfigMap with the CA bundle:

    ```yaml
    apiVersion: v1
    kind: ConfigMap
    metadata:
      labels:
        config.openshift.io/inject-trusted-cabundle: "true"
      name: cluster-ca-bundle
    ```
2. Create a values file with the `custom_ca_configmap` configuration:
    ```yaml
    instances:
      - app_name: deploytime-exporter
        exporter_type: deploytime
        custom_ca_configmap: cluster-ca-bundle
      - app_name: committime-exporter
        exporter_type: committime
        custom_ca_configmap: cluster-ca-bundle
        extraEnv:
        - name: PROVIDER
          value: containerimage
    ```
3. Deploy the exporters helm chart using the values file just created.